### PR TITLE
feat: pnpm dev now starts Django + Next.js together

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,30 +87,13 @@ Re-run `pnpm bootstrap` after pulling changes that touch dependencies, env templ
 
 ### Every day, while coding
 
-**Option A — one terminal (simplest):**
-
-```bash
-bash scripts/dev/dev-up.sh
-```
-
-This starts the databases, boots the Next.js dev server in the background, and runs Django in the foreground. Ctrl-C stops everything.
-
-**Option B — two terminals (cleaner logs):**
-
-Terminal 1 — frontend (Next.js on http://localhost:3002):
-
 ```bash
 pnpm dev
 ```
 
-Terminal 2 — backend (Django on http://localhost:8000):
+That's it. Turborepo starts both the Next.js frontend (http://localhost:3002) and the Django backend (http://localhost:8000) together in one terminal via the turbo TUI.
 
-```bash
-cd apps/api
-.venv/bin/python manage.py runserver
-```
-
-Magic links print to the Django terminal in dev — copy the link from the logs to sign in.
+Magic links print to the Django pane in the TUI — copy the link from the logs to sign in.
 
 ### Once you're done
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": ".venv/bin/python manage.py runserver"
+  }
+}

--- a/scripts/setup/setup-local.sh
+++ b/scripts/setup/setup-local.sh
@@ -383,20 +383,16 @@ done_screen() {
 
   label "Start developing"
   printf "\n"
-  printf "  ${CY}pnpm dev${R}                        ${D}# Next.js  → http://localhost:3002${R}\n"
-  printf "  ${D}cd apps/api${R}\n"
-  printf "  ${D}.venv/bin/python manage.py runserver${R}  ${D}# Django   → http://localhost:8000${R}\n"
-  printf "\n"
-  label "Or both at once"
-  printf "\n"
-  printf "  ${CY}bash scripts/dev/dev-up.sh${R}      ${D}# frontend + backend in one terminal${R}\n"
+  printf "  ${CY}pnpm dev${R}                        ${D}# frontend + backend together (turbo TUI)${R}\n"
+  printf "                                  ${D}Next.js → http://localhost:3002${R}\n"
+  printf "                                  ${D}Django  → http://localhost:8000${R}\n"
   printf "\n"
   label "Handy commands"
   printf "\n"
   printf "  ${CY}pnpm db:down${R}                    ${D}# stop databases${R}\n"
   printf "  ${CY}pnpm db:logs${R}                    ${D}# tail database logs${R}\n"
   printf "\n"
-  printf "  ${D}Magic-link emails print to the Django terminal. Copy the link to sign in.${R}\n\n"
+  printf "  ${D}Magic-link emails print to the Django pane in turbo. Copy the link to sign in.${R}\n\n"
 }
 
 # ── Main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Add `apps/api/package.json` with a single `dev` script:

```json
{ "scripts": { "dev": ".venv/bin/python manage.py runserver" } }
```

`apps/*` is already in `pnpm-workspace.yaml`, so pnpm picks this up automatically. Turbo already has `"dev": { "cache": false, "persistent": true }`, so it treats Django as a long-running process alongside Next.js.

## Result

```bash
pnpm dev   # starts both — Next.js :3002 and Django :8000 in the turbo TUI
```

Verified with `pnpm turbo run dev --dry-run` — turbo now shows `api` and `frontend` in scope.

## Also updated

- README — simplified "every day" section to just `pnpm dev`
- Setup done-screen — removed the two-terminal option, `pnpm dev` is now the one answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)