### PR TITLE
fix(setup): replace tr|head generators with openssl rand (SIGPIPE crash)

### DIFF
--- a/scripts/setup/setup-local.sh
+++ b/scripts/setup/setup-local.sh
@@ -80,8 +80,8 @@ find_free() {
 }
 
 # ── Secret generators ─────────────────────────────────────────────────────────
-gen_hex()        { openssl rand -hex 32 2>/dev/null || LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 64; }
-gen_django_key() { LC_ALL=C tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)' </dev/urandom | head -c 50; }
+gen_hex()        { openssl rand -hex 32; }
+gen_django_key() { openssl rand -hex 25; }
 
 # ── Banner ────────────────────────────────────────────────────────────────────
 banner() {


### PR DESCRIPTION
## Problem

Step 3 (Environment files) was crashing with exit code 141 (SIGPIPE).

Root cause: `gen_django_key` and the `gen_hex` fallback both piped `tr … </dev/urandom` into `head -c N`. Once `head` reads enough bytes it closes the read end of the pipe, which sends SIGPIPE to `tr`. With `set -euo pipefail` at the top of the script, the non-zero exit status from `tr` propagates and kills the whole script.

## Fix

Replace both generators with simple `openssl rand` calls — no pipes, no SIGPIPE:

```bash
gen_hex()        { openssl rand -hex 32; }   # 64-char hex string
gen_django_key() { openssl rand -hex 25; }   # 50-char hex string
```

`openssl` is available on macOS by default and was already used as the primary method in `gen_hex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)