### PR TITLE
feat(infra): self-hosted Grafana observability (logs + metrics) on the prod VM

### DIFF
--- a/infra/gcp/terraform/compute.tf
+++ b/infra/gcp/terraform/compute.tf
@@ -57,6 +57,7 @@ resource "google_compute_instance" "app" {
     "apilens-pg-secret-id"      = google_secret_manager_secret.postgres_password.secret_id
     "apilens-ch-secret-id"      = google_secret_manager_secret.clickhouse_password.secret_id
     "apilens-resend-secret-id"  = google_secret_manager_secret.resend_api_key.secret_id
+    "apilens-grafana-secret-id" = google_secret_manager_secret.grafana_admin_password.secret_id
     "apilens-from-email"        = var.default_from_email
     "apilens-webauthn-rp-id"    = local.webauthn_rp_id
     "apilens-webauthn-rp-name"  = var.webauthn_rp_name
@@ -71,5 +72,6 @@ resource "google_compute_instance" "app" {
     google_project_iam_member.vm_artifact_reader,
     google_secret_manager_secret_version.postgres_password,
     google_secret_manager_secret_version.clickhouse_password,
+    google_secret_manager_secret_version.grafana_admin_password,
   ]
 }

--- a/infra/gcp/terraform/iam.tf
+++ b/infra/gcp/terraform/iam.tf
@@ -7,6 +7,7 @@ locals {
     postgres_password   = google_secret_manager_secret.postgres_password.secret_id
     clickhouse_password = google_secret_manager_secret.clickhouse_password.secret_id
     resend_api_key      = google_secret_manager_secret.resend_api_key.secret_id
+    grafana_admin       = google_secret_manager_secret.grafana_admin_password.secret_id
   }
 }
 

--- a/infra/gcp/terraform/secrets.tf
+++ b/infra/gcp/terraform/secrets.tf
@@ -60,3 +60,24 @@ resource "google_secret_manager_secret" "resend_api_key" {
   }
   depends_on = [google_project_service.apis]
 }
+
+# Grafana admin password. Grafana is bound to the VM's loopback (127.0.0.1:3001)
+# and reached only over an SSH tunnel, so this is low-risk — but generating it
+# here (like postgres/clickhouse) keeps it out of git and out of metadata.
+resource "random_password" "grafana_admin" {
+  length  = 32
+  special = false
+}
+
+resource "google_secret_manager_secret" "grafana_admin_password" {
+  secret_id = "apilens-grafana-admin-password"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "grafana_admin_password" {
+  secret      = google_secret_manager_secret.grafana_admin_password.id
+  secret_data = random_password.grafana_admin.result
+}

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -25,10 +25,22 @@ x-db-env: &db-env
   APILENS_CLICKHOUSE_URL: "clickhouse://default:${CLICKHOUSE_PASSWORD}@clickhouse:9000/apilens"
   APILENS_REDIS_URL: "redis://redis:6379/0"
 
+# Cap per-container log files. Docker's default json-file driver is UNBOUNDED, so
+# without this the container logs grow until they fill /var/lib/docker on the boot
+# disk (and are lost on `down -v`). 10MB x 5 files = 50MB max per container. Promtail
+# tails these same json files to ship them to Loki, so rotation is safe — shipped
+# lines are already in Loki before the file rotates out.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "80:80"
       - "443:443"
@@ -49,6 +61,7 @@ services:
   web:
     image: "${REGISTRY_BASE}/frontend:${IMAGE_TAG:-latest}"
     restart: unless-stopped
+    logging: *default-logging
     environment:
       NODE_ENV: production
       PORT: "3000"
@@ -62,6 +75,7 @@ services:
   api:
     image: "${REGISTRY_BASE}/backend:${IMAGE_TAG:-latest}"
     restart: unless-stopped
+    logging: *default-logging
     environment:
       <<: *db-env
       DJANGO_DEBUG: "False"
@@ -115,6 +129,7 @@ services:
   migrate:
     image: "${REGISTRY_BASE}/backend:${IMAGE_TAG:-latest}"
     restart: "no"
+    logging: *default-logging
     command: >
       sh -c "python manage.py migrate --noinput &&
              python manage.py clickhouse_migrate"
@@ -132,6 +147,7 @@ services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: apilens
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -148,6 +164,7 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24-alpine
     restart: unless-stopped
+    logging: *default-logging
     # Without SYS_NICE the server spins forever on the get_mempolicy() NUMA
     # syscall ("Operation not permitted") and never reaches "Ready for
     # connections" — granting it lets ClickHouse actually start.
@@ -179,6 +196,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    logging: *default-logging
     command: ["redis-server", "--save", "60", "1", "--appendonly", "yes"]
     volumes:
       - /mnt/data/redis:/data
@@ -187,3 +205,127 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+
+  # ==========================================================================
+  # Observability stack (logs + metrics) — see infra/gcp/vm/startup.sh for the
+  # config files these mount. Everything here is INTERNAL-ONLY on the compose
+  # network except grafana, which binds to 127.0.0.1:3001 (loopback) so it is
+  # reachable solely via an SSH tunnel — never published to the public IP.
+  # ==========================================================================
+
+  # Log store. Promtail pushes here; Grafana queries it. Single-binary mode with
+  # a filesystem-backed store on the persistent disk.
+  loki:
+    image: grafana/loki:3.3.2
+    restart: unless-stopped
+    logging: *default-logging
+    command: ["-config.file=/etc/loki/loki-config.yaml"]
+    volumes:
+      - /opt/apilens/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - /mnt/data/loki:/loki
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3100/ready | grep -q ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  # Tails every container's json-file logs (discovered via the docker socket so
+  # each stream is labelled with its container name) and ships them to Loki.
+  promtail:
+    image: grafana/promtail:3.3.2
+    restart: unless-stopped
+    logging: *default-logging
+    command: ["-config.file=/etc/promtail/promtail-config.yaml"]
+    volumes:
+      - /opt/apilens/promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      # Read-only access to the container log files + the docker socket for
+      # service discovery (container names, labels).
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /mnt/data/promtail:/tmp/promtail
+    depends_on:
+      - loki
+
+  # Metrics store. Scrapes cadvisor + node-exporter (+ itself); Grafana queries it.
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    restart: unless-stopped
+    logging: *default-logging
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+    volumes:
+      - /opt/apilens/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /mnt/data/prometheus:/prometheus
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:9090/-/ready | grep -q Ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      - cadvisor
+      - node-exporter
+
+  # Per-container resource metrics (CPU, memory, network, fs).
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    restart: unless-stopped
+    logging: *default-logging
+    # cAdvisor needs broad read access to the host to introspect cgroups +
+    # containers; privileged + the device below are the documented requirements.
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # Host-level metrics (CPU, memory, disk, filesystem) for the VM itself.
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    restart: unless-stopped
+    logging: *default-logging
+    command:
+      - "--path.rootfs=/host"
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+
+  # The only service that binds a host port: 127.0.0.1:3001 (loopback only).
+  # Datasources (Loki + Prometheus) are provisioned from a file on boot; admin
+  # password comes from Secret Manager via .env.
+  grafana:
+    image: grafana/grafana-oss:11.4.0
+    restart: unless-stopped
+    logging: *default-logging
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+      # Served behind an SSH tunnel at localhost:3001.
+      GF_SERVER_ROOT_URL: "http://localhost:3001"
+    volumes:
+      - /mnt/data/grafana:/var/lib/grafana
+      - /opt/apilens/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - loki
+      - prometheus

--- a/infra/gcp/vm/startup.sh
+++ b/infra/gcp/vm/startup.sh
@@ -35,6 +35,7 @@ SESSION_SECRET_ID="$(attr apilens-session-secret-id)"
 PG_SECRET_ID="$(attr apilens-pg-secret-id)"
 CH_SECRET_ID="$(attr apilens-ch-secret-id)"
 RESEND_SECRET_ID="$(attr apilens-resend-secret-id)"
+GRAFANA_SECRET_ID="$(attr apilens-grafana-secret-id)"
 FROM_EMAIL="$(attr apilens-from-email)"
 WEBAUTHN_RP_ID="$(attr apilens-webauthn-rp-id)"
 WEBAUTHN_RP_NAME="$(attr apilens-webauthn-rp-name)"
@@ -88,11 +89,18 @@ else
 fi
 
 mkdir -p /mnt/data/postgres /mnt/data/clickhouse /mnt/data/redis \
-         /mnt/data/caddy/data /mnt/data/caddy/config
+         /mnt/data/caddy/data /mnt/data/caddy/config \
+         /mnt/data/grafana /mnt/data/loki /mnt/data/prometheus /mnt/data/promtail
 # The alpine ClickHouse image runs as uid 101 and refuses to start if its data
 # dir is owned by another user (e.g. root, from an earlier boot). Keep it owned
 # by 101 every boot so a VM/disk recreate can't wedge ClickHouse.
 chown -R 101:101 /mnt/data/clickhouse 2>/dev/null || true
+# Same fix-ownership-every-boot trick for the observability stores: each image
+# drops to a non-root uid and refuses to write a root-owned data dir.
+#   grafana -> 472, loki -> 10001, prometheus (nobody) -> 65534
+chown -R 472:472 /mnt/data/grafana 2>/dev/null || true
+chown -R 10001:10001 /mnt/data/loki 2>/dev/null || true
+chown -R 65534:65534 /mnt/data/prometheus 2>/dev/null || true
 
 # ----------------------------------------------------------------------------
 # Docker
@@ -130,6 +138,9 @@ CLICKHOUSE_PASSWORD="$(access_secret "${CH_SECRET_ID}")"
 # Resend key may have no version yet on a fresh project; tolerate that so the
 # stack still boots (email just no-ops until the secret is populated).
 RESEND_API_KEY="$(access_secret "${RESEND_SECRET_ID}" || true)"
+# Grafana admin password (terraform generates it; localhost-only UI). Tolerate a
+# missing version so the stack still boots — compose falls back to "admin".
+GRAFANA_ADMIN_PASSWORD="$(access_secret "${GRAFANA_SECRET_ID}" || true)"
 
 # ----------------------------------------------------------------------------
 # App directory + config files (from metadata)
@@ -172,6 +183,130 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 SQL
 
 # ----------------------------------------------------------------------------
+# Observability stack config (Loki + Promtail + Prometheus + Grafana)
+# Written inline (same pattern as listen.xml / init.sql above). The compose file
+# bind-mounts each of these into its container.
+# ----------------------------------------------------------------------------
+mkdir -p /opt/apilens/loki /opt/apilens/promtail /opt/apilens/prometheus \
+         /opt/apilens/grafana/provisioning/datasources
+
+# Loki — single-binary, filesystem-backed store on the persistent disk. No auth
+# (it's only reachable on the internal compose network). Retention handled by the
+# compactor; ~14 days.
+cat > /opt/apilens/loki/loki-config.yaml <<'YAML'
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 336h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false
+YAML
+
+# Promtail — discover containers via the docker socket and ship their json-file
+# logs to Loki, labelled by container name + compose service.
+cat > /opt/apilens/promtail/promtail-config.yaml <<'YAML'
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /tmp/promtail/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 15s
+    relabel_configs:
+      # Strip the leading "/" docker puts on container names.
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container_name
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: compose_service
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: stream
+YAML
+
+# Prometheus — scrape the two exporters plus itself.
+cat > /opt/apilens/prometheus/prometheus.yml <<'YAML'
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']
+  - job_name: node-exporter
+    static_configs:
+      - targets: ['node-exporter:9100']
+YAML
+
+# Grafana — provision the Loki + Prometheus datasources so the UI works on first
+# login with zero clicks. Prometheus is the default datasource.
+cat > /opt/apilens/grafana/provisioning/datasources/datasources.yaml <<'YAML'
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+YAML
+
+# ----------------------------------------------------------------------------
 # .env (locked down)
 # ----------------------------------------------------------------------------
 (
@@ -195,6 +330,7 @@ EMAIL_HOST_PASSWORD=${RESEND_API_KEY}
 DEFAULT_FROM_EMAIL=${FROM_EMAIL}
 WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID}
 WEBAUTHN_RP_NAME=${WEBAUTHN_RP_NAME}
+GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
 ENV
 )
 


### PR DESCRIPTION
## What

Adds an open-source **Grafana + Loki + Prometheus** observability stack to the single-VM docker-compose deployment, so we can search prod logs and view resource dashboards without SSHing in to run `docker compose logs`.

| Service | Role |
|---|---|
| `loki` + `promtail` | All container logs, labelled by container name (`{container_name="apilens-api-1"}`) |
| `prometheus` | Metrics store, 15d retention |
| `cadvisor` | Per-container CPU / mem / net / fs |
| `node-exporter` | Host CPU / mem / disk |
| `grafana` (oss) | UI, Loki + Prometheus datasources pre-provisioned |

## Access (locked down)

Grafana binds **`127.0.0.1:3001` (loopback only)** — no public port, no DNS. Reached via SSH tunnel:

```
gcloud compute ssh apilens-prod-app --zone asia-south1-a --tunnel-through-iap -- -L 3001:localhost:3001
# then open http://localhost:3001  (admin / <apilens-grafana-admin-password secret>)
```

Everything else stays internal to the compose network — matches the existing posture where only Caddy binds 80/443.

## Also

- Caps the previously **unbounded** json-file container logs at 10MB × 5 per container (shared `x-logging` anchor, applied to existing services too).
- `startup.sh` writes the loki/promtail/prometheus/grafana configs inline (same heredoc pattern as `listen.xml` / `init.sql`), creates `/mnt/data/{grafana,loki,prometheus,promtail}` with the correct per-image uids, and sources the Grafana admin password from Secret Manager.
- Terraform generates the admin password (`random_password`, like postgres/clickhouse) and grants the VM SA read access.

## Rollout

After merge: `terraform apply` (creates the secret + pushes new metadata), then on the VM `sudo google_metadata_script_runner startup` (writes configs, pulls the 6 public images, restarts `apilens.service`).

## Verify

- `docker compose ps` → 13 containers healthy (7 existing + 6 new), app still serves `/`→200, `/api/v1/docs`→200
- Tunnel → Grafana → Explore/Loki returns live logs; Prometheus targets all `UP`
- `curl http://34.180.52.71:3001` from outside fails (loopback only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)