### PR TITLE
feat(sdks/js): add nextjs sdk

### DIFF
--- a/sdks/js/CHANGELOG.md
+++ b/sdks/js/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.2 - 2026-02-26
+
+- Added Next.js App Router support via `apilens-js-sdk/next`:
+  - `withApiLens` route-handler wrapper
+  - route wrapper aliases (`createApiLensRouteHandler`, `createNextRouteHandler`, `instrumentNextRouteHandler`)
+  - consumer helpers (`setConsumer`, `trackConsumer`)
+- Added Next.js config helpers:
+  - `createApiLensNextConfig(overrides?)`
+  - `getApiLensNextEnvSummary(overrides?)`
+- Next.js wrapper now supports zero-config env loading from:
+  - `APILENS_API_KEY`
+  - `APILENS_BASE_URL`
+  - `APILENS_ENVIRONMENT`
+- When API key is missing, Next.js wrapper now auto-disables instrumentation instead of throwing.
+- Added tests for Next.js route captures, OPTIONS skipping, and error-path logging.
+- Added tests for env-based config resolution, explicit override precedence, payload truncation, and fallback `getConsumer` behavior.
+- Updated package exports/build config for the new `./next` subpath.
+
 ## 0.1.1 - 2026-02-19
 
 - Fixed `ingestPath` URL resolution behavior:

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -1,6 +1,6 @@
 # API Lens JavaScript SDK
 
-JavaScript SDK for API Lens with an Express-first middleware API.
+JavaScript SDK for API Lens with first-class Express and Next.js APIs.
 
 ## Install
 
@@ -15,6 +15,8 @@ npm install ./sdks/js
 ```
 
 ## Quick start
+
+### Express
 
 ```js
 import express from "express";
@@ -43,6 +45,25 @@ process.on("SIGTERM", async () => {
 });
 ```
 
+### Next.js (App Router)
+
+```ts
+import { NextResponse } from "next/server";
+import { createApiLensNextConfig, setConsumer, withApiLens } from "apilens-js-sdk/next";
+
+const apilens = createApiLensNextConfig({
+  // Optional overrides:
+  // baseUrl: "http://localhost:8000/api/v1",
+  // environment: "local",
+});
+
+export const POST = withApiLens(async (request) => {
+  setConsumer(request, { id: "user_123", name: "Demo User", group: "starter" });
+  const body = await request.json();
+  return NextResponse.json({ ok: true, item: body.item }, { status: 201 });
+}, apilens);
+```
+
 ## Manual capture
 
 ```js
@@ -66,18 +87,36 @@ await client.handleShutdown({ flush: true });
 
 ## API
 
+### `apilens-js-sdk/express`
+
 - `useApiLens(app, config)`
 - `createApiLensMiddleware(config)`
 - `createExpressMiddleware(config)` (alias)
 - `instrumentExpress(app, config)` (alias)
 - `setConsumer(req, consumer)`
 - `trackConsumer(req, consumer)`
+
+### `apilens-js-sdk/next`
+
+- `withApiLens(handler, config)`
+- `createApiLensNextConfig(overrides?)`
+- `getApiLensNextEnvSummary(overrides?)`
+- `createApiLensRouteHandler(handler, config)` (alias)
+- `createNextRouteHandler(handler, config)` (alias)
+- `instrumentNextRouteHandler(handler, config)` (alias)
+- `setConsumer(request, consumer)`
+- `trackConsumer(request, consumer)`
+
+### Common
+
 - `ApiLensClient`
 
 ## Notes
 
 - Add `express.json()` before the API Lens middleware if you want request payload capture.
-- `apiKey` is required; prefer loading from env (`APILENS_API_KEY`).
+- Next.js SDK is designed for App Router route handlers (`app/api/**/route.ts`).
+- `createApiLensNextConfig()` reads `APILENS_API_KEY`, `APILENS_BASE_URL`, and `APILENS_ENVIRONMENT`.
+- If `APILENS_API_KEY` is missing, Next handler instrumentation auto-disables instead of crashing.
 - `ingestPath` resolution rules:
   - `ingest/requests` -> appended to `baseUrl` path.
   - `/ingest/requests` -> resolved from host root.

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apilens-js-sdk",
-  "version": "0.1.1",
-  "description": "API Lens JavaScript SDK with first-class Express middleware",
+  "version": "0.1.2",
+  "description": "API Lens JavaScript SDK with first-class Express and Next.js instrumentation",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -34,12 +34,25 @@
         "default": "./dist/express.cjs"
       }
     },
+    "./next": {
+      "import": {
+        "types": "./dist/next.d.ts",
+        "default": "./dist/next.js"
+      },
+      "require": {
+        "types": "./dist/next.d.cts",
+        "default": "./dist/next.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
       "express": [
         "./dist/express.d.ts"
+      ],
+      "next": [
+        "./dist/next.d.ts"
       ]
     }
   },
@@ -54,6 +67,7 @@
   "keywords": [
     "apilens",
     "express",
+    "nextjs",
     "monitoring",
     "sdk"
   ],

--- a/sdks/js/src/client.ts
+++ b/sdks/js/src/client.ts
@@ -13,7 +13,7 @@ import type {
   Logger,
 } from "./types.js";
 
-const SDK_VERSION = "0.1.0";
+const SDK_VERSION = "0.1.2";
 
 type RequiredConfig = {
   apiKey: string;

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -11,6 +11,8 @@ export type {
   ApiLensClientConfig,
   ApiLensConsumer,
   ApiLensExpressConfig,
+  ApiLensNextConfig,
+  ApiLensNextEnvSummary,
   ApiLensRecord,
   ApiLensRecordInput,
   Logger,

--- a/sdks/js/src/next.ts
+++ b/sdks/js/src/next.ts
@@ -1,0 +1,353 @@
+import { performance } from "node:perf_hooks";
+
+import { ApiLensClient } from "./client.js";
+import {
+  firstForwardedIp,
+  normalizePath,
+  payloadToString,
+  toNonNegativeInt,
+  toNumber,
+} from "./utils.js";
+import type {
+  ApiLensConsumer,
+  ApiLensNextConfig,
+  ApiLensNextEnvSummary,
+} from "./types.js";
+
+type ConsumerSnapshot = {
+  consumer_id: string;
+  consumer_name: string;
+  consumer_group: string;
+};
+
+type PayloadSnapshot = {
+  payload: string;
+  size: number;
+};
+
+type NextRouteHandler<TContext = unknown, TRequest extends Request = Request> = (
+  request: TRequest,
+  context?: TContext,
+) => Response | Promise<Response>;
+
+type NextRouteHandlerWithClient<
+  TContext = unknown,
+  TRequest extends Request = Request,
+> = NextRouteHandler<TContext, TRequest> & { apilensClient: ApiLensClient };
+
+const consumerByRequest = new WeakMap<Request, ApiLensConsumer | string>();
+const DEFAULT_BASE_URL = "https://api.apilens.ai/api/v1";
+const DEFAULT_ENVIRONMENT = "production";
+const DISABLED_PLACEHOLDER_API_KEY = "missing-api-key";
+
+function readProcessEnv(key: string): string {
+  if (typeof process === "undefined" || !process.env) {
+    return "";
+  }
+
+  return String(process.env[key] || "").trim();
+}
+
+function consumerFromStringOrObject(
+  value: ApiLensConsumer | string | null | undefined,
+): ConsumerSnapshot | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return {
+      consumer_id: value,
+      consumer_name: "",
+      consumer_group: "",
+    };
+  }
+
+  return {
+    consumer_id: String(value.id || value.identifier || value.consumer_id || ""),
+    consumer_name: String(value.name || value.consumer_name || ""),
+    consumer_group: String(value.group || value.consumer_group || ""),
+  };
+}
+
+function setConsumer(
+  request: Request,
+  consumer: ApiLensConsumer | string | null | undefined,
+): void {
+  if (!consumer) {
+    consumerByRequest.delete(request);
+    return;
+  }
+
+  consumerByRequest.set(request, consumer);
+}
+
+function trackConsumer(
+  request: Request,
+  consumer: ApiLensConsumer | string | null | undefined,
+): void {
+  setConsumer(request, consumer);
+}
+
+function createApiLensNextConfig(config: ApiLensNextConfig = {}): ApiLensNextConfig {
+  const apiKey =
+    String(
+      config.apiKey || config.api_key || config.clientId || config.client_id || "",
+    ).trim() || readProcessEnv("APILENS_API_KEY");
+  const baseUrl =
+    String(config.baseUrl || config.base_url || "").trim() ||
+    readProcessEnv("APILENS_BASE_URL") ||
+    DEFAULT_BASE_URL;
+  const environment =
+    String(config.environment || config.env || "").trim() ||
+    readProcessEnv("APILENS_ENVIRONMENT") ||
+    DEFAULT_ENVIRONMENT;
+  const enabled = config.enabled ?? Boolean(apiKey);
+  const normalizedApiKey =
+    apiKey || (enabled ? "" : DISABLED_PLACEHOLDER_API_KEY);
+
+  return {
+    ...config,
+    apiKey: normalizedApiKey,
+    baseUrl,
+    environment,
+    enabled,
+  };
+}
+
+function getApiLensNextEnvSummary(
+  config: ApiLensNextConfig = {},
+): ApiLensNextEnvSummary {
+  const normalized = createApiLensNextConfig(config);
+  const apiKey = String(normalized.apiKey || "").trim();
+  return {
+    hasApiKey: Boolean(apiKey) && apiKey !== DISABLED_PLACEHOLDER_API_KEY,
+    baseUrl: String(normalized.baseUrl || DEFAULT_BASE_URL),
+    environment: String(normalized.environment || DEFAULT_ENVIRONMENT),
+  };
+}
+
+function buildClient(config: ApiLensNextConfig): ApiLensClient {
+  if (config.client instanceof ApiLensClient) {
+    return config.client;
+  }
+
+  try {
+    return ApiLensClient.getInstance();
+  } catch (_error) {
+    // No existing singleton; create one with Next.js-friendly defaults.
+  }
+
+  return new ApiLensClient({
+    apiKey:
+      config.apiKey || config.api_key || config.clientId || config.client_id,
+    baseUrl: config.baseUrl || config.base_url,
+    ingestPath: config.ingestPath || config.ingest_path,
+    environment: config.environment || config.env,
+    batchSize: config.batchSize ?? 1,
+    flushIntervalMs: config.flushIntervalMs ?? 1000,
+    timeoutMs: config.timeoutMs,
+    maxQueueSize: config.maxQueueSize,
+    maxRetries: config.maxRetries,
+    retryBackoffBaseMs: config.retryBackoffBaseMs,
+    retryBackoffMaxMs: config.retryBackoffMaxMs,
+    enabled: config.enabled,
+    userAgent: config.userAgent,
+    fetchImpl: config.fetchImpl,
+    logger: config.logger,
+  });
+}
+
+function requestPathFromUrl(url: string): string {
+  try {
+    return normalizePath(new URL(url).pathname || "/");
+  } catch (_error) {
+    return "/";
+  }
+}
+
+async function readRequestPayload(
+  request: Request,
+  maxPayloadBytes: number,
+  capturePayload: boolean,
+): Promise<PayloadSnapshot> {
+  const declaredSize = toNonNegativeInt(request.headers.get("content-length"), 0);
+  const method = String(request.method || "GET").toUpperCase();
+  const hasRequestBody = method !== "GET" && method !== "HEAD";
+
+  if (!hasRequestBody) {
+    return {
+      payload: "",
+      size: declaredSize,
+    };
+  }
+
+  if (!capturePayload && declaredSize > 0) {
+    return {
+      payload: "",
+      size: declaredSize,
+    };
+  }
+
+  try {
+    const bodyBytes = Buffer.from(await request.clone().arrayBuffer());
+    return {
+      payload: capturePayload ? payloadToString(bodyBytes, maxPayloadBytes) : "",
+      size: bodyBytes.length || declaredSize,
+    };
+  } catch (_error) {
+    return {
+      payload: "",
+      size: declaredSize,
+    };
+  }
+}
+
+async function readResponsePayload(
+  response: Response,
+  maxPayloadBytes: number,
+  capturePayload: boolean,
+): Promise<PayloadSnapshot> {
+  const declaredSize = toNonNegativeInt(response.headers.get("content-length"), 0);
+
+  if (!capturePayload && declaredSize > 0) {
+    return {
+      payload: "",
+      size: declaredSize,
+    };
+  }
+
+  try {
+    const bodyBytes = Buffer.from(await response.clone().arrayBuffer());
+    return {
+      payload: capturePayload ? payloadToString(bodyBytes, maxPayloadBytes) : "",
+      size: bodyBytes.length || declaredSize,
+    };
+  } catch (_error) {
+    return {
+      payload: "",
+      size: declaredSize,
+    };
+  }
+}
+
+function withApiLens<TContext = unknown, TRequest extends Request = Request>(
+  handler: NextRouteHandler<TContext, TRequest>,
+  config: ApiLensNextConfig = {},
+): NextRouteHandlerWithClient<TContext, TRequest> {
+  const normalized = createApiLensNextConfig(config);
+  const client = buildClient(normalized);
+  const environment = normalized.environment || normalized.env;
+  const requestLogging = normalized.requestLogging || {};
+
+  const enabled = normalized.enabled !== false;
+  const logRequestBody = requestLogging.logRequestBody !== false;
+  const logResponseBody = requestLogging.logResponseBody !== false;
+  const capturePayloads = requestLogging.capturePayloads !== false;
+  const maxPayloadBytes = Math.max(
+    0,
+    toNonNegativeInt(requestLogging.maxPayloadBytes, 8192),
+  );
+
+  const wrapped = (async (request: TRequest, context?: TContext) => {
+    const method = String(request.method || "GET").toUpperCase();
+
+    if (!enabled || !client.isEnabled() || method === "OPTIONS") {
+      return handler(request, context);
+    }
+
+    const startedAt = performance.now();
+    const path = requestPathFromUrl(request.url);
+    const ipAddress =
+      firstForwardedIp(request.headers.get("x-forwarded-for")) ||
+      String(request.headers.get("x-real-ip") || "");
+    const userAgent = String(request.headers.get("user-agent") || "");
+    const requestPayloadPromise = readRequestPayload(
+      request,
+      maxPayloadBytes,
+      capturePayloads && logRequestBody,
+    );
+
+    const captureFinalRecord = async (response?: Response, statusCode = 500) => {
+      try {
+        const responseTimeMs = Math.max(performance.now() - startedAt, 0);
+        const [requestSnapshot, responseSnapshot] = await Promise.all([
+          requestPayloadPromise,
+          response
+            ? readResponsePayload(
+                response,
+                maxPayloadBytes,
+                capturePayloads && logResponseBody,
+              )
+            : Promise.resolve({ payload: "", size: 0 }),
+        ]);
+
+        const consumer =
+          consumerFromStringOrObject(consumerByRequest.get(request)) ||
+          consumerFromStringOrObject(
+            normalized.getConsumer?.(request, response, context),
+          );
+
+        client.capture({
+          timestamp: new Date(),
+          environment,
+          method,
+          path,
+          status_code: statusCode,
+          response_time_ms: responseTimeMs,
+          request_size: requestSnapshot.size,
+          response_size: responseSnapshot.size,
+          ip_address: ipAddress,
+          user_agent: userAgent,
+          consumer_id: consumer?.consumer_id || "",
+          consumer_name: consumer?.consumer_name || "",
+          consumer_group: consumer?.consumer_group || "",
+          request_payload: requestSnapshot.payload,
+          response_payload: responseSnapshot.payload,
+        });
+      } catch (error) {
+        client.config.logger.error?.(
+          "Error while logging request in API Lens Next.js route handler",
+          error,
+        );
+      } finally {
+        consumerByRequest.delete(request);
+      }
+    };
+
+    try {
+      const response = await handler(request, context);
+      const finalStatusCode =
+        response instanceof Response
+          ? Math.max(toNumber(response.status, 200), 100)
+          : 200;
+      const finalResponse =
+        response instanceof Response ? response : new Response(response);
+
+      void captureFinalRecord(finalResponse, finalStatusCode);
+      return finalResponse;
+    } catch (error) {
+      void captureFinalRecord(undefined, 500);
+      throw error;
+    }
+  }) as NextRouteHandlerWithClient<TContext, TRequest>;
+
+  wrapped.apilensClient = client;
+  return wrapped;
+}
+
+const createApiLensRouteHandler = withApiLens;
+const createNextRouteHandler = withApiLens;
+const instrumentNextRouteHandler = withApiLens;
+
+export {
+  createApiLensNextConfig,
+  getApiLensNextEnvSummary,
+  createApiLensRouteHandler,
+  createNextRouteHandler,
+  instrumentNextRouteHandler,
+  setConsumer,
+  trackConsumer,
+  withApiLens,
+};
+export type { NextRouteHandler, NextRouteHandlerWithClient };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -87,3 +87,22 @@ export type ApiLensExpressConfig = ApiLensClientConfig & {
   requestLogging?: RequestLoggingConfig;
   getConsumer?: (req: unknown, res: unknown) => ApiLensConsumer | string | null | undefined;
 };
+
+export type ApiLensNextConfig = ApiLensClientConfig & {
+  client?: unknown;
+  env?: string;
+  clientId?: string;
+  client_id?: string;
+  requestLogging?: RequestLoggingConfig;
+  getConsumer?: (
+    request: Request,
+    response?: Response,
+    context?: unknown,
+  ) => ApiLensConsumer | string | null | undefined;
+};
+
+export type ApiLensNextEnvSummary = {
+  hasApiKey: boolean;
+  baseUrl: string;
+  environment: string;
+};

--- a/sdks/js/tests/next.test.ts
+++ b/sdks/js/tests/next.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ApiLensClient } from "../src/client.js";
+import {
+  createApiLensNextConfig,
+  getApiLensNextEnvSummary,
+  setConsumer,
+  withApiLens,
+} from "../src/next.js";
+
+const ORIGINAL_ENV = {
+  APILENS_API_KEY: process.env.APILENS_API_KEY,
+  APILENS_BASE_URL: process.env.APILENS_BASE_URL,
+  APILENS_ENVIRONMENT: process.env.APILENS_ENVIRONMENT,
+};
+
+async function waitForCapturePipeline(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (typeof value === "string") {
+      process.env[key] = value;
+      continue;
+    }
+    delete process.env[key];
+  }
+}
+
+afterEach(async () => {
+  await ApiLensClient.shutdown();
+  restoreEnv();
+});
+
+describe("Next.js route handler wrapper", () => {
+  it("builds Next.js config from APILENS_* env vars", () => {
+    process.env.APILENS_API_KEY = "env-api-key";
+    process.env.APILENS_BASE_URL = "http://localhost:8000/api/v1";
+    process.env.APILENS_ENVIRONMENT = "local";
+
+    const config = createApiLensNextConfig();
+    const summary = getApiLensNextEnvSummary();
+
+    expect(config.apiKey).toBe("env-api-key");
+    expect(config.baseUrl).toBe("http://localhost:8000/api/v1");
+    expect(config.environment).toBe("local");
+    expect(config.enabled).toBe(true);
+
+    expect(summary.hasApiKey).toBe(true);
+    expect(summary.baseUrl).toBe("http://localhost:8000/api/v1");
+    expect(summary.environment).toBe("local");
+  });
+
+  it("prefers explicit config over APILENS_* env vars", () => {
+    process.env.APILENS_API_KEY = "env-api-key";
+    process.env.APILENS_BASE_URL = "http://localhost:8000/api/v1";
+    process.env.APILENS_ENVIRONMENT = "local";
+
+    const config = createApiLensNextConfig({
+      apiKey: "override-key",
+      baseUrl: "http://localhost:9000/custom",
+      environment: "staging",
+      enabled: true,
+    });
+    const summary = getApiLensNextEnvSummary({
+      apiKey: "override-key",
+      baseUrl: "http://localhost:9000/custom",
+      environment: "staging",
+    });
+
+    expect(config.apiKey).toBe("override-key");
+    expect(config.baseUrl).toBe("http://localhost:9000/custom");
+    expect(config.environment).toBe("staging");
+    expect(config.enabled).toBe(true);
+    expect(summary.hasApiKey).toBe(true);
+  });
+
+  it("auto-disables when no API key is available", async () => {
+    delete process.env.APILENS_API_KEY;
+    process.env.APILENS_BASE_URL = "http://localhost:8000/api/v1";
+    process.env.APILENS_ENVIRONMENT = "local";
+
+    const config = createApiLensNextConfig();
+    const summary = getApiLensNextEnvSummary();
+    const route = withApiLens(async () => Response.json({ ok: true }));
+
+    const response = await route(new Request("http://localhost/ping"));
+    expect(response.status).toBe(200);
+
+    expect(config.enabled).toBe(false);
+    expect(config.apiKey).toBe("missing-api-key");
+    expect(summary.hasApiKey).toBe(false);
+  });
+
+  it("uses getConsumer callback when setConsumer is not called", async () => {
+    const ingestCalls: string[] = [];
+    const route = withApiLens(async () => {
+      return Response.json({ ok: true }, { status: 200 });
+    }, {
+      apiKey: "test-api-key",
+      batchSize: 100,
+      fetchImpl: async (_url, options) => {
+        ingestCalls.push(String(options?.body || ""));
+        return new Response(null, { status: 200 });
+      },
+      getConsumer: (request) => {
+        const id = request.headers.get("x-consumer-id");
+        if (!id) {
+          return null;
+        }
+        return { id, name: "Header User", group: "header" };
+      },
+    });
+
+    const response = await route(new Request("http://localhost/get-consumer", {
+      headers: { "x-consumer-id": "c_42" },
+    }));
+    expect(response.status).toBe(200);
+
+    await waitForCapturePipeline();
+    await ApiLensClient.getInstance().flushAll();
+
+    const payload = JSON.parse(ingestCalls[0]);
+    const record = payload.requests[0];
+    expect(record.consumer_id).toBe("c_42");
+    expect(record.consumer_name).toBe("Header User");
+    expect(record.consumer_group).toBe("header");
+  });
+
+  it("respects payload capture flags and maxPayloadBytes", async () => {
+    const ingestCalls: string[] = [];
+    const route = withApiLens(async () => {
+      return new Response("response-abcdefghijklmnopqrstuvwxyz", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }, {
+      apiKey: "test-api-key",
+      batchSize: 100,
+      requestLogging: {
+        logRequestBody: true,
+        logResponseBody: true,
+        maxPayloadBytes: 10,
+      },
+      fetchImpl: async (_url, options) => {
+        ingestCalls.push(String(options?.body || ""));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    const response = await route(new Request("http://localhost/truncate", {
+      method: "POST",
+      body: "request-abcdefghijklmnopqrstuvwxyz",
+    }));
+    expect(response.status).toBe(200);
+
+    await waitForCapturePipeline();
+    await ApiLensClient.getInstance().flushAll();
+
+    const payload = JSON.parse(ingestCalls[0]);
+    const record = payload.requests[0];
+    expect(Buffer.from(record.request_payload, "utf8").length).toBeLessThanOrEqual(10);
+    expect(Buffer.from(record.response_payload, "utf8").length).toBeLessThanOrEqual(10);
+  });
+
+  it("captures request/response metadata and consumer details", async () => {
+    const ingestCalls: string[] = [];
+    const postOrders = withApiLens(async (request: Request) => {
+      setConsumer(request, { id: "user_123", name: "John", group: "starter" });
+      const body = (await request.json()) as { item: string };
+      return Response.json({ ok: true, item: body.item }, { status: 201 });
+    }, {
+      apiKey: "test-api-key",
+      environment: "test",
+      batchSize: 100,
+      fetchImpl: async (_url, options) => {
+        ingestCalls.push(String(options?.body || ""));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    const request = new Request("http://localhost/orders?expand=true", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "next-sdk-test",
+        "X-Forwarded-For": "1.2.3.4, 5.6.7.8",
+      },
+      body: JSON.stringify({ item: "book" }),
+    });
+
+    const response = await postOrders(request);
+    expect(response.status).toBe(201);
+
+    await waitForCapturePipeline();
+    await ApiLensClient.getInstance().flushAll();
+
+    expect(ingestCalls).toHaveLength(1);
+    const payload = JSON.parse(ingestCalls[0]);
+    expect(payload.requests).toHaveLength(1);
+
+    const record = payload.requests[0];
+    expect(record.environment).toBe("test");
+    expect(record.method).toBe("POST");
+    expect(record.path).toBe("/orders");
+    expect(record.status_code).toBe(201);
+    expect(record.ip_address).toBe("1.2.3.4");
+    expect(record.user_agent).toBe("next-sdk-test");
+    expect(record.consumer_id).toBe("user_123");
+    expect(record.consumer_name).toBe("John");
+    expect(record.consumer_group).toBe("starter");
+    expect(record.request_payload).toContain('"item":"book"');
+    expect(record.response_payload).toContain('"ok":true');
+    expect(record.response_time_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captures thrown handler errors as 500 responses", async () => {
+    const ingestCalls: string[] = [];
+    const crashingRoute = withApiLens(async () => {
+      throw new Error("boom");
+    }, {
+      apiKey: "test-api-key",
+      batchSize: 100,
+      fetchImpl: async (_url, options) => {
+        ingestCalls.push(String(options?.body || ""));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    await expect(
+      crashingRoute(
+        new Request("http://localhost/fail", {
+          method: "POST",
+          body: JSON.stringify({ reason: "test" }),
+        }),
+      ),
+    ).rejects.toThrow("boom");
+
+    await waitForCapturePipeline();
+    await ApiLensClient.getInstance().flushAll();
+
+    expect(ingestCalls).toHaveLength(1);
+    const payload = JSON.parse(ingestCalls[0]);
+    expect(payload.requests).toHaveLength(1);
+    expect(payload.requests[0].path).toBe("/fail");
+    expect(payload.requests[0].status_code).toBe(500);
+  });
+
+  it("skips capture for OPTIONS requests", async () => {
+    const ingestCalls: string[] = [];
+    const optionsRoute = withApiLens(async () => {
+      return new Response(null, { status: 204 });
+    }, {
+      apiKey: "test-api-key",
+      batchSize: 100,
+      fetchImpl: async (_url, options) => {
+        ingestCalls.push(String(options?.body || ""));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    const response = await optionsRoute(
+      new Request("http://localhost/health", { method: "OPTIONS" }),
+    );
+    expect(response.status).toBe(204);
+
+    await waitForCapturePipeline();
+    await ApiLensClient.getInstance().flushAll();
+
+    expect(ingestCalls).toHaveLength(0);
+  });
+});

--- a/sdks/js/tsup.config.ts
+++ b/sdks/js/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/express.ts"],
+  entry: ["src/index.ts", "src/express.ts", "src/next.ts"],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
### Summary
  This PR adds first-class Next.js App Router support to the JavaScript SDK so users can instrument route handlers with the same API Lens capture model already available
  for Express.

  ### What Changed
  - Added new Next entrypoint: `apilens-js-sdk/next`.
  - Added Next route wrapper APIs:
    - `withApiLens`
    - `createApiLensRouteHandler` (alias)
    - `createNextRouteHandler` (alias)
    - `instrumentNextRouteHandler` (alias)
  - Added consumer helpers for Next requests:
    - `setConsumer`
    - `trackConsumer`
  - Added env-based Next config helpers:
    - `createApiLensNextConfig(overrides?)`
    - `getApiLensNextEnvSummary(overrides?)`
  - Added `ApiLensNextConfig` and `ApiLensNextEnvSummary` typing support.
  - Updated package build/exports to publish the `./next` subpath.
  - Updated docs and changelog for new Next APIs and usage.

  ### Behavior Details
  - Config defaults are resolved from env:
    - `APILENS_API_KEY`
    - `APILENS_BASE_URL`
    - `APILENS_ENVIRONMENT`
  - Explicit config values override env values.
  - If API key is missing, Next instrumentation is auto-disabled instead of throwing.
  - OPTIONS requests are skipped from capture.
  - Request/response payload capture supports truncation via `maxPayloadBytes`.
  - `getConsumer` callback is supported when `setConsumer` is not explicitly called.
