### PR TITLE
fix: rename pnpm setup → pnpm bootstrap (conflicts with pnpm built-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ There are two commands you'll use. `setup` is one-time, `dev` is every day.
 After cloning the repo:
 
 ```bash
-pnpm setup
+pnpm bootstrap
 ```
 
 This is interactive — it checks your environment, asks before overwriting anything, and walks you through each step:
@@ -81,7 +81,9 @@ This is interactive — it checks your environment, asks before overwriting anyt
 5. **Databases** — starts postgres + clickhouse + redis via Docker, detects port conflicts and offers to remap them
 6. **Migrations** — optionally runs Django migrations to get the DB schema ready
 
-Re-run `pnpm setup` after pulling changes that touch dependencies, env templates, or Docker config. It skips steps that are already done.
+Re-run `pnpm bootstrap` after pulling changes that touch dependencies, env templates, or Docker config. It skips steps that are already done.
+
+> **Why `bootstrap` and not `setup`?** `pnpm setup` is a built-in pnpm command (it adds pnpm to your PATH). Running it would silently do nothing instead of running our script.
 
 ### Every day, while coding
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:up": "docker compose -f infra/docker/docker-compose.local.yml up -d",
     "db:down": "docker compose -f infra/docker/docker-compose.local.yml down",
     "db:logs": "docker compose -f infra/docker/docker-compose.local.yml logs -f",
-    "setup": "bash scripts/setup/setup-local.sh"
+    "bootstrap": "bash scripts/setup/setup-local.sh"
   },
   "devDependencies": {
     "turbo": "^2.3.0",

--- a/scripts/setup/setup-local.sh
+++ b/scripts/setup/setup-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Interactive local-dev bootstrap for APILens.
-# Run: pnpm setup  (or: bash scripts/setup/setup-local.sh)
+# Run: pnpm bootstrap  (or: bash scripts/setup/setup-local.sh)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Problem

`pnpm setup` is a built-in pnpm command that adds pnpm to the shell PATH. It always takes precedence over package.json scripts, so running `pnpm setup` silently printed "No changes to the environment were made" and exited — our bootstrap script never ran, `node_modules` was never installed, and the next `pnpm dev` failed with `turbo: command not found`.

## Fix

- Rename the npm script from `setup` → `bootstrap` in `package.json`
- Update the comment in `scripts/setup/setup-local.sh`
- Update all `pnpm setup` references in `README.md` to `pnpm bootstrap`
- Add a callout in the README explaining why it's named `bootstrap`

## Test plan

- [ ] `pnpm bootstrap` on a fresh clone runs the interactive setup script
- [ ] `pnpm setup` still prints pnpm's own output (PATH check) — no longer interferes

🤖 Generated with [Claude Code](https://claude.com/claude-code)