### PR TITLE
fix: pagination not working on endpoints page

### DIFF
--- a/frontend/src/app/apps/[slug]/endpoints/EndpointsContent.tsx
+++ b/frontend/src/app/apps/[slug]/endpoints/EndpointsContent.tsx
@@ -542,6 +542,13 @@ export default function EndpointsContent({ appSlug }: EndpointsContentProps) {
   const pageStart = totalCount === 0 ? 0 : (safePage - 1) * DEFAULT_PAGE_SIZE + 1;
   const pageEnd = Math.min(safePage * DEFAULT_PAGE_SIZE, totalCount);
 
+  const goToPage = (page: number) => {
+    const clampedPage = Math.max(1, Math.min(page, totalPages));
+    setCurrentPage(clampedPage);
+    // Scroll to top of page when changing pages
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const openEndpointDetails = (endpointId: string | null | undefined, method: string, path: string) => {
     if (endpointId) {
       router.push(`/apps/${appSlug}/endpoints/${endpointId}`);
@@ -951,19 +958,19 @@ export default function EndpointsContent({ appSlug }: EndpointsContentProps) {
             <button
               type="button"
               className="endpoints-page-btn"
-              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-              disabled={safePage <= 1}
+              onClick={() => goToPage(currentPage - 1)}
+              disabled={currentPage <= 1}
             >
               Previous
             </button>
             <span className="endpoints-page-indicator">
-              Page {safePage} / {totalPages}
+              Page {currentPage} / {totalPages}
             </span>
             <button
               type="button"
               className="endpoints-page-btn"
-              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-              disabled={safePage >= totalPages}
+              onClick={() => goToPage(currentPage + 1)}
+              disabled={currentPage >= totalPages}
             >
               Next
             </button>

--- a/frontend/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
+++ b/frontend/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
@@ -370,6 +370,13 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
   const safePage = Math.max(1, Math.min(currentPage, Math.ceil(totalCount / DEFAULT_PAGE_SIZE) || 1));
   const totalPages = Math.ceil(totalCount / DEFAULT_PAGE_SIZE) || 1;
 
+  const goToPage = (page: number) => {
+    const clampedPage = Math.max(1, Math.min(page, totalPages));
+    setCurrentPage(clampedPage);
+    // Scroll to top of page when changing pages
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const activeWindowMinutes = useMemo(() => {
     if (customActive && customSince && customUntil) {
       const sinceMs = new Date(customSince).getTime();
@@ -791,19 +798,19 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
             <button
               type="button"
               className="endpoints-page-btn"
-              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-              disabled={safePage <= 1}
+              onClick={() => goToPage(currentPage - 1)}
+              disabled={currentPage <= 1}
             >
               Previous
             </button>
             <span className="endpoints-page-indicator">
-              Page {safePage} / {totalPages}
+              Page {currentPage} / {totalPages}
             </span>
             <button
               type="button"
               className="endpoints-page-btn"
-              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-              disabled={safePage >= totalPages}
+              onClick={() => goToPage(currentPage + 1)}
+              disabled={currentPage >= totalPages}
             >
               Next
             </button>


### PR DESCRIPTION
## Summary
Fixes pagination functionality on endpoints page (both app-level and project-level).

## Problem
The pagination buttons were not working correctly due to React closure issues. The onClick handlers were using `Math.min(totalPages, p + 1)` inside `setCurrentPage`, which could capture stale values of `totalPages`.

## Solution
- Created a `goToPage` function that ensures we always use the latest `totalPages` value
- Added scroll-to-top behavior when changing pages for better UX
- Fixed both `/apps/{slug}/endpoints` and `/projects/{slug}/endpoints` pages
- Changed button disabled state to use `currentPage` instead of `safePage`

## Changes
**Before:**
```typescript
onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
disabled={safePage >= totalPages}
```

**After:**
```typescript
const goToPage = (page: number) => {
  const clampedPage = Math.max(1, Math.min(page, totalPages));
  setCurrentPage(clampedPage);
  window.scrollTo({ top: 0, behavior: "smooth" });
};

onClick={() => goToPage(currentPage + 1)}
disabled={currentPage >= totalPages}
```

## Testing
- [x] Code compiles successfully
- [x] Pagination state updates correctly
- [x] Scroll-to-top works on page change
- [x] Previous/Next buttons enable/disable correctly

## Closes
Fixes #17