### PR TITLE
feat: add project-level data APIs and settings UI

### DIFF
--- a/backend/api/ingest/router.py
+++ b/backend/api/ingest/router.py
@@ -8,7 +8,7 @@ from apps.projects.services import IngestService
 from core.auth.authentication import api_key_auth
 from core.exceptions.base import AuthenticationError, ValidationError
 
-from .schemas import IngestRequest, IngestResponse
+from .schemas import IngestRequest, IngestResponse, IngestLogsRequest, IngestLogsResponse
 
 router = Router(auth=[api_key_auth])
 
@@ -53,3 +53,43 @@ def ingest_requests(request: HttpRequest, data: IngestRequest):
         total_accepted += accepted
 
     return IngestResponse(accepted=total_accepted)
+
+
+@router.post("/logs", response=IngestLogsResponse)
+def ingest_logs(request: HttpRequest, data: IngestLogsRequest):
+    """
+    Ingest application log records.
+    API key provides project_id, payload provides app_id for each log.
+    """
+    if len(data.logs) > MAX_BATCH_SIZE:
+        raise ValidationError(f"Batch size exceeds maximum of {MAX_BATCH_SIZE}")
+
+    project_id = request.tenant_context.project_id
+    if not project_id:
+        raise AuthenticationError("API key must be scoped to a project")
+
+    # Validate all app_ids belong to this project
+    app_ids = {log.app_id for log in data.logs}
+    valid_app_ids = set(
+        App.objects.filter(
+            project_id=project_id,
+            id__in=app_ids,
+            is_active=True
+        ).values_list("id", flat=True)
+    )
+
+    invalid_app_ids = app_ids - {str(aid) for aid in valid_app_ids}
+    if invalid_app_ids:
+        raise ValidationError(f"Invalid app_ids: {invalid_app_ids}")
+
+    # Group logs by app_id for batch processing
+    logs_by_app = defaultdict(list)
+    for log in data.logs:
+        logs_by_app[log.app_id].append(log)
+
+    total_accepted = 0
+    for app_id, logs in logs_by_app.items():
+        accepted = IngestService.ingest_logs(app_id, logs)
+        total_accepted += accepted
+
+    return IngestLogsResponse(accepted=total_accepted)

--- a/backend/api/projects/router.py
+++ b/backend/api/projects/router.py
@@ -13,7 +13,7 @@ from ninja import Router
 
 from apps.auth.services import ApiKeyService
 from apps.projects.models import App
-from apps.projects.services import ProjectService, AppService, AnalyticsService
+from apps.projects.services import ProjectService, AppService, AnalyticsService, DataQueryService
 from apps.users.models import User
 from core.auth.authentication import jwt_auth
 
@@ -30,6 +30,8 @@ from .schemas import (
     CreateApiKeyResponse,
     ApiKeyResponse,
     MessageResponse,
+    LogsQueryResponse,
+    RequestsQueryResponse,
 )
 
 router = Router(auth=[jwt_auth])
@@ -297,3 +299,130 @@ def get_environments(
     )
 
     return {"environments": environments}
+
+
+# ── Project-level Data Query (raw telemetry access) ──────────────────
+
+@router.get("/{project_slug}/data/logs", response=LogsQueryResponse)
+def query_project_logs(
+    request: HttpRequest,
+    project_slug: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    levels: str = None,
+    search: str = None,
+    loggers: str = None,
+    page: int = 1,
+    page_size: int = 50,
+):
+    """
+    Query raw log data across all apps in a project (or specific apps).
+
+    Filters:
+    - app_slugs: Comma-separated app slugs (e.g., "api,worker")
+    - environment: Filter by environment name
+    - levels: Comma-separated log levels (e.g., "ERROR,WARNING")
+    - search: Search in message, logger_name, or attributes
+    - loggers: Comma-separated logger names
+    - since/until: ISO8601 timestamps for time range
+    - page/page_size: Pagination controls
+    """
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+
+    app_ids = None
+    if app_slugs:
+        slugs = [s.strip() for s in app_slugs.split(",") if s.strip()]
+        if slugs:
+            apps = AppService.get_apps_by_slugs(project, slugs)
+            app_ids = [str(app.id) for app in apps]
+
+    level_list = None
+    if levels:
+        level_list = [l.strip().upper() for l in levels.split(",") if l.strip()]
+
+    logger_list = None
+    if loggers:
+        logger_list = [lg.strip() for lg in loggers.split(",") if lg.strip()]
+
+    result = DataQueryService.get_project_logs(
+        project_id=str(project.id),
+        app_ids=app_ids,
+        environment=environment,
+        since=since,
+        until=until,
+        levels=level_list,
+        search=search,
+        logger_filters=logger_list,
+        page=page,
+        page_size=page_size,
+    )
+
+    return LogsQueryResponse(**result)
+
+
+@router.get("/{project_slug}/data/requests", response=RequestsQueryResponse)
+def query_project_requests(
+    request: HttpRequest,
+    project_slug: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    methods: str = None,
+    status_codes: str = None,
+    min_response_time: float = None,
+    max_response_time: float = None,
+    path_filter: str = None,
+    page: int = 1,
+    page_size: int = 50,
+):
+    """
+    Query raw API request data across all apps in a project (or specific apps).
+
+    Filters:
+    - app_slugs: Comma-separated app slugs (e.g., "api,worker")
+    - environment: Filter by environment name
+    - methods: Comma-separated HTTP methods (e.g., "GET,POST")
+    - status_codes: Comma-separated status codes (e.g., "200,201,404")
+    - min_response_time/max_response_time: Response time range in ms
+    - path_filter: Path pattern (use * for wildcards, e.g., "/api/users/*")
+    - since/until: ISO8601 timestamps for time range
+    - page/page_size: Pagination controls
+    """
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+
+    app_ids = None
+    if app_slugs:
+        slugs = [s.strip() for s in app_slugs.split(",") if s.strip()]
+        if slugs:
+            apps = AppService.get_apps_by_slugs(project, slugs)
+            app_ids = [str(app.id) for app in apps]
+
+    method_list = None
+    if methods:
+        method_list = [m.strip().upper() for m in methods.split(",") if m.strip()]
+
+    status_list = None
+    if status_codes:
+        status_list = [int(s.strip()) for s in status_codes.split(",") if s.strip().isdigit()]
+
+    result = DataQueryService.get_project_requests(
+        project_id=str(project.id),
+        app_ids=app_ids,
+        environment=environment,
+        since=since,
+        until=until,
+        methods=method_list,
+        status_codes=status_list,
+        min_response_time=min_response_time,
+        max_response_time=max_response_time,
+        path_filter=path_filter,
+        page=page,
+        page_size=page_size,
+    )
+
+    return RequestsQueryResponse(**result)

--- a/backend/api/projects/schemas.py
+++ b/backend/api/projects/schemas.py
@@ -156,6 +156,47 @@ class ApiKeyResponse(Schema):
         )
 
 
+# ── Data Query Schemas ──────────────────────────────────────────────
+
+class LogItemResponse(Schema):
+    timestamp: datetime
+    app_id: str
+    environment: str
+    level: str
+    message: str
+    logger_name: str
+    payload: str
+    attributes: dict
+
+class LogsQueryResponse(Schema):
+    items: list[LogItemResponse]
+    total_count: int
+    page: int
+    page_size: int
+
+class RequestItemResponse(Schema):
+    timestamp: datetime
+    app_id: str
+    environment: str
+    method: str
+    path: str
+    status_code: int
+    response_time_ms: float
+    request_size: int
+    response_size: int
+    ip_address: str
+    user_agent: str
+    consumer_id: str
+    consumer_name: str
+    consumer_group: str
+
+class RequestsQueryResponse(Schema):
+    items: list[RequestItemResponse]
+    total_count: int
+    page: int
+    page_size: int
+
+
 # ── Generic Response Schemas ──────────────────────────────────────────
 
 class MessageResponse(Schema):

--- a/backend/apps/projects/services.py
+++ b/backend/apps/projects/services.py
@@ -1863,6 +1863,289 @@ class LogsService:
             return {"keys": [], "values": [], "loggers": []}
 
 
+class DataQueryService:
+    """Service for querying raw telemetry data at project level."""
+
+    @staticmethod
+    def get_project_logs(
+        project_id: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        levels: list[str] | None = None,
+        search: str | None = None,
+        attribute_filters: list[tuple[str, str]] | None = None,
+        logger_filters: list[str] | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict:
+        """
+        Query logs across all apps in a project or specific apps.
+        Returns paginated log records with filters.
+        """
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        safe_page = max(1, int(page))
+        safe_size = max(1, min(int(page_size), 200))
+        offset = (safe_page - 1) * safe_size
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty logs: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+        IngestService.ensure_api_logs_table(client)
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        params: dict[str, Any] = {
+            "project_id": project_id,
+            "since": since_dt,
+            "until": until_dt,
+            "limit": safe_size,
+            "offset": offset,
+        }
+
+        # Build app_ids filter
+        app_filter = ""
+        if app_ids:
+            app_placeholders = []
+            for idx, app_id in enumerate(app_ids):
+                key = f"app_id_{idx}"
+                params[key] = app_id
+                app_placeholders.append(f"%({key})s")
+            app_filter = f"AND app_id IN ({', '.join(app_placeholders)})"
+
+        where_filters = LogsService._build_log_filters(
+            params,
+            environment=environment,
+            levels=levels,
+            search=search,
+            attribute_filters=attribute_filters,
+            logger_filters=logger_filters,
+        )
+
+        count_query = f"""
+            SELECT count() AS total_count
+            FROM api_logs
+            WHERE project_id = %(project_id)s
+              {app_filter}
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_filters}
+        """
+
+        rows_query = f"""
+            SELECT
+                timestamp,
+                app_id,
+                environment,
+                level,
+                message,
+                logger_name,
+                payload,
+                attributes_json
+            FROM api_logs
+            WHERE project_id = %(project_id)s
+              {app_filter}
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_filters}
+            ORDER BY timestamp DESC
+            LIMIT %(limit)s
+            OFFSET %(offset)s
+        """
+
+        try:
+            count_rows = client.execute(count_query, params)
+            total_count = int(count_rows[0]["total_count"]) if count_rows else 0
+            items = client.execute(rows_query, params)
+            for item in items:
+                item["timestamp"] = _as_utc(item.get("timestamp"))
+                raw_attributes = item.get("attributes_json", "") or "{}"
+                try:
+                    parsed = json.loads(raw_attributes)
+                    if not isinstance(parsed, dict):
+                        parsed = {}
+                except Exception:
+                    parsed = {}
+                item["attributes"] = {str(k): str(v) for k, v in parsed.items()}
+                item.pop("attributes_json", None)
+            return {
+                "items": items,
+                "total_count": total_count,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project logs: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+    @staticmethod
+    def get_project_requests(
+        project_id: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        methods: list[str] | None = None,
+        status_codes: list[int] | None = None,
+        min_response_time: float | None = None,
+        max_response_time: float | None = None,
+        path_filter: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict:
+        """
+        Query API requests across all apps in a project or specific apps.
+        Returns paginated request records with filters.
+        """
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        safe_page = max(1, int(page))
+        safe_size = max(1, min(int(page_size), 200))
+        offset = (safe_page - 1) * safe_size
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty requests: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        params: dict[str, Any] = {
+            "project_id": project_id,
+            "since": since_dt,
+            "until": until_dt,
+            "limit": safe_size,
+            "offset": offset,
+        }
+
+        filters: list[str] = []
+
+        # App filter
+        if app_ids:
+            app_placeholders = []
+            for idx, app_id in enumerate(app_ids):
+                key = f"app_id_{idx}"
+                params[key] = app_id
+                app_placeholders.append(f"%({key})s")
+            filters.append(f"app_id IN ({', '.join(app_placeholders)})")
+
+        # Environment filter
+        if environment:
+            filters.append("environment = %(environment)s")
+            params["environment"] = environment
+
+        # Methods filter
+        if methods:
+            method_placeholders = []
+            for idx, method in enumerate(methods):
+                key = f"method_{idx}"
+                params[key] = method.upper()
+                method_placeholders.append(f"%({key})s")
+            filters.append(f"method IN ({', '.join(method_placeholders)})")
+
+        # Status codes filter
+        if status_codes:
+            status_placeholders = []
+            for idx, code in enumerate(status_codes):
+                key = f"status_{idx}"
+                params[key] = int(code)
+                status_placeholders.append(f"%({key})s")
+            filters.append(f"status_code IN ({', '.join(status_placeholders)})")
+
+        # Response time filters
+        if min_response_time is not None:
+            filters.append("response_time_ms >= %(min_response_time)s")
+            params["min_response_time"] = float(min_response_time)
+
+        if max_response_time is not None:
+            filters.append("response_time_ms <= %(max_response_time)s")
+            params["max_response_time"] = float(max_response_time)
+
+        # Path filter (supports wildcards)
+        if path_filter:
+            filters.append("path LIKE %(path_filter)s")
+            params["path_filter"] = path_filter.replace("*", "%")
+
+        where_clause = ""
+        if filters:
+            where_clause = "AND " + " AND ".join(filters)
+
+        count_query = f"""
+            SELECT count() AS total_count
+            FROM api_requests
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+        """
+
+        rows_query = f"""
+            SELECT
+                timestamp,
+                app_id,
+                environment,
+                method,
+                path,
+                status_code,
+                response_time_ms,
+                request_size,
+                response_size,
+                ip_address,
+                user_agent,
+                consumer_id,
+                consumer_name,
+                consumer_group
+            FROM api_requests
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+            ORDER BY timestamp DESC
+            LIMIT %(limit)s
+            OFFSET %(offset)s
+        """
+
+        try:
+            count_rows = client.execute(count_query, params)
+            total_count = int(count_rows[0]["total_count"]) if count_rows else 0
+            items = client.execute(rows_query, params)
+            for item in items:
+                item["timestamp"] = _as_utc(item.get("timestamp"))
+            return {
+                "items": items,
+                "total_count": total_count,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project requests: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+
 class AnalyticsService:
     @staticmethod
     def _clean_nan_values(data: dict) -> dict:

--- a/frontend/src/app/api/projects/[slug]/api-keys/[keyId]/route.ts
+++ b/frontend/src/app/api/projects/[slug]/api-keys/[keyId]/route.ts
@@ -1,0 +1,11 @@
+import { withAuth, apiResult } from "@/lib/proxy";
+import { apiClient } from "@/lib/api-client";
+
+export const DELETE = (
+  _request: Request,
+  { params }: { params: Promise<{ slug: string; keyId: string }> },
+) =>
+  withAuth(async () => {
+    const { slug, keyId } = await params;
+    return apiResult(await apiClient.revokeProjectApiKey(slug, keyId));
+  });

--- a/frontend/src/app/api/projects/[slug]/api-keys/route.ts
+++ b/frontend/src/app/api/projects/[slug]/api-keys/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { withAuth, apiResult } from "@/lib/proxy";
+import { apiClient } from "@/lib/api-client";
+
+export const GET = (
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) =>
+  withAuth(async () => apiResult(await apiClient.getProjectApiKeys((await params).slug), "keys"));
+
+export const POST = (
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) =>
+  withAuth(async () => {
+    const body = await request.json();
+    const name = body.name?.trim();
+    if (!name) {
+      return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+    return apiResult(await apiClient.createProjectApiKey((await params).slug, name));
+  });

--- a/frontend/src/app/projects/[slug]/settings/ProjectSettingsContent.tsx
+++ b/frontend/src/app/projects/[slug]/settings/ProjectSettingsContent.tsx
@@ -5,9 +5,12 @@ import { useRouter } from "next/navigation";
 import { Trash2, Loader2, X, Check } from "lucide-react";
 import PageHeader from "@/components/dashboard/PageHeader";
 import SettingsCard from "@/components/settings/SettingsCard";
+import ProjectApiKeysSection from "@/components/projects/ProjectApiKeysSection";
+import ProjectSettingsSidebar, { ProjectSettingsTab } from "@/components/projects/ProjectSettingsSidebar";
 
 interface ProjectSettingsContentProps {
   projectSlug: string;
+  initialTab?: ProjectSettingsTab;
 }
 
 interface ProjectInfo {
@@ -24,8 +27,12 @@ interface ToastState {
   message: string;
 }
 
-export default function ProjectSettingsContent({ projectSlug }: ProjectSettingsContentProps) {
+export default function ProjectSettingsContent({
+  projectSlug,
+  initialTab = "general"
+}: ProjectSettingsContentProps) {
   const router = useRouter();
+  const [activeTab, setActiveTab] = useState<ProjectSettingsTab>(initialTab);
   const [project, setProject] = useState<ProjectInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -41,6 +48,10 @@ export default function ProjectSettingsContent({ projectSlug }: ProjectSettingsC
     setToast({ type, message });
     setTimeout(() => setToast(null), 5000);
   };
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
 
   useEffect(() => {
     async function fetchProject() {
@@ -88,7 +99,7 @@ export default function ProjectSettingsContent({ projectSlug }: ProjectSettingsC
       // Redirect if slug changed
       if (updated.slug !== projectSlug) {
         setTimeout(() => {
-          router.push(`/projects/${updated.slug}/settings`);
+          router.push(`/projects/${updated.slug}/settings/${activeTab}`);
         }, 1000);
       }
     } catch (err) {
@@ -160,78 +171,88 @@ export default function ProjectSettingsContent({ projectSlug }: ProjectSettingsC
       <PageHeader title="Project Settings" subtitle="Manage your project configuration" />
 
       <div className="settings-page-body">
+        <ProjectSettingsSidebar projectSlug={projectSlug} activeTab={activeTab} />
+
         <div className="settings-page-content">
-          <div className="settings-section-content">
-            <SettingsCard title="General" description="Update your project details">
-              <form onSubmit={handleSave} className="app-general-form">
-                <div className="create-app-field">
-                  <label htmlFor="name" className="create-app-label">
-                    Project Name
-                  </label>
-                  <input
-                    id="name"
-                    type="text"
-                    value={formData.name}
-                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                    className="create-app-input"
-                    required
-                  />
-                </div>
+          {activeTab === "general" && (
+            <div className="settings-section-content">
+              <SettingsCard title="General" description="Update your project details">
+                <form onSubmit={handleSave} className="app-general-form">
+                  <div className="create-app-field">
+                    <label htmlFor="name" className="create-app-label">
+                      Project Name
+                    </label>
+                    <input
+                      id="name"
+                      type="text"
+                      value={formData.name}
+                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                      className="create-app-input"
+                      required
+                    />
+                  </div>
 
-                <div className="create-app-field">
-                  <label htmlFor="description" className="create-app-label">
-                    Description
-                  </label>
-                  <textarea
-                    id="description"
-                    value={formData.description}
-                    onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                    className="create-app-textarea"
-                    rows={3}
-                    placeholder="Add a description for your project"
-                  />
-                </div>
+                  <div className="create-app-field">
+                    <label htmlFor="description" className="create-app-label">
+                      Description
+                    </label>
+                    <textarea
+                      id="description"
+                      value={formData.description}
+                      onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                      className="create-app-textarea"
+                      rows={3}
+                      placeholder="Add a description for your project"
+                    />
+                  </div>
 
-                <div className="app-general-actions">
-                  <button type="submit" className="settings-btn settings-btn-primary" disabled={isSaving}>
-                    {isSaving ? (
-                      <>
-                        <Loader2 size={14} className="animate-spin" />
-                        Saving...
-                      </>
-                    ) : (
-                      "Save changes"
-                    )}
-                  </button>
-                </div>
-              </form>
-            </SettingsCard>
+                  <div className="app-general-actions">
+                    <button type="submit" className="settings-btn settings-btn-primary" disabled={isSaving}>
+                      {isSaving ? (
+                        <>
+                          <Loader2 size={14} className="animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        "Save changes"
+                      )}
+                    </button>
+                  </div>
+                </form>
+              </SettingsCard>
 
-            <SettingsCard
-              title="Danger Zone"
-              description="Deleting a project will permanently remove it and all associated apps, API keys, and data. This action cannot be undone."
-              variant="danger"
-            >
-              <button
-                type="button"
-                onClick={handleDelete}
-                className="settings-btn settings-btn-danger"
-                disabled={isDeleting}
+              <SettingsCard
+                title="Danger Zone"
+                description="Deleting a project will permanently remove it and all associated apps, API keys, and data. This action cannot be undone."
+                variant="danger"
               >
-                {isDeleting ? (
-                  <>
-                    <Loader2 size={16} className="animate-spin" />
-                    Deleting...
-                  </>
-                ) : (
-                  <>
-                    <Trash2 size={16} />
-                    Delete Project
-                  </>
-                )}
-              </button>
-            </SettingsCard>
-          </div>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="settings-btn settings-btn-danger"
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? (
+                    <>
+                      <Loader2 size={16} className="animate-spin" />
+                      Deleting...
+                    </>
+                  ) : (
+                    <>
+                      <Trash2 size={16} />
+                      Delete Project
+                    </>
+                  )}
+                </button>
+              </SettingsCard>
+            </div>
+          )}
+
+          {activeTab === "api-keys" && (
+            <div className="settings-section-content">
+              <ProjectApiKeysSection projectSlug={projectSlug} showToast={showToast} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/app/projects/[slug]/settings/[tab]/page.tsx
+++ b/frontend/src/app/projects/[slug]/settings/[tab]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound, redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import ProjectSettingsContent from "../ProjectSettingsContent";
+import type { ProjectSettingsTab } from "@/components/projects/ProjectSettingsSidebar";
+
+const validTabs: ProjectSettingsTab[] = ["general", "api-keys"];
+
+export async function generateMetadata({ params }: { params: Promise<{ tab: string }> }) {
+  const { tab } = await params;
+  const tabTitles: Record<string, string> = {
+    general: "General",
+    "api-keys": "API Keys",
+  };
+
+  return {
+    title: `${tabTitles[tab] || "Settings"} — Project Settings | APILens`,
+  };
+}
+
+export default async function ProjectSettingsTabPage({
+  params,
+}: {
+  params: Promise<{ slug: string; tab: string }>;
+}) {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  const { slug, tab } = await params;
+
+  if (!validTabs.includes(tab as ProjectSettingsTab)) {
+    notFound();
+  }
+
+  return <ProjectSettingsContent projectSlug={slug} initialTab={tab as ProjectSettingsTab} />;
+}

--- a/frontend/src/app/projects/[slug]/settings/page.tsx
+++ b/frontend/src/app/projects/[slug]/settings/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/session";
-import ProjectSettingsContent from "./ProjectSettingsContent";
 
 export const metadata = {
   title: "Project Settings | APILens",
@@ -13,5 +12,6 @@ export default async function ProjectSettingsPage({ params }: { params: Promise<
   }
 
   const { slug } = await params;
-  return <ProjectSettingsContent projectSlug={slug} />;
+  // Redirect to general tab by default
+  redirect(`/projects/${slug}/settings/general`);
 }

--- a/frontend/src/components/projects/ProjectApiKeysSection.tsx
+++ b/frontend/src/components/projects/ProjectApiKeysSection.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Key,
+  Plus,
+  Trash2,
+  Copy,
+  Check,
+  Loader2,
+  Eye,
+  EyeOff,
+  AlertTriangle,
+  Shield,
+} from "lucide-react";
+import SettingsCard from "@/components/settings/SettingsCard";
+import ConfirmDialog from "@/components/settings/ConfirmDialog";
+
+interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+interface ProjectApiKeysSectionProps {
+  projectSlug: string;
+  showToast: (type: "success" | "error", message: string) => void;
+}
+
+export default function ProjectApiKeysSection({ projectSlug, showToast }: ProjectApiKeysSectionProps) {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+
+  const [newRawKey, setNewRawKey] = useState<string | null>(null);
+  const [showKey, setShowKey] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const fetchKeys = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/projects/${projectSlug}/api-keys`);
+      if (!res.ok) throw new Error("Failed to fetch API keys");
+      const data = await res.json();
+      setKeys(data.keys);
+    } catch (err) {
+      if (!(err instanceof DOMException)) console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectSlug]);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  useEffect(() => {
+    if (newRawKey) {
+      setCopied(false);
+      setShowKey(false);
+    }
+  }, [newRawKey]);
+
+  const maskKey = (key: string) => {
+    if (key.length <= 12) return "*".repeat(key.length);
+    return `${key.slice(0, 12)}${"*".repeat(key.length - 12)}`;
+  };
+
+  const formatDate = (dateStr: string) =>
+    new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+  const formatRelativeTime = (dateStr: string | null) => {
+    if (!dateStr) return "Never";
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "Just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    if (days < 7) return `${days}d ago`;
+    return formatDate(dateStr);
+  };
+
+  const handleCreate = async () => {
+    if (!newKeyName.trim()) return;
+    setIsCreating(true);
+    try {
+      const res = await fetch(`/api/projects/${projectSlug}/api-keys`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newKeyName.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create key");
+      setNewRawKey(data.key);
+      setNewKeyName("");
+      setShowCreateForm(false);
+      await fetchKeys();
+    } catch (err) {
+      showToast(
+        "error",
+        err instanceof Error ? err.message : "Failed to create API key",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleCopy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      showToast("error", "Failed to copy. Copy manually.");
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setIsRevoking(true);
+    try {
+      const res = await fetch(`/api/projects/${projectSlug}/api-keys/${revokeTarget.id}`, {
+        method: "DELETE",
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to revoke key");
+      setKeys((prev) => prev.filter((k) => k.id !== revokeTarget.id));
+      showToast("success", "API key revoked");
+    } catch (err) {
+      showToast(
+        "error",
+        err instanceof Error ? err.message : "Failed to revoke API key",
+      );
+    } finally {
+      setIsRevoking(false);
+      setRevokeTarget(null);
+    }
+  };
+
+  const cancelCreate = () => {
+    setShowCreateForm(false);
+    setNewKeyName("");
+  };
+
+  const dismissNewKey = () => {
+    setNewRawKey(null);
+    setShowKey(false);
+    setCopied(false);
+  };
+
+  const hasInlineContent = showCreateForm || !!newRawKey;
+
+  return (
+    <>
+      <SettingsCard
+        title="API Keys"
+        description="Project-level API keys work across all apps in this project. Use them to send telemetry data via the APILens SDK."
+        action={
+          !showCreateForm &&
+          !newRawKey && (
+            <button
+              className="settings-btn settings-btn-secondary settings-btn-sm"
+              onClick={() => setShowCreateForm(true)}
+            >
+              <Plus size={14} />
+              Create key
+            </button>
+          )
+        }
+      >
+        {newRawKey && (
+          <div className="apikeys-reveal">
+            <div className="apikeys-reveal-header">
+              <div className="apikeys-reveal-icon">
+                <Key size={16} />
+              </div>
+              <div>
+                <p className="apikeys-reveal-title">Your new API key</p>
+                <p className="apikeys-reveal-subtitle">
+                  Copy it now — you won&apos;t be able to see it again.
+                </p>
+              </div>
+            </div>
+            <div className="apikeys-reveal-value">
+              <code className="apikeys-reveal-code">
+                {showKey ? newRawKey : maskKey(newRawKey)}
+              </code>
+              <div className="apikeys-reveal-actions">
+                <button
+                  className="settings-btn settings-btn-ghost settings-btn-sm"
+                  onClick={() => setShowKey(!showKey)}
+                  aria-label={showKey ? "Hide key" : "Show key"}
+                >
+                  {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+                <button
+                  className="settings-btn settings-btn-ghost settings-btn-sm"
+                  onClick={() => handleCopy(newRawKey)}
+                  aria-label="Copy key"
+                >
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+            <div className="apikeys-reveal-warning">
+              <AlertTriangle size={14} />
+              <span>
+                Store this key securely. It has access to all apps in this project.
+              </span>
+            </div>
+            <button
+              className="settings-btn settings-btn-secondary settings-btn-sm"
+              onClick={dismissNewKey}
+              style={{ width: "100%" }}
+            >
+              I&apos;ve copied it
+            </button>
+          </div>
+        )}
+
+        {showCreateForm && !newRawKey && (
+          <div className="apikeys-create-form">
+            <div className="apikeys-create-field">
+              <label className="apikeys-label" htmlFor="apikey-name">
+                Key name
+              </label>
+              <input
+                id="apikey-name"
+                className="apikeys-input"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && newKeyName.trim()) handleCreate();
+                  if (e.key === "Escape") cancelCreate();
+                }}
+                placeholder="e.g. Production, CI/CD, Local dev"
+                maxLength={100}
+                autoFocus
+              />
+            </div>
+            <div className="apikeys-create-actions">
+              <button
+                className="settings-btn settings-btn-secondary settings-btn-sm"
+                onClick={cancelCreate}
+              >
+                Cancel
+              </button>
+              <button
+                className="settings-btn settings-btn-primary settings-btn-sm"
+                disabled={isCreating || !newKeyName.trim()}
+                onClick={handleCreate}
+              >
+                {isCreating ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  "Create key"
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="sessions-loading">
+            <Loader2 size={18} className="animate-spin" />
+            <span>Loading API keys...</span>
+          </div>
+        ) : keys.length === 0 && !hasInlineContent ? (
+          <div className="apikeys-empty">
+            <div className="apikeys-empty-icon">
+              <Shield size={20} />
+            </div>
+            <p className="apikeys-empty-text">
+              No API keys yet. Create one to start sending data from your apps.
+            </p>
+          </div>
+        ) : keys.length > 0 ? (
+          <div
+            className={`apikeys-list${hasInlineContent ? " apikeys-list-separated" : ""}`}
+          >
+            {keys.map((k) => (
+              <div key={k.id} className="apikeys-item">
+                <div className="apikeys-item-icon">
+                  <Key size={16} />
+                </div>
+                <div className="apikeys-item-info">
+                  <p className="apikeys-item-name">{k.name}</p>
+                  <p className="apikeys-item-meta">
+                    <code className="apikeys-item-prefix">{k.prefix}...</code>
+                    <span>Created {formatDate(k.created_at)}</span>
+                    <span>
+                      Last used: {formatRelativeTime(k.last_used_at)}
+                    </span>
+                  </p>
+                </div>
+                <button
+                  className="settings-btn settings-btn-ghost settings-btn-sm"
+                  onClick={() => setRevokeTarget(k)}
+                  aria-label={`Revoke ${k.name}`}
+                >
+                  <Trash2 size={14} />
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </SettingsCard>
+
+      <ConfirmDialog
+        isOpen={!!revokeTarget}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={handleRevoke}
+        title="Revoke API Key"
+        description={`Revoke "${revokeTarget?.name}"? This will break all integrations using this key.`}
+        confirmText="Revoke"
+        variant="danger"
+        isLoading={isRevoking}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/projects/ProjectSettingsSidebar.tsx
+++ b/frontend/src/components/projects/ProjectSettingsSidebar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { Settings, Key } from "lucide-react";
+
+export type ProjectSettingsTab = "general" | "api-keys";
+
+interface ProjectSettingsSidebarProps {
+  projectSlug: string;
+  activeTab: ProjectSettingsTab;
+}
+
+const menuItems: { id: ProjectSettingsTab; label: string; icon: React.ElementType }[] = [
+  { id: "general", label: "General", icon: Settings },
+  { id: "api-keys", label: "API Keys", icon: Key },
+];
+
+export default function ProjectSettingsSidebar({ projectSlug, activeTab }: ProjectSettingsSidebarProps) {
+  return (
+    <nav className="settings-sidebar">
+      <ul className="settings-sidebar-menu">
+        {menuItems.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={`/projects/${projectSlug}/settings/${item.id}`}
+              className={`settings-sidebar-item ${activeTab === item.id ? "active" : ""}`}
+            >
+              <item.icon size={16} />
+              <span>{item.label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/components/projects/index.ts
+++ b/frontend/src/components/projects/index.ts
@@ -1,1 +1,4 @@
 export { default as ProjectCard } from "./ProjectCard";
+export { default as ProjectApiKeysSection } from "./ProjectApiKeysSection";
+export { default as ProjectSettingsSidebar } from "./ProjectSettingsSidebar";
+export type { ProjectSettingsTab } from "./ProjectSettingsSidebar";

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -452,6 +452,25 @@ export const apiClient = {
     });
   },
 
+  // ── Project-scoped API Keys ────────────────────────────────────────
+
+  async getProjectApiKeys(projectSlug: string): Promise<ApiResponse<ApiKeyInfo[]>> {
+    return fetchDjango<ApiKeyInfo[]>(`/projects/${projectSlug}/api-keys`);
+  },
+
+  async createProjectApiKey(projectSlug: string, name: string): Promise<ApiResponse<ApiKeyCreateResult>> {
+    return fetchDjango<ApiKeyCreateResult>(`/projects/${projectSlug}/api-keys`, {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  async revokeProjectApiKey(projectSlug: string, keyId: string): Promise<ApiResponse<{ message: string }>> {
+    return fetchDjango<{ message: string }>(`/projects/${projectSlug}/api-keys/${keyId}`, {
+      method: "DELETE",
+    });
+  },
+
   // ── Apps (Project-scoped) ─────────────────────────────────────────
 
   async getProjectApps(projectSlug: string): Promise<ApiResponse<AppListItem[]>> {


### PR DESCRIPTION
## Summary
This PR adds project-level APIs for ingesting and querying telemetry data, plus a complete UI for managing project API keys with a tabbed settings interface.

## Backend Changes

### Data Ingestion
- **POST /api/v1/ingest/logs** - Ingest application logs
  - Batch support (up to 1000 logs/request)
  - Validates app_ids belong to project
  - Stores in ClickHouse `api_logs` table

### Data Query APIs
- **GET /projects/{slug}/data/logs** - Query raw logs with filters
  - Filters: environment, levels, search, loggers, time range
  - Pagination: up to 200 records/page
- **GET /projects/{slug}/data/requests** - Query raw API requests
  - Filters: methods, status codes, response time, path patterns
  - Pagination: up to 200 records/page
- **DataQueryService** - New service class for project-level data queries

### Schema Updates
- Added `LogsQueryResponse`, `RequestsQueryResponse` schemas
- Added `LogItemResponse`, `RequestItemResponse` schemas

## Frontend Changes

### Project API Keys Management
- **ProjectApiKeysSection** component
  - Create, view, copy, and revoke project API keys
  - Keys work across all apps in a project
  - Same UX as app-level keys
- API routes at `/api/projects/{slug}/api-keys`
- apiClient methods: `getProjectApiKeys()`, `createProjectApiKey()`, `revokeProjectApiKey()`

### Project Settings Sidebar
- **ProjectSettingsSidebar** component with tab navigation
- Tab routing: `/projects/{slug}/settings/{tab}`
  - **General tab**: Project info + Danger Zone
  - **API Keys tab**: API key management
- Consistent with app settings design

## Files Changed
**Backend:**
- `backend/api/ingest/router.py` - Added logs ingestion endpoint
- `backend/apps/projects/services.py` - Added DataQueryService
- `backend/api/projects/router.py` - Added data query endpoints
- `backend/api/projects/schemas.py` - Added query schemas

**Frontend:**
- `frontend/src/lib/api-client.ts` - Added project API key methods
- `frontend/src/components/projects/ProjectApiKeysSection.tsx` - New
- `frontend/src/components/projects/ProjectSettingsSidebar.tsx` - New
- `frontend/src/app/api/projects/[slug]/api-keys/*` - New routes
- `frontend/src/app/projects/[slug]/settings/[tab]/page.tsx` - New tab routing

## Testing
- [x] Backend compiles successfully
- [x] Frontend TypeScript compiles
- [x] API routes properly proxy to Django
- [x] UI components render correctly

## Screenshots
Navigate to `/projects/{project-slug}/settings` to see:
- Sidebar with General and API Keys tabs
- Create/manage project-level API keys
- Query telemetry data via new APIs