### PR TITLE
fix: correct postgres password in .env.example (apilens_dev not apilens_password)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -15,9 +15,9 @@ DJANGO_SETTINGS_MODULE=config.settings
 # Database
 # =============================================================================
 # Primary connection URL
-APILENS_POSTGRES_URL=postgresql://apilens:apilens_password@localhost:5432/apilens
+APILENS_POSTGRES_URL=postgresql://apilens:apilens_dev@localhost:5432/apilens
 # Optional alternate URL (non-pooling)
-# APILENS_POSTGRES_URL_NON_POOLING=postgresql://apilens:apilens_password@localhost:5432/apilens
+# APILENS_POSTGRES_URL_NON_POOLING=postgresql://apilens:apilens_dev@localhost:5432/apilens
 
 # =============================================================================
 # ClickHouse (analytics for endpoint stats)


### PR DESCRIPTION
## Problem

`apps/api/.env.example` had the postgres password as `apilens_password`, but `infra/docker/docker-compose.local.yml` sets `POSTGRES_PASSWORD: apilens_dev`. On a fresh `pnpm bootstrap`, Django migrations failed immediately with:

```
FATAL: password authentication failed for user "apilens"
```

## Fix

Update `.env.example` to use `apilens_dev` to match the docker-compose definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)