### PR TITLE
fix: complete the auth-services cleanup merge (PR #84 follow-up)

### DIFF
--- a/backend/api/apps/router.py
+++ b/backend/api/apps/router.py
@@ -8,7 +8,7 @@ from apps.auth.services import ApiKeyService
 from apps.projects.services import AppService, EnvironmentService
 from apps.users.models import User
 from apps.users.services import UserService
-from core.auth.authentication import jwt_auth
+from apps.auth.authentication import jwt_auth
 from core.exceptions.base import ValidationError
 
 from .schemas import (

--- a/backend/api/auth/router.py
+++ b/backend/api/auth/router.py
@@ -2,7 +2,7 @@ from django.http import HttpRequest
 from ninja import Router
 
 from apps.auth.services import AuthService, TokenService, PasswordResetService, PasskeyService
-from core.auth.authentication import JWTBearer
+from apps.auth.authentication import JWTBearer
 
 from .schemas import (
     MagicLinkRequest,

--- a/backend/api/ingest/router.py
+++ b/backend/api/ingest/router.py
@@ -7,7 +7,7 @@ from ninja import Router
 
 from apps.projects.models import App
 from apps.projects.services import IngestService
-from core.auth.authentication import api_key_auth
+from apps.auth.authentication import api_key_auth
 from core.exceptions.base import AuthenticationError, ValidationError
 
 from .schemas import IngestRequest, IngestResponse, IngestLogsRequest, IngestLogsResponse

--- a/backend/api/projects/router.py
+++ b/backend/api/projects/router.py
@@ -17,7 +17,7 @@ from apps.projects.models import App
 from apps.projects.services import ProjectService, AppService, AnalyticsService, DataQueryService
 from apps.users.models import User
 from apps.users.services import UserService
-from core.auth.authentication import jwt_auth
+from apps.auth.authentication import jwt_auth
 
 from .schemas import (
     CreateProjectRequest,

--- a/backend/api/users/router.py
+++ b/backend/api/users/router.py
@@ -5,7 +5,7 @@ from ninja.files import UploadedFile
 from apps.auth.services import TokenService
 from apps.users.models import User
 from apps.users.services import UserService
-from core.auth.authentication import jwt_auth
+from apps.auth.authentication import jwt_auth
 from core.exceptions.base import NotFoundError, ValidationError
 
 from .schemas import (

--- a/backend/apps/auth/authentication.py
+++ b/backend/apps/auth/authentication.py
@@ -5,17 +5,17 @@ from typing import Optional
 
 from django.http import HttpRequest
 from django.utils import timezone
-from ninja.security import HttpBearer, APIKeyHeader
+from ninja.security import APIKeyHeader, HttpBearer
 
+from apps.auth.models import ApiKey, RefreshToken
 from apps.users.models import User
+from core.auth.context import TenantContext
+from core.auth.jwt import verify_access_token
 from core.exceptions.base import TokenExpiredError, TokenInvalidError
-
-from .jwt import verify_access_token
-from .context import TenantContext
 
 logger = logging.getLogger(__name__)
 
-# Only update last_used_at if more than 60s have passed (avoids DB write on every request)
+# Skip last_used_at writes within this window to avoid a DB write per request.
 _LAST_USED_DEBOUNCE = timedelta(seconds=60)
 
 
@@ -24,9 +24,7 @@ class JWTBearer(HttpBearer):
         try:
             claims = verify_access_token(token)
 
-            user = User.objects.filter(
-                id=claims["sub"], is_active=True
-            ).first()
+            user = User.objects.filter(id=claims["sub"], is_active=True).first()
             if user is None:
                 return None
 
@@ -39,7 +37,6 @@ class JWTBearer(HttpBearer):
                 email=user.email,
             )
 
-            # Touch last_used_at on the session (debounced)
             if token_family:
                 self._touch_session(token_family)
 
@@ -54,7 +51,6 @@ class JWTBearer(HttpBearer):
     @staticmethod
     def _touch_session(token_family: str) -> None:
         try:
-            from apps.auth.models import RefreshToken
             now = timezone.now()
             threshold = now - _LAST_USED_DEBOUNCE
             RefreshToken.objects.filter(
@@ -81,8 +77,6 @@ class ApiKeyAuth(APIKeyHeader):
             return None
 
         try:
-            from apps.auth.models import ApiKey
-
             key_hash = hashlib.sha256(key.encode()).hexdigest()
             api_key = (
                 ApiKey.objects.active()
@@ -107,7 +101,6 @@ class ApiKeyAuth(APIKeyHeader):
             )
             request._auth_method = "api_key"
 
-            # Touch last_used_at (debounced)
             now = timezone.now()
             if (
                 api_key.last_used_at is None

--- a/backend/core/auth/__init__.py
+++ b/backend/core/auth/__init__.py
@@ -1,22 +1,8 @@
 from .context import TenantContext
 from .jwt import create_access_token, verify_access_token
-from .authentication import (
-    JWTBearer,
-    JWTBearerOptional,
-    ApiKeyAuth,
-    jwt_auth,
-    jwt_auth_optional,
-    api_key_auth,
-)
 
 __all__ = [
     "TenantContext",
     "create_access_token",
     "verify_access_token",
-    "JWTBearer",
-    "JWTBearerOptional",
-    "ApiKeyAuth",
-    "jwt_auth",
-    "jwt_auth_optional",
-    "api_key_auth",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "clickhouse-driver>=0.2.10",
     "fastapi[standard]>=0.129.0",
     "uvicorn>=0.44.0",
-    "apilenss>=0.1.6",
     "webauthn>=2.7.1,<3.0",
     "pyotp>=2.9,<3.0",
 ]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -64,4 +64,7 @@ Documentation = "https://apilens.ai"
 Repository = "https://github.com/apilens/apilens"
 
 [tool.hatch.build.targets.wheel]
-packages = ["apilens", "apilenss"]
+# Wheel published as `apilenss` on PyPI (see `name` above); the actual code
+# lives in the `apilens` Python package. The empty `apilenss/` mirror was a
+# placeholder from the initial scaffold and got removed in the cleanup pass.
+packages = ["apilens"]


### PR DESCRIPTION
## Why

PR #84 squash-landed with 9 file edits that were on disk but not git-staged at commit time. The merge therefore left main in a broken state:

\`\`\`
ModuleNotFoundError: No module named 'core.auth.authentication'
\`\`\`

Production isn't down — the live revision is from a pre-#84 image (\`815f172\`). But the next \`gcloud run deploy\` from main would crash on Django import.

## What this fixes

| File | Problem on main | Fix |
|---|---|---|
| 5 routers under \`backend/api/\` | Still \`from core.auth.authentication import ...\` (path removed in #84) | → \`from apps.auth.authentication import ...\` |
| \`backend/core/auth/__init__.py\` | Re-exports JWTBearer/ApiKeyAuth from \`.authentication\` (deleted) | Trim re-exports to just TenantContext + jwt helpers |
| \`backend/apps/auth/authentication.py\` | Still has deferred in-method imports for what used to be circular deps | Lift to module-level (no longer circular since file is next to its models) |
| \`backend/pyproject.toml\` | Declares unused \`apilenss>=0.1.6\` runtime dep | Remove |
| \`sdks/python/pyproject.toml\` | \`packages = ["apilens", "apilenss"]\` — the \`apilenss/\` dir was deleted in #84, hatchling build would fail | → \`packages = ["apilens"]\` (with comment) |

## Verification

Local \`django.setup()\` + walking each router:

\`\`\`python
from api.auth.router import router
from api.users.router import router
from api.projects.router import router
from api.apps.router import router
from api.ingest.router import router
\`\`\`

All resolve cleanly with the changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)