### PR TITLE
feat(infra): GCP production foundation (Terraform)

### DIFF
--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,13 @@
+# Local state shouldn't be committed — we use a GCS backend.
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+
+# tfvars contains environment-specific config + sometimes secrets.
+terraform.tfvars
+*.auto.tfvars
+
+# Editor noise
+*.swp

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,138 @@
+# APILens — GCP Infrastructure
+
+Terraform that stands up the production cloud footprint for APILens on GCP.
+
+## What this provisions
+
+| Resource | Name pattern | Purpose |
+|----------|--------------|---------|
+| Artifact Registry | `apilens` (Docker repo) | Container images for backend + frontend |
+| Cloud SQL Postgres 16 | `apilens-<env>-pg` | Primary database |
+| Cloud Run service | `apilens-<env>-backend` | Django + Gunicorn |
+| Cloud Run service | `apilens-<env>-frontend` | Next.js standalone |
+| Secret Manager | 4 secrets | `django-secret-key`, `session-secret`, `apilens-database-url`, `apilens-clickhouse-url` |
+| Service accounts | 3 | Backend runtime, frontend runtime, GitHub-deploy |
+| Workload Identity Federation | pool `github-actions` | Keyless GitHub Actions → GCP auth |
+
+The deploy workflows in `.github/workflows/` push images and roll Cloud Run revisions; Terraform owns the wiring.
+
+## What this does NOT provision
+
+- **Custom domains / managed certs** — follow-up. Use Cloud Run domain mapping.
+- **ClickHouse** — provisioned outside GCP via ClickHouse Cloud. Terraform creates an empty `apilens-clickhouse-url` Secret Manager entry; you fill in the value after creating the CH project.
+- **Email provider (SES/Mailgun/Postmark)** — also follow-up. Default Django console backend ships logs to stdout until you wire SMTP credentials through Secret Manager.
+
+## First-time bootstrap
+
+You need:
+- `gcloud` CLI, authenticated against an account with `roles/owner` on the project.
+- `terraform` ≥ 1.5.
+- A target GCP project (create one with `gcloud projects create` if needed) and its **project number** (`gcloud projects describe <id> --format='value(projectNumber)'`).
+
+### 1. Create the state bucket
+
+Terraform stores its state in GCS so apply is safe from anywhere:
+
+```bash
+PROJECT=apilens-prod
+gcloud auth application-default login
+gcloud config set project "$PROJECT"
+gsutil mb -p "$PROJECT" -l us-central1 "gs://$PROJECT-tfstate"
+gsutil versioning set on "gs://$PROJECT-tfstate"
+```
+
+### 2. Configure variables
+
+```bash
+cd infra/terraform
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars   # fill in project_id, project_number, github_repo
+```
+
+### 3. Init + apply
+
+```bash
+terraform init -backend-config="bucket=$PROJECT-tfstate"
+terraform plan
+terraform apply
+```
+
+First apply takes ~5 minutes — Cloud SQL is the slow step.
+
+### 4. Populate the secrets that Terraform doesn't own
+
+After apply, three Secret Manager entries still have no payload (`apilens-database-url` is the exception — Terraform writes its first version):
+
+```bash
+# Django app secret (used to sign JWTs, CSRF tokens, etc.)
+openssl rand -base64 64 | tr -d '\n' | \
+  gcloud secrets versions add django-secret-key --data-file=-
+
+# Frontend session cookie key (AES-256-GCM, raw bytes / hex)
+openssl rand -hex 32 | tr -d '\n' | \
+  gcloud secrets versions add session-secret --data-file=-
+
+# ClickHouse Cloud DSN — after creating the CH project, copy its URL here.
+# Until you do this, backend starts fine but ClickHouse queries no-op.
+echo -n 'https://default:PWD@xxxx.region.clickhouse.cloud:8443/apilens' | \
+  gcloud secrets versions add apilens-clickhouse-url --data-file=-
+```
+
+### 5. Confirm Cloud Run is up
+
+```bash
+terraform output backend_service_url
+terraform output frontend_service_url
+```
+
+Both services come up serving the placeholder `gcr.io/cloudrun/hello` image — that's expected. Real images land once PR 3's deploy workflows fire.
+
+### 6. Set GitHub repo secrets for the deploy workflows
+
+Terraform emits everything you need via the `github_secrets_to_set` output:
+
+```bash
+terraform output -json github_secrets_to_set | \
+  jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
+  while IFS='=' read -r k v; do
+    gh secret set "$k" --body "$v"
+  done
+```
+
+Verify in the GitHub UI under **Settings → Secrets and variables → Actions**.
+
+## Adding a new environment
+
+`var.environment` is the only thing baked into resource names. To spin up staging:
+
+```bash
+# Separate state file under the same bucket
+terraform workspace new staging
+terraform apply -var environment=staging -var db_tier=db-f1-micro
+```
+
+## Routine operations
+
+- **Rotate the Django secret key:** `openssl rand -base64 64 | gcloud secrets versions add django-secret-key --data-file=-`. Cloud Run instances pick up the new version on next start.
+- **Roll Postgres password:** edit `random_password.db_password` to use `keepers`, `terraform apply`, the new password lands in the URL secret.
+- **Destroy everything (dev only!):** set `db_deletion_protection = false` in `terraform.tfvars`, `terraform apply`, then `terraform destroy`.
+
+## File map
+
+```
+infra/terraform/
+├── providers.tf              Provider pins, remote state config
+├── variables.tf              Inputs
+├── locals.tf                 Naming + image-path conventions
+├── apis.tf                   Enable required Google APIs
+├── artifact_registry.tf      Docker repo + cleanup policies
+├── cloud_sql.tf              Postgres instance, db, user, password
+├── secrets.tf                Secret Manager entries
+├── service_accounts.tf       Runtime + deploy SAs
+├── workload_identity.tf      WIF pool + provider, GitHub trust
+├── iam.tf                    IAM bindings (secret access, actAs, run.admin)
+├── cloud_run_backend.tf      Django service definition
+├── cloud_run_frontend.tf     Next.js service definition
+├── outputs.tf                URLs, image paths, github-secrets dump
+└── terraform.tfvars.example  Starter values
+```

--- a/infra/terraform/apis.tf
+++ b/infra/terraform/apis.tf
@@ -1,0 +1,22 @@
+# Enable every Google API we depend on. `disable_on_destroy=false` keeps the
+# APIs on even if Terraform is destroyed, so we don't break unrelated workloads
+# in the same project.
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "sqladmin.googleapis.com",
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "cloudbuild.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.key
+  disable_on_destroy = false
+}

--- a/infra/terraform/artifact_registry.tf
+++ b/infra/terraform/artifact_registry.tf
@@ -1,0 +1,27 @@
+resource "google_artifact_registry_repository" "apilens" {
+  location      = var.region
+  repository_id = "apilens"
+  description   = "Container images for APILens backend + frontend"
+  format        = "DOCKER"
+
+  # Trim old images so storage costs don't grow unbounded. Keeps the 10 most
+  # recent tagged revisions per image name; untagged blobs are GC'd after 7d.
+  cleanup_policies {
+    id     = "keep-recent-10"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s" # 7 days
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/terraform/cloud_run_backend.tf
+++ b/infra/terraform/cloud_run_backend.tf
@@ -1,0 +1,145 @@
+resource "google_cloud_run_v2_service" "backend" {
+  name     = "${local.name_prefix}-backend"
+  location = var.region
+
+  # Drop unauthenticated requests at the LB; we open it up explicitly below.
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.backend_runtime.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 5
+    }
+
+    # Mount the Cloud SQL Auth Proxy as a unix socket at /cloudsql/<connection>.
+    # Backend's DATABASE_URL points at this socket, so no public DB exposure.
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.postgres.connection_name]
+      }
+    }
+
+    containers {
+      image = local.placeholder_image
+
+      ports {
+        container_port = 8000
+      }
+
+      env {
+        name  = "DJANGO_DEBUG"
+        value = "False"
+      }
+
+      env {
+        name  = "DJANGO_ALLOWED_HOSTS"
+        value = var.backend_allowed_hosts
+      }
+
+      env {
+        name  = "PORT"
+        value = "8000"
+      }
+
+      env {
+        name  = "GUNICORN_WORKERS"
+        value = "2"
+      }
+
+      # Frontend URL is wired by the deploy workflow at deploy time (it can't be
+      # known here without a circular reference to the frontend service).
+      # Default keeps email-template links well-formed if the workflow forgets.
+      env {
+        name  = "FRONTEND_URL"
+        value = var.frontend_url
+      }
+
+      env {
+        name = "DJANGO_SECRET_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.django_secret_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "APILENS_DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.database_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "APILENS_CLICKHOUSE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.clickhouse_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        cpu_idle = true
+      }
+
+      startup_probe {
+        tcp_socket {
+          port = 8000
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 5
+        timeout_seconds       = 3
+        # Cold start = container pull + gunicorn boot + (first-time) migrations.
+        # Generous threshold so we don't kill healthy instances during scale-up.
+        failure_threshold = 30
+      }
+    }
+  }
+
+  lifecycle {
+    # Image revisions are managed by the deploy workflow; Terraform shouldn't
+    # roll back a freshly-deployed image just because the .tf hasn't moved.
+    # The whole template containers block is ignored because the deploy workflow
+    # also injects FRONTEND_URL (set to the live frontend Cloud Run URL) and we
+    # don't want apply to reset that to the variable default.
+    ignore_changes = [
+      template[0].containers,
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.backend_cloudsql,
+    google_secret_manager_secret_iam_member.backend_secrets,
+    google_secret_manager_secret_version.database_url,
+  ]
+}
+
+# Public access — required for browser-side SDK use + dashboard logins.
+# Auth is handled by Django/JWT at the application layer.
+resource "google_cloud_run_v2_service_iam_member" "backend_public" {
+  project  = google_cloud_run_v2_service.backend.project
+  location = google_cloud_run_v2_service.backend.location
+  name     = google_cloud_run_v2_service.backend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/terraform/cloud_run_frontend.tf
+++ b/infra/terraform/cloud_run_frontend.tf
@@ -1,0 +1,90 @@
+resource "google_cloud_run_v2_service" "frontend" {
+  name     = "${local.name_prefix}-frontend"
+  location = var.region
+
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.frontend_runtime.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 5
+    }
+
+    containers {
+      image = local.placeholder_image
+
+      ports {
+        container_port = 3000
+      }
+
+      env {
+        name  = "NODE_ENV"
+        value = "production"
+      }
+
+      env {
+        name  = "PORT"
+        value = "3000"
+      }
+
+      # Backend API URL is injected by the deploy workflow once it's resolved
+      # the live backend Cloud Run URL. Static placeholder keeps the manifest
+      # valid for the first apply.
+      env {
+        name  = "DJANGO_API_URL"
+        value = "https://placeholder.run.app/api/v1"
+      }
+
+      env {
+        name = "SESSION_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.session_secret.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        cpu_idle = true
+      }
+
+      startup_probe {
+        tcp_socket {
+          port = 3000
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        timeout_seconds       = 3
+        failure_threshold     = 20
+      }
+    }
+  }
+
+  lifecycle {
+    # Same logic as backend — deploy workflow owns image + DJANGO_API_URL.
+    ignore_changes = [
+      template[0].containers,
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.frontend_session_secret,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "frontend_public" {
+  project  = google_cloud_run_v2_service.frontend.project
+  location = google_cloud_run_v2_service.frontend.location
+  name     = google_cloud_run_v2_service.frontend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/terraform/cloud_sql.tf
+++ b/infra/terraform/cloud_sql.tf
@@ -1,0 +1,52 @@
+resource "random_password" "db_password" {
+  length  = 32
+  # Skip special chars so the password can sit in a URL without percent-encoding.
+  special = false
+}
+
+resource "google_sql_database_instance" "postgres" {
+  name             = "${local.name_prefix}-pg"
+  database_version = "POSTGRES_16"
+  region           = var.region
+
+  deletion_protection = var.db_deletion_protection
+
+  settings {
+    tier              = var.db_tier
+    availability_type = "ZONAL" # bump to REGIONAL for HA when it matters
+    disk_size         = 10
+    disk_autoresize   = true
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+      start_time                     = "03:00"
+      transaction_log_retention_days = 7
+    }
+
+    ip_configuration {
+      # Public IP is OK because Cloud Run connects via the Cloud SQL Auth Proxy
+      # over a unix socket, never directly. SSL-only enforced below.
+      ipv4_enabled = true
+      ssl_mode     = "ENCRYPTED_ONLY"
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "100"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_sql_database" "apilens" {
+  name     = "apilens"
+  instance = google_sql_database_instance.postgres.name
+}
+
+resource "google_sql_user" "apilens" {
+  name     = "apilens"
+  instance = google_sql_database_instance.postgres.name
+  password = random_password.db_password.result
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,75 @@
+# ────────────────────────────────────────────────────────────────────
+# Backend runtime: secret access, Cloud SQL, logs.
+# ────────────────────────────────────────────────────────────────────
+
+locals {
+  backend_secret_ids = [
+    google_secret_manager_secret.django_secret_key.id,
+    google_secret_manager_secret.database_url.id,
+    google_secret_manager_secret.clickhouse_url.id,
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "backend_secrets" {
+  for_each  = toset(local.backend_secret_ids)
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backend_runtime.email}"
+}
+
+resource "google_project_iam_member" "backend_cloudsql" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.backend_runtime.email}"
+}
+
+resource "google_project_iam_member" "backend_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.backend_runtime.email}"
+}
+
+# ────────────────────────────────────────────────────────────────────
+# Frontend runtime: just the session-secret + logs.
+# ────────────────────────────────────────────────────────────────────
+
+resource "google_secret_manager_secret_iam_member" "frontend_session_secret" {
+  secret_id = google_secret_manager_secret.session_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.frontend_runtime.email}"
+}
+
+resource "google_project_iam_member" "frontend_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.frontend_runtime.email}"
+}
+
+# ────────────────────────────────────────────────────────────────────
+# GitHub deploy SA: push images, deploy Cloud Run, actAs each runtime SA.
+# ────────────────────────────────────────────────────────────────────
+
+resource "google_project_iam_member" "deploy_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.github_deploy.email}"
+}
+
+resource "google_project_iam_member" "deploy_artifact_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.github_deploy.email}"
+}
+
+# `actAs` is required for `gcloud run deploy --service-account=...`.
+resource "google_service_account_iam_member" "deploy_acts_as_backend" {
+  service_account_id = google_service_account.backend_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deploy.email}"
+}
+
+resource "google_service_account_iam_member" "deploy_acts_as_frontend" {
+  service_account_id = google_service_account.frontend_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deploy.email}"
+}

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  name_prefix = "apilens-${var.environment}"
+
+  # Used until the first real image lands in Artifact Registry.
+  placeholder_image = "gcr.io/cloudrun/hello"
+
+  artifact_registry_base = "${var.region}-docker.pkg.dev/${var.project_id}/apilens"
+  backend_image_path     = "${local.artifact_registry_base}/backend"
+  frontend_image_path    = "${local.artifact_registry_base}/frontend"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,76 @@
+output "backend_service_url" {
+  description = "Public URL of the backend Cloud Run service"
+  value       = google_cloud_run_v2_service.backend.uri
+}
+
+output "frontend_service_url" {
+  description = "Public URL of the frontend Cloud Run service"
+  value       = google_cloud_run_v2_service.frontend.uri
+}
+
+output "artifact_registry_path" {
+  description = "Base path for pushing container images"
+  value       = local.artifact_registry_base
+}
+
+output "backend_image_path" {
+  description = "Repository path for backend image tags"
+  value       = local.backend_image_path
+}
+
+output "frontend_image_path" {
+  description = "Repository path for frontend image tags"
+  value       = local.frontend_image_path
+}
+
+output "backend_service_name" {
+  description = "Cloud Run service name for the backend (used by deploy workflow)"
+  value       = google_cloud_run_v2_service.backend.name
+}
+
+output "frontend_service_name" {
+  description = "Cloud Run service name for the frontend (used by deploy workflow)"
+  value       = google_cloud_run_v2_service.frontend.name
+}
+
+output "cloud_sql_connection_name" {
+  description = "Cloud SQL connection name (project:region:instance)"
+  value       = google_sql_database_instance.postgres.connection_name
+}
+
+output "workload_identity_provider" {
+  description = "Full WIF provider resource name — set as GitHub repo secret GCP_WIF_PROVIDER"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "github_deploy_sa_email" {
+  description = "Service account impersonated by GitHub Actions — set as GCP_DEPLOY_SA_EMAIL"
+  value       = google_service_account.github_deploy.email
+}
+
+output "backend_runtime_sa_email" {
+  description = "Backend Cloud Run runtime service account email"
+  value       = google_service_account.backend_runtime.email
+}
+
+output "frontend_runtime_sa_email" {
+  description = "Frontend Cloud Run runtime service account email"
+  value       = google_service_account.frontend_runtime.email
+}
+
+output "github_secrets_to_set" {
+  description = "Map you can paste into `gh secret set` after a first apply"
+  value = {
+    GCP_PROJECT_ID          = var.project_id
+    GCP_REGION              = var.region
+    GCP_WIF_PROVIDER        = google_iam_workload_identity_pool_provider.github.name
+    GCP_DEPLOY_SA_EMAIL     = google_service_account.github_deploy.email
+    GCP_BACKEND_RUNTIME_SA  = google_service_account.backend_runtime.email
+    GCP_FRONTEND_RUNTIME_SA = google_service_account.frontend_runtime.email
+    GCP_CLOUDSQL_CONNECTION = google_sql_database_instance.postgres.connection_name
+    GCP_BACKEND_SERVICE     = google_cloud_run_v2_service.backend.name
+    GCP_FRONTEND_SERVICE    = google_cloud_run_v2_service.frontend.name
+    GCP_BACKEND_IMAGE_PATH  = local.backend_image_path
+    GCP_FRONTEND_IMAGE_PATH = local.frontend_image_path
+  }
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # Remote state in GCS. Bucket is supplied via `-backend-config` at init time
+  # so this file can stay generic across environments:
+  #
+  #   terraform init -backend-config="bucket=<project-id>-tfstate"
+  backend "gcs" {
+    prefix = "apilens/state"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,0 +1,53 @@
+# Django app secret — set manually post-apply:
+#   echo -n "$(openssl rand -base64 64 | tr -d '\n')" | \
+#     gcloud secrets versions add django-secret-key --data-file=-
+resource "google_secret_manager_secret" "django_secret_key" {
+  secret_id = "django-secret-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+# Frontend session cookie key (AES-256-GCM). Set manually post-apply:
+#   openssl rand -hex 32 | tr -d '\n' | \
+#     gcloud secrets versions add session-secret --data-file=-
+resource "google_secret_manager_secret" "session_secret" {
+  secret_id = "session-secret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+# Database URL — Terraform populates the version because it owns the password.
+# Backend reads this as APILENS_DATABASE_URL (canonical name in settings.py).
+resource "google_secret_manager_secret" "database_url" {
+  secret_id = "apilens-database-url"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "database_url" {
+  secret = google_secret_manager_secret.database_url.id
+  secret_data = format(
+    "postgresql://%s:%s@/%s?host=/cloudsql/%s",
+    google_sql_user.apilens.name,
+    random_password.db_password.result,
+    google_sql_database.apilens.name,
+    google_sql_database_instance.postgres.connection_name,
+  )
+}
+
+# ClickHouse Cloud DSN — provisioned manually outside Terraform:
+#   echo -n "https://default:PWD@ID.region.clickhouse.cloud:8443/apilens" | \
+#     gcloud secrets versions add apilens-clickhouse-url --data-file=-
+resource "google_secret_manager_secret" "clickhouse_url" {
+  secret_id = "apilens-clickhouse-url"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}

--- a/infra/terraform/service_accounts.tf
+++ b/infra/terraform/service_accounts.tf
@@ -1,0 +1,20 @@
+# Runtime SA assumed by the backend Cloud Run service. Only gets the minimum
+# permissions it needs at request time (secret-accessor + cloudsql.client + logs).
+resource "google_service_account" "backend_runtime" {
+  account_id   = "${local.name_prefix}-backend-run"
+  display_name = "APILens backend Cloud Run runtime"
+}
+
+# Runtime SA for the frontend service. Just needs to read its one secret and write logs.
+resource "google_service_account" "frontend_runtime" {
+  account_id   = "${local.name_prefix}-frontend-run"
+  display_name = "APILens frontend Cloud Run runtime"
+}
+
+# Deploy SA — impersonated by GitHub Actions via Workload Identity Federation.
+# Holds Cloud Run + Artifact Registry write permissions, and the `actAs` role
+# on each runtime SA so `gcloud run deploy --service-account=...` works.
+resource "google_service_account" "github_deploy" {
+  account_id   = "${local.name_prefix}-github-deploy"
+  display_name = "GitHub Actions deploy SA for APILens"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars itself is gitignored
+# (see .gitignore in this folder).
+
+project_id     = "apilens-prod"
+project_number = "123456789012"
+region         = "us-central1"
+environment    = "prod"
+github_repo    = "apilens/apilens"
+
+# Bump to e.g. "db-custom-1-3840" once you have real load.
+db_tier = "db-f1-micro"
+
+# Hosts the Django backend will accept. Add custom domains here.
+backend_allowed_hosts = ".run.app,.apilens.ai"
+
+# Set once the frontend has its custom domain; until then the deploy workflow
+# injects the live frontend Cloud Run URL into the backend at deploy time.
+frontend_url = ""

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,50 @@
+variable "project_id" {
+  description = "GCP project ID hosting all APILens resources"
+  type        = string
+}
+
+variable "project_number" {
+  description = "GCP project number (numeric). Needed for some IAM member references."
+  type        = string
+}
+
+variable "region" {
+  description = "Region for Cloud Run, Cloud SQL, and Artifact Registry"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Logical environment baked into resource names (prod, staging, ...)"
+  type        = string
+  default     = "prod"
+}
+
+variable "github_repo" {
+  description = "`owner/name` of the GitHub repo allowed to impersonate the deploy SA"
+  type        = string
+}
+
+variable "db_tier" {
+  description = "Cloud SQL machine tier. db-f1-micro is the cheapest; bump for prod load."
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "db_deletion_protection" {
+  description = "Cloud SQL deletion protection. Disable only when intentionally tearing down."
+  type        = bool
+  default     = true
+}
+
+variable "backend_allowed_hosts" {
+  description = "Comma-separated DJANGO_ALLOWED_HOSTS value. .run.app covers Cloud Run defaults."
+  type        = string
+  default     = ".run.app,.apilens.ai"
+}
+
+variable "frontend_url" {
+  description = "Canonical frontend origin written to FRONTEND_URL on the backend."
+  type        = string
+  default     = ""
+}

--- a/infra/terraform/workload_identity.tf
+++ b/infra/terraform/workload_identity.tf
@@ -1,0 +1,35 @@
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "OIDC trust for ${var.github_repo}"
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions-provider"
+  display_name                       = "GitHub OIDC"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  # Hard-lock the provider to the one GitHub repo. Without this, any workflow
+  # in any repo on github.com could ask for tokens from this pool.
+  attribute_condition = "assertion.repository == \"${var.github_repo}\""
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Bind: workflows running in `var.github_repo` can impersonate the deploy SA.
+resource "google_service_account_iam_member" "github_deploy_workload_identity" {
+  service_account_id = google_service_account.github_deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+}


### PR DESCRIPTION
## Summary

Declarative GCP provisioning for the production deployment. After `terraform apply`, the project has all the wiring PR 3's deploy workflows need:

- **Artifact Registry** — `apilens` Docker repo, 10-tag retention, 7-day untagged GC.
- **Cloud SQL Postgres 16** — daily backups + PITR + SSL-only. Auto-generated password baked into a Secret Manager DSN.
- **Secret Manager** — `django-secret-key`, `session-secret`, `apilens-database-url` (Terraform writes the first version), `apilens-clickhouse-url` (manually filled after ClickHouse Cloud is set up).
- **Service accounts** — backend-runtime, frontend-runtime, github-deploy with minimum scopes.
- **Workload Identity Federation** — keyless GitHub Actions → GCP, locked to this repo via `attribute.repository` condition.
- **Cloud Run** — backend (Django + Cloud SQL Auth Proxy unix-socket mount) and frontend services, both starting from a placeholder image. `ignore_changes` on the container blocks so subsequent applies don't roll back live revisions deployed by CI.

Layout split into focused files (`cloud_run_*.tf`, `cloud_sql.tf`, `iam.tf`, `secrets.tf`, etc.) so it scales without a single 1000-line file.

`README.md` documents the full bootstrap: GCS state bucket, `terraform init` with backend-config, populating secrets manually, then dumping `github_secrets_to_set` output through `gh secret set` to wire CI.

This is **PR 2 of 3** for the GCP rollout. PR 3 will add the deploy workflows that build images and roll Cloud Run revisions.

## Out of scope (queued as follow-ups)

- **Custom domains + managed certs** — Cloud Run domain mapping, separate PR once DNS is ready.
- **ClickHouse provisioning** — done via ClickHouse Cloud externally; Terraform only holds the URL secret.
- **Email provider** — Django stays on the console backend until SMTP creds are wired through Secret Manager.

## Test plan

- [ ] Reviewer reads through the file structure — no shell scripts, no surprise resources.
- [ ] Once approved + merged, applier runs:
  - [ ] \`gsutil mb gs://$PROJECT-tfstate\`
  - [ ] \`terraform init -backend-config="bucket=$PROJECT-tfstate"\`
  - [ ] \`terraform plan\` — confirm only the expected resources will be created.
  - [ ] \`terraform apply\` — should succeed in ~5 minutes (Cloud SQL is the slow step).
- [ ] Post-apply:
  - [ ] Both Cloud Run services come up serving \`gcr.io/cloudrun/hello\`.
  - [ ] Backend Cloud Run → Connections → shows the Cloud SQL instance attached.
  - [ ] Secret Manager shows 4 secrets; \`apilens-database-url\` has 1 enabled version.
  - [ ] \`gh secret set\` populated all 11 GitHub repo secrets from \`github_secrets_to_set\` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)