### PR TITLE
fix(auth): wire WEBAUTHN_RP_ID + RP_NAME through Django settings

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -203,6 +203,14 @@ else:
 # Frontend URL (for magic link emails)
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")
 
+# WebAuthn / passkey config.
+# RPID is the domain the browser binds the credential to. It must equal the
+# origin's effective domain, OR a registrable parent (e.g. `apilens.ai` works
+# for `app.apilens.ai`, `docs.apilens.ai`, etc. — useful for cross-subdomain).
+# Locally we use `localhost` so dev passkeys work without HTTPS.
+WEBAUTHN_RP_ID = os.environ.get("WEBAUTHN_RP_ID", "localhost")
+WEBAUTHN_RP_NAME = os.environ.get("WEBAUTHN_RP_NAME", "API Lens")
+
 # Email Configuration
 EMAIL_BACKEND = os.environ.get(
     "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
## Why

Passkey login on `https://app.apilens.ai` was returning:

> The requested RPID did not match the origin or related origins.

Root cause: `PasskeyService.RP_ID` reads `getattr(settings, "WEBAUTHN_RP_ID", "localhost")`, but `WEBAUTHN_RP_ID` was never defined in `settings.py`. So production silently used the `localhost` fallback. Browser sees `origin = app.apilens.ai`, server-issued challenge says `rpId = localhost` → spec violation → browser refuses.

## What

Adds two env-driven settings:
- `WEBAUTHN_RP_ID` — default `localhost` for dev convenience (passkeys-over-HTTP work on localhost without HTTPS).
- `WEBAUTHN_RP_NAME` — default `API Lens`.

Production sets `WEBAUTHN_RP_ID=apilens.ai` so passkeys work across every subdomain (`app.apilens.ai`, `docs.apilens.ai`, etc.).

## Already deployed

Hotfix image is live as revision `apilens-prod-backend-00008-892` with the env var set via `gcloud run services update`. This PR just makes the change durable across future builds.

## Test plan

- [x] `gcloud run` env now shows `WEBAUTHN_RP_ID=apilens.ai`.
- [x] `POST /api/v1/auth/passkey/login/options` response includes `"rpId":"apilens.ai"`.
- [ ] Touch ID / Face ID on `app.apilens.ai/auth/login` — challenge passes browser validation.
- [ ] Note: passkeys registered against `localhost` rpId won't work in prod. New passkeys must be registered from `https://app.apilens.ai/account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)