### PR TITLE
feat(media): switch user uploads to Google Cloud Storage in production

### DIFF
--- a/backend/api/apps/schemas.py
+++ b/backend/api/apps/schemas.py
@@ -1,10 +1,8 @@
+import os
 from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-import os
-
-from django.conf import settings
 from ninja import Schema
 
 from apps.projects.models import App
@@ -13,11 +11,21 @@ FrameworkValue = Literal["fastapi", "flask", "django", "starlette", "express"]
 
 
 def _build_app_icon_url(app: App) -> str:
+    """Return the public URL for the app's icon, or "".
+
+    Mirrors users.schemas._build_picture_url — `icon_image.url` is absolute on
+    GCS (prod), path-relative on the local filesystem backend.
+    """
     if not app.icon_image:
         return ""
-    base = os.environ.get("DJANGO_BASE_URL", "http://localhost:8000")
+    url = app.icon_image.url
+    if url.startswith(("http://", "https://")):
+        base_url = url
+    else:
+        base = os.environ.get("DJANGO_BASE_URL", "http://localhost:8000").rstrip("/")
+        base_url = f"{base}{url}"
     cache_bust = int(app.updated_at.timestamp()) if app.updated_at else ""
-    return f"{base}{settings.MEDIA_URL}{app.icon_image.name}?v={cache_bust}"
+    return f"{base_url}?v={cache_bust}" if cache_bust else base_url
 
 
 class CreateAppRequest(Schema):

--- a/backend/api/users/schemas.py
+++ b/backend/api/users/schemas.py
@@ -1,8 +1,7 @@
+import os
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
-
-import os
 
 from django.conf import settings
 from ninja import Schema
@@ -12,11 +11,22 @@ from apps.users.services import UserService
 
 
 def _build_picture_url(user: User) -> str:
+    """Return the public URL for the user's picture, or "".
+
+    On GCS (prod) `picture.url` is already absolute (`https://storage.googleapis.com/<bucket>/...`).
+    On the local filesystem backend it's path-relative (`/media/...`), so we prepend
+    DJANGO_BASE_URL — settable to e.g. `http://localhost:8000` for local dev.
+    """
     if not user.picture:
         return ""
-    base = os.environ.get("DJANGO_BASE_URL", "http://localhost:8000")
+    url = user.picture.url
+    if url.startswith(("http://", "https://")):
+        base_url = url
+    else:
+        base = os.environ.get("DJANGO_BASE_URL", "http://localhost:8000").rstrip("/")
+        base_url = f"{base}{url}"
     cache_bust = int(user.updated_at.timestamp()) if user.updated_at else ""
-    return f"{base}{settings.MEDIA_URL}{user.picture.name}?v={cache_bust}"
+    return f"{base_url}?v={cache_bust}" if cache_bust else base_url
 
 
 class UserProfileResponse(Schema):

--- a/backend/apps/projects/apps.py
+++ b/backend/apps/projects/apps.py
@@ -5,3 +5,8 @@ class ProjectsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.projects"
     label = "projects"
+
+    def ready(self):
+        # Wire signal handlers (cascade-delete for uploaded files).
+        from . import signals  # noqa: F401
+

--- a/backend/apps/projects/services.py
+++ b/backend/apps/projects/services.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 import json
 from typing import Any
@@ -364,13 +363,10 @@ class AppService:
         img.save(buffer, format="JPEG", quality=90)
         buffer.seek(0)
 
+        # Delete the previous file via Django's storage API so this works
+        # against any backend (local FS, GCS, S3, …).
         if app.icon_image:
-            try:
-                old_path = app.icon_image.path
-                if os.path.exists(old_path):
-                    os.remove(old_path)
-            except Exception:
-                pass
+            app.icon_image.delete(save=False)
 
         app.icon_image.save(
             f"{app.id}.jpg",
@@ -384,12 +380,7 @@ class AppService:
     @transaction.atomic
     def remove_icon(app: App) -> App:
         if app.icon_image:
-            try:
-                old_path = app.icon_image.path
-                if os.path.exists(old_path):
-                    os.remove(old_path)
-            except Exception:
-                pass
+            app.icon_image.delete(save=False)
             app.icon_image = ""
             app.save(update_fields=["icon_image", "updated_at"])
         return app

--- a/backend/apps/projects/signals.py
+++ b/backend/apps/projects/signals.py
@@ -1,0 +1,18 @@
+"""Auto-cleanup of uploaded files when their owning row is deleted.
+
+Django's `ImageField` doesn't delete the underlying file on row delete —
+it just clears the FK. Without this, deleting an App row leaves the icon
+as an orphan in the storage bucket forever.
+"""
+
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+from .models import App
+
+
+@receiver(post_delete, sender=App)
+def delete_app_icon(sender, instance: App, **kwargs):
+    if instance.icon_image:
+        # save=False because the row is already gone — nothing left to save.
+        instance.icon_image.delete(save=False)

--- a/backend/apps/users/apps.py
+++ b/backend/apps/users/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.users"
+    label = "users"
+
+    def ready(self):
+        # Wire signal handlers (cascade-delete for uploaded files).
+        from . import signals  # noqa: F401

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from io import BytesIO
 from typing import Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -171,11 +170,10 @@ class UserService:
         img.save(buffer, format="JPEG", quality=90)
         buffer.seek(0)
 
-        # Delete old file if exists
+        # Delete the previous file via Django's storage API so this works
+        # against any backend (local FS, GCS, S3, …).
         if user.picture:
-            old_path = user.picture.path
-            if os.path.exists(old_path):
-                os.remove(old_path)
+            user.picture.delete(save=False)
 
         user.picture.save(
             f"{user.id}.jpg",
@@ -189,12 +187,7 @@ class UserService:
     @transaction.atomic
     def remove_picture(user: User) -> User:
         if user.picture:
-            try:
-                old_path = user.picture.path
-                if os.path.exists(old_path):
-                    os.remove(old_path)
-            except Exception:
-                pass
+            user.picture.delete(save=False)
             user.picture = ""
             user.save(update_fields=["picture", "updated_at"])
         return user

--- a/backend/apps/users/signals.py
+++ b/backend/apps/users/signals.py
@@ -1,0 +1,19 @@
+"""Auto-cleanup of uploaded files when their owning row is deleted.
+
+Django's `ImageField` does NOT delete the underlying file when the model
+row is deleted — it just clears the FK. Without this signal, deleting a
+User row leaves the profile picture as an orphan in the storage bucket
+forever.
+"""
+
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+from .models import User
+
+
+@receiver(post_delete, sender=User)
+def delete_user_picture(sender, instance: User, **kwargs):
+    if instance.picture:
+        # save=False because the row is already gone — nothing left to save.
+        instance.picture.delete(save=False)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -268,10 +268,41 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-MEDIA_URL = "/media/"
-MEDIA_ROOT = BASE_DIR / "media"
+# Media (user uploads): GCS in production, local filesystem in dev.
+# Production sets `GS_BUCKET_NAME=<project>-media` on Cloud Run; locally the
+# env var is unset and uploads land in backend/media/ as before.
+GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME", "").strip()
+
+if GS_BUCKET_NAME:
+    MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/"
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "OPTIONS": {
+                "bucket_name": GS_BUCKET_NAME,
+                "default_acl": None,  # bucket has uniform IAM; per-object ACLs are off
+                "querystring_auth": False,  # public bucket — emit clean URLs
+                "object_parameters": {
+                    "cache_control": "public, max-age=31536000",
+                },
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
+else:
+    MEDIA_URL = "/media/"
+    MEDIA_ROOT = BASE_DIR / "media"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
 
 # Profile picture constraints
 PROFILE_PICTURE_MAX_SIZE = 5 * 1024 * 1024  # 5 MB

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "uvicorn>=0.44.0",
     "webauthn>=2.7.1,<3.0",
     "pyotp>=2.9,<3.0",
+    "django-storages[google]>=1.14,<2.0",
 ]
 
 [build-system]

--- a/infra/terraform/media_bucket.tf
+++ b/infra/terraform/media_bucket.tf
@@ -1,0 +1,51 @@
+# GCS bucket for user-uploaded media (profile pictures, app icons).
+#
+# Public-read so the frontend can `<img src="https://storage.googleapis.com/...">`
+# directly — no signed-URL round trip on every page render. URLs are
+# unguessable (UUID-based filenames), same privacy model as GitHub/Slack avatars.
+#
+# Uniform bucket-level access means we control public access via IAM (the
+# `allUsers` -> `storage.objectViewer` binding below), not per-object ACLs.
+
+resource "google_storage_bucket" "media" {
+  name     = "${var.project_id}-media"
+  location = var.region
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "inherited"
+
+  # Don't keep deleted versions around — when an upload is replaced or
+  # removed we want it actually gone.
+  versioning {
+    enabled = false
+  }
+
+  # CORS: browser fetches inline from `<img>` tags loaded by the app at
+  # app.apilens.ai. Restrict to known origins.
+  cors {
+    origin          = ["https://app.apilens.ai", "http://localhost:3000"]
+    method          = ["GET", "HEAD"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+
+  # Don't strand orphan resources during dev `terraform destroy`.
+  force_destroy = false
+
+  depends_on = [google_project_service.apis]
+}
+
+# Anyone can GET objects (the frontend renders them in <img> tags); nobody
+# can list or write without authenticated credentials.
+resource "google_storage_bucket_iam_member" "media_public_read" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# Backend runtime SA writes + deletes objects (upload, replace, remove).
+resource "google_storage_bucket_iam_member" "backend_media_admin" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.backend_runtime.email}"
+}


### PR DESCRIPTION
Cloud Run containers have ephemeral disk → profile pics and app icons were vanishing on scale-up/cold-start. Switching to GCS for prod, keeping FileSystemStorage for local dev. See branch commit for full details.