### PR TITLE
fix(auth): pin passkey registration to platform authenticator

### DIFF
--- a/backend/apps/auth/services.py
+++ b/backend/apps/auth/services.py
@@ -34,6 +34,7 @@ from webauthn import (
 from webauthn.helpers.structs import (
     PublicKeyCredentialDescriptor,
     AuthenticatorTransport,
+    AuthenticatorAttachment,
     UserVerificationRequirement,
     AuthenticatorSelectionCriteria,
     ResidentKeyRequirement,
@@ -692,6 +693,11 @@ class PasskeyService:
             user_display_name=user.email.split("@")[0],
             exclude_credentials=exclude_credentials,
             authenticator_selection=AuthenticatorSelectionCriteria(
+                # Bind the new passkey to the device's built-in biometric (Touch ID,
+                # Face ID, Windows Hello). Without this, browsers — especially mobile
+                # Safari — default to "use a passkey from another device" via QR,
+                # which is jarring when the user is on the device they want to enroll.
+                authenticator_attachment=AuthenticatorAttachment.PLATFORM,
                 resident_key=ResidentKeyRequirement.PREFERRED,
                 user_verification=UserVerificationRequirement.PREFERRED,
             ),


### PR DESCRIPTION
## Why

Reported: tapping "Add passkey" on phone shows a QR code instead of Face ID. Same on signup. Confusing — user wants to use *this* device, not scan from another.

Without `authenticator_attachment=PLATFORM` in `AuthenticatorSelectionCriteria`, the browser picks any authenticator. Mobile Safari + Android Chrome default to the cross-device flow (QR/hybrid), so the prompt is "use a passkey from another device" rather than "use Face ID."

## What

`PasskeyService.generate_registration_options` now sets `authenticator_attachment=AuthenticatorAttachment.PLATFORM`. Result:

| Device | Prompt |
|---|---|
| iPhone | Face ID directly |
| Android | Fingerprint / Face Unlock |
| MacBook | Touch ID |
| Windows | Windows Hello |
| Linux | system biometric / not offered |
| YubiKey | not offered here (separate flow if needed) |

## Login path untouched

`generate_authentication_options` deliberately stays unrestricted. If a user has a passkey only on their MacBook and signs in on the phone, the QR / hybrid flow is the *correct* UX — that's the supported path to use a different device's passkey. Once they enroll a phone passkey (now Face-ID-prompted thanks to this fix), Face-ID login follows naturally.

## Test plan

- [ ] On phone, sign in via magic link → see PasskeyUpsellBanner → tap "Add passkey" → Face ID prompts (not QR code).
- [ ] On MacBook, same path → Touch ID prompts.
- [ ] After enrollment, log out and log back in on phone → Face ID prompts on `/auth/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)