### PR TITLE
feat(infra): expose Grafana at grafana.apilens.ai (Caddy auto-HTTPS)

### DIFF
--- a/infra/gcp/terraform/compute.tf
+++ b/infra/gcp/terraform/compute.tf
@@ -50,6 +50,7 @@ resource "google_compute_instance" "app" {
     "apilens-image-tag"         = var.image_tag
     "apilens-app-site"          = local.app_site
     "apilens-api-site"          = local.api_site
+    "apilens-grafana-site"      = local.grafana_site
     "apilens-allowed-hosts"     = local.allowed_hosts
     "apilens-csrf-origins"      = local.csrf_trusted_origins
     "apilens-django-secret-id"  = google_secret_manager_secret.django_secret_key.secret_id

--- a/infra/gcp/terraform/locals.tf
+++ b/infra/gcp/terraform/locals.tf
@@ -8,8 +8,9 @@ locals {
 
   # Caddy site addresses. With no app_domain we serve plain HTTP on the IP
   # (":80"); with one, Caddy auto-issues a Let's Encrypt cert for that host.
-  app_site = var.app_domain != "" ? var.app_domain : ":80"
-  api_site = var.api_domain
+  app_site     = var.app_domain != "" ? var.app_domain : ":80"
+  api_site     = var.api_domain
+  grafana_site = var.grafana_domain
 
   # Django ALLOWED_HOSTS + CSRF/CORS origins derived from the domains. Internal
   # service names (api/web) and loopback are appended in startup.sh.

--- a/infra/gcp/terraform/terraform.tfvars.example
+++ b/infra/gcp/terraform/terraform.tfvars.example
@@ -21,6 +21,11 @@ data_disk_size = 100
 app_domain = "app.example.com"
 api_domain = "api.example.com"
 
+# Optional dedicated host for the Grafana observability UI. When set, Caddy
+# proxies it (auto-HTTPS) to the grafana container; Grafana's own login gates
+# access. Leave empty to keep Grafana on the SSH tunnel only (127.0.0.1:3001).
+grafana_domain = "grafana.example.com"
+
 ssh_source_ranges = ["0.0.0.0/0"]
 
 # Extra DJANGO_ALLOWED_HOSTS beyond app_domain/api_domain (which are added

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -94,6 +94,17 @@ variable "api_domain" {
   default     = ""
 }
 
+variable "grafana_domain" {
+  description = <<-EOT
+    Optional dedicated hostname for the Grafana observability UI, e.g.
+    "grafana.apilens.ai". When set, Caddy proxies this host to the grafana
+    container with auto-HTTPS (Grafana's own login still gates access). Leave
+    empty to keep Grafana reachable only over the SSH tunnel (127.0.0.1:3001).
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "image_tag" {
   description = "Container image tag the VM should run for the api + web images."
   type        = string

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -321,8 +321,11 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_ANALYTICS_REPORTING_ENABLED: "false"
       GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
-      # Served behind an SSH tunnel at localhost:3001.
-      GF_SERVER_ROOT_URL: "http://localhost:3001"
+      # External URL the browser uses to reach Grafana. startup.sh sets this to
+      # https://<grafana_domain> when a dedicated host is configured, otherwise
+      # it stays the loopback address used by the SSH tunnel. Must match reality
+      # so Grafana's redirects + cookie/asset URLs work.
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3001}
     volumes:
       - /mnt/data/grafana:/var/lib/grafana
       - /opt/apilens/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/infra/gcp/vm/startup.sh
+++ b/infra/gcp/vm/startup.sh
@@ -28,6 +28,7 @@ REGISTRY_BASE="$(attr apilens-registry-base)"
 IMAGE_TAG="$(attr apilens-image-tag)"
 APP_SITE="$(attr apilens-app-site)"
 API_SITE="$(attr apilens-api-site)"
+GRAFANA_SITE="$(attr apilens-grafana-site)"
 ALLOWED_HOSTS="$(attr apilens-allowed-hosts)"
 CSRF_ORIGINS="$(attr apilens-csrf-origins)"
 DJANGO_SECRET_ID="$(attr apilens-django-secret-id)"
@@ -52,6 +53,15 @@ fi
 
 # Browser CORS origins: the app origin plus localhost for dev tooling.
 CORS_ORIGINS="${FRONTEND_URL},http://localhost:3000,http://127.0.0.1:3000"
+
+# Grafana's external root URL: the dedicated HTTPS host when one is configured,
+# else the loopback address used by the SSH tunnel. Grafana needs this correct so
+# its redirects + asset/cookie URLs match how the browser actually reaches it.
+if [[ -n "${GRAFANA_SITE}" ]]; then
+  GRAFANA_ROOT_URL="https://${GRAFANA_SITE}"
+else
+  GRAFANA_ROOT_URL="http://localhost:3001"
+fi
 
 # GCS media bucket name matches the terraform resource: "<project>-media".
 # The Django app reads it from GS_BUCKET_NAME (apps/api config/settings.py).
@@ -161,6 +171,19 @@ if [[ -n "${API_SITE}" ]]; then
 ${API_SITE} {
 	encode gzip zstd
 	reverse_proxy api:8000
+}
+CADDY
+fi
+
+# Dedicated Grafana host (auto-HTTPS). Appended only when configured so an empty
+# site label can't make Caddy refuse to start. Grafana's own login still gates
+# access; the upstream is the in-network container port (grafana:3000).
+if [[ -n "${GRAFANA_SITE}" ]]; then
+  cat >> /opt/apilens/Caddyfile <<CADDY
+
+${GRAFANA_SITE} {
+	encode gzip zstd
+	reverse_proxy grafana:3000
 }
 CADDY
 fi
@@ -331,6 +354,7 @@ DEFAULT_FROM_EMAIL=${FROM_EMAIL}
 WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID}
 WEBAUTHN_RP_NAME=${WEBAUTHN_RP_NAME}
 GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+GRAFANA_ROOT_URL=${GRAFANA_ROOT_URL}
 ENV
 )
 


### PR DESCRIPTION
Follow-up to #119. Exposes the Grafana UI on a dedicated HTTPS host so it's reachable in a browser without an SSH tunnel.

## What
- New `grafana_domain` terraform var (set to `grafana.apilens.ai` in tfvars) → `local.grafana_site` → metadata `apilens-grafana-site`.
- `startup.sh` appends a Caddy site block (`grafana.apilens.ai { reverse_proxy grafana:3000 }`) only when the var is set, and derives `GRAFANA_ROOT_URL` (`https://<host>`) into `.env`.
- Compose `GF_SERVER_ROOT_URL` now comes from `${GRAFANA_ROOT_URL}`. Loopback binding `127.0.0.1:3001` kept for tunnel use.

## DNS / cert
- Added explicit `grafana A 34.180.52.71` in Vercel DNS (overrides the `*` ALIAS → Vercel). Already resolves to the VM.
- Cert issues via Caddy's **ZeroSSL (Sectigo)** fallback — allowed by the apilens.ai CAA records (Let's Encrypt isn't); same path `app`/`api` use.

## Access after deploy
`https://grafana.apilens.ai` → Grafana login (admin / `apilens-grafana-admin-password` secret). Sign-up disabled.

## Verify
- `https://grafana.apilens.ai/api/health` → 200, valid cert
- App unaffected: `app.apilens.ai` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)