### PR TITLE
feat: Support app slug in addition to UUID for app_id parameter

### DIFF
--- a/backend/api/ingest/router.py
+++ b/backend/api/ingest/router.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
+from uuid import UUID
 
+from django.db.models import Q
 from django.http import HttpRequest
 from ninja import Router
 
@@ -15,11 +17,62 @@ router = Router(auth=[api_key_auth])
 MAX_BATCH_SIZE = 1000
 
 
+def resolve_app_identifiers(project_id: str, app_identifiers: set[str]) -> dict[str, str]:
+    """
+    Resolve app identifiers (UUID or slug) to UUIDs.
+    Returns a mapping of {identifier: uuid_string}.
+    Raises ValidationError if any identifiers are invalid.
+    """
+    # Separate UUIDs from slugs
+    uuids = set()
+    slugs = set()
+
+    for identifier in app_identifiers:
+        try:
+            UUID(identifier)
+            uuids.add(identifier)
+        except (ValueError, AttributeError):
+            slugs.add(identifier)
+
+    # Build query to match either UUID or slug
+    query = Q()
+    if uuids:
+        query |= Q(id__in=uuids)
+    if slugs:
+        query |= Q(slug__in=slugs)
+
+    # Fetch apps that match
+    apps = App.objects.filter(
+        project_id=project_id,
+        is_active=True
+    ).filter(query).values('id', 'slug')
+
+    # Build mapping: both UUID and slug map to UUID
+    identifier_to_uuid = {}
+    found_uuids = set()
+    found_slugs = set()
+
+    for app in apps:
+        app_uuid = str(app['id'])
+        app_slug = app['slug']
+        identifier_to_uuid[app_uuid] = app_uuid
+        identifier_to_uuid[app_slug] = app_uuid
+        found_uuids.add(app_uuid)
+        found_slugs.add(app_slug)
+
+    # Check for invalid identifiers
+    invalid = (uuids - found_uuids) | (slugs - found_slugs)
+    if invalid:
+        raise ValidationError(f"Invalid app identifiers: {invalid}")
+
+    return identifier_to_uuid
+
+
 @router.post("/requests", response=IngestResponse)
 def ingest_requests(request: HttpRequest, data: IngestRequest):
     """
     Ingest API request records.
-    API key provides project_id, payload provides app_id for each record.
+    API key provides project_id, payload provides app_id (UUID or slug) for each record.
     """
     if len(data.requests) > MAX_BATCH_SIZE:
         raise ValidationError(f"Batch size exceeds maximum of {MAX_BATCH_SIZE}")
@@ -28,28 +81,19 @@ def ingest_requests(request: HttpRequest, data: IngestRequest):
     if not project_id:
         raise AuthenticationError("API key must be scoped to a project")
 
-    # Validate all app_ids belong to this project
-    app_ids = {record.app_id for record in data.requests}
-    valid_app_ids = set(
-        App.objects.filter(
-            project_id=project_id,
-            id__in=app_ids,
-            is_active=True
-        ).values_list("id", flat=True)
-    )
+    # Resolve app identifiers (UUID or slug) to UUIDs
+    app_identifiers = {record.app_id for record in data.requests}
+    identifier_to_uuid = resolve_app_identifiers(project_id, app_identifiers)
 
-    invalid_app_ids = app_ids - {str(aid) for aid in valid_app_ids}
-    if invalid_app_ids:
-        raise ValidationError(f"Invalid app_ids: {invalid_app_ids}")
-
-    # Group records by app_id for batch processing
+    # Group records by resolved app UUID for batch processing
     records_by_app = defaultdict(list)
     for record in data.requests:
-        records_by_app[record.app_id].append(record)
+        app_uuid = identifier_to_uuid[record.app_id]
+        records_by_app[app_uuid].append(record)
 
     total_accepted = 0
-    for app_id, records in records_by_app.items():
-        accepted = IngestService.ingest(app_id, records)
+    for app_uuid, records in records_by_app.items():
+        accepted = IngestService.ingest(app_uuid, records)
         total_accepted += accepted
 
     return IngestResponse(accepted=total_accepted)
@@ -59,7 +103,7 @@ def ingest_requests(request: HttpRequest, data: IngestRequest):
 def ingest_logs(request: HttpRequest, data: IngestLogsRequest):
     """
     Ingest application log records.
-    API key provides project_id, payload provides app_id for each log.
+    API key provides project_id, payload provides app_id (UUID or slug) for each log.
     """
     if len(data.logs) > MAX_BATCH_SIZE:
         raise ValidationError(f"Batch size exceeds maximum of {MAX_BATCH_SIZE}")
@@ -68,28 +112,19 @@ def ingest_logs(request: HttpRequest, data: IngestLogsRequest):
     if not project_id:
         raise AuthenticationError("API key must be scoped to a project")
 
-    # Validate all app_ids belong to this project
-    app_ids = {log.app_id for log in data.logs}
-    valid_app_ids = set(
-        App.objects.filter(
-            project_id=project_id,
-            id__in=app_ids,
-            is_active=True
-        ).values_list("id", flat=True)
-    )
+    # Resolve app identifiers (UUID or slug) to UUIDs
+    app_identifiers = {log.app_id for log in data.logs}
+    identifier_to_uuid = resolve_app_identifiers(project_id, app_identifiers)
 
-    invalid_app_ids = app_ids - {str(aid) for aid in valid_app_ids}
-    if invalid_app_ids:
-        raise ValidationError(f"Invalid app_ids: {invalid_app_ids}")
-
-    # Group logs by app_id for batch processing
+    # Group logs by resolved app UUID for batch processing
     logs_by_app = defaultdict(list)
     for log in data.logs:
-        logs_by_app[log.app_id].append(log)
+        app_uuid = identifier_to_uuid[log.app_id]
+        logs_by_app[app_uuid].append(log)
 
     total_accepted = 0
-    for app_id, logs in logs_by_app.items():
-        accepted = IngestService.ingest_logs(app_id, logs)
+    for app_uuid, logs in logs_by_app.items():
+        accepted = IngestService.ingest_logs(app_uuid, logs)
         total_accepted += accepted
 
     return IngestLogsResponse(accepted=total_accepted)

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -59,7 +59,7 @@ client = ApiLensClient(
 )
 
 client.capture(
-    app_id="your_app_id",  # Required: Get this from API Lens dashboard
+    app_id="my-api-service",  # Required: App slug or UUID
     method="GET",
     path="/health",
     status_code=200,
@@ -71,10 +71,18 @@ client.shutdown(flush=True)
 
 ### Getting your App ID
 
+You can use either the **app slug** (recommended) or **app UUID**:
+
+**Using App Slug (Recommended):**
+```python
+app_id = "my-api-service"  # Human-readable, easy to remember
+```
+
+**Using App UUID:**
 1. Log in to [API Lens Dashboard](https://app.apilens.ai)
 2. Navigate to your project
 3. Select or create an app
-4. Copy the **App ID** from the app settings
+4. Copy the **App UUID** from the app settings
 
 ## FastAPI
 
@@ -91,7 +99,7 @@ app = FastAPI()
 app.add_middleware(
     ApiLensMiddleware,
     api_key="your_app_api_key",      # Required: Your API key
-    app_id="your_app_id",              # Required: Your app ID from dashboard
+    app_id="my-api-service",           # Required: App slug (or UUID)
     base_url="https://api.apilens.ai/api/v1",
     env="production",
     enable_request_logging=True,
@@ -251,8 +259,8 @@ instrument_app(
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `api_key` | ✅ Yes | - | Your API key from API Lens dashboard |
-| `app_id` | ✅ Yes | - | Your app ID from API Lens dashboard |
+| `api_key` | Yes | - | Your API key from API Lens dashboard |
+| `app_id` | Yes | - | Your app slug or UUID from API Lens dashboard |
 | `base_url` | No | `https://api.apilens.ai/api/v1` | API Lens ingest endpoint |
 | `environment` | No | `production` | Environment name (e.g., production, staging, dev) |
 | `enable_request_logging` | No | `True` | Enable request/response logging |
@@ -289,13 +297,19 @@ app.add_middleware(
 
 ### Finding Your App ID
 
+**Using App Slug (Recommended):**
+The slug is shown in the app list and is human-readable (e.g., `user-service`, `api-gateway`).
+
+**Using App UUID:**
 1. Log in to [API Lens Dashboard](https://app.apilens.ai)
 2. Navigate to your project
 3. Go to the Apps tab
 4. Select your app or create a new one
-5. Copy the **App ID** from the URL or app settings
+5. Copy the UUID from the URL or app settings
 
-Example App ID format: `c2537f6e-9b59-47ec-ab13-3559ae645c60`
+Example formats:
+- Slug: `user-service` (recommended)
+- UUID: `c2537f6e-9b59-47ec-ab13-3559ae645c60`
 
 ### Data Not Appearing in Dashboard
 


### PR DESCRIPTION
## Summary

Adds support for using human-readable app **slugs** in addition to UUIDs for the `app_id` parameter in SDK configuration and ingest endpoints.

Closes #25

## Changes

### Backend
- Added `resolve_app_identifiers()` helper function in `api/ingest/router.py`
  - Accepts both UUID and slug formats
  - Resolves to app UUID for internal processing
  - Validates against project scope
  - Returns clear error messages for invalid identifiers

- Updated `ingest_requests()` endpoint
  - Now accepts app_id as UUID or slug
  - Backwards compatible with existing UUID-based integrations

- Updated `ingest_logs()` endpoint
  - Same slug support as requests endpoint

### SDK Documentation
- Updated README.md to show slug examples as primary
- Added "Getting your App ID" section explaining both slug and UUID options
- Updated configuration table to mention slug support
- Updated troubleshooting section with slug examples

### Examples
- Updated FastAPI sidecar example to use slug: `APILENS_APP_ID=user-mgmt`
- Added comment showing UUID alternative for clarity

## Implementation Details

The `resolve_app_identifiers()` function:
1. Separates input identifiers into UUIDs and slugs using UUID validation
2. Queries database with `Q(id__in=uuids) | Q(slug__in=slugs)`
3. Builds a mapping of identifier to UUID for both formats
4. Validates all identifiers belong to the authenticated project
5. Raises clear `ValidationError` for any invalid identifiers

## Benefits

- More developer-friendly: `app_id="user-service"` vs `app_id="c2537f6e-9b59-47ec-ab13-3559ae645c60"`
- Easier to read and maintain configuration files
- Better for multi-environment setups (same slug across dev/staging/prod)
- More consistent with project slug pattern
- Backwards compatible: existing UUID-based configs continue to work

## Testing

Tested with FastAPI sidecar:
- Using slug: works correctly
- Using UUID: still works (backwards compatible)
- Invalid identifier: returns clear error message
- Mixed batch (some slugs, some UUIDs): resolves correctly

## Before (UUID only)

```python
app.add_middleware(
    ApiLensMiddleware,
    api_key="...",
    app_id="c2537f6e-9b59-47ec-ab13-3559ae645c60",  # Hard to read
)
```

## After (Slug supported)

```python
app.add_middleware(
    ApiLensMiddleware,
    api_key="...",
    app_id="user-mgmt",  # Much better
)
```

## Breaking Changes

None. This is fully backwards compatible.