### PR TITLE
feat(api): full Sentry — tracing, profiling, structured logs (prod + local)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -51,3 +51,21 @@ DEFAULT_FROM_EMAIL=no-reply@apilens.ai
 # =============================================================================
 LOG_LEVEL=INFO
 ENVIRONMENT=development
+
+# =============================================================================
+# Sentry — errors + tracing + profiling + logs (https://sentry.io)
+# =============================================================================
+# Paste your project DSN to enable Sentry locally too. Leave EMPTY to disable
+# (the whole integration is a no-op without a DSN). In prod the DSN is injected
+# from GCP Secret Manager — it is NOT committed here.
+# When DEBUG is on, events are auto-tagged environment="development".
+SENTRY_DSN=
+# Capture everything locally; dial these down (e.g. 0.2) in high-traffic prod.
+SENTRY_TRACES_SAMPLE_RATE=1.0
+SENTRY_PROFILES_SAMPLE_RATE=1.0
+SENTRY_ENABLE_LOGS=True
+# Optional overrides:
+# SENTRY_ENVIRONMENT=development
+# SENTRY_LOGS_LEVEL=INFO       # min level forwarded to Sentry Logs
+# SENTRY_EVENT_LEVEL=ERROR     # min level captured as Sentry issues
+# SENTRY_SEND_PII=True

--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -349,25 +349,54 @@ LOGGING = {
 }
 
 # ---------------------------------------------------------------------------
-# Sentry — error + performance monitoring (https://sentry.io)
+# Sentry — full observability: errors + tracing + profiling + logs
 # ---------------------------------------------------------------------------
 # Active ONLY when SENTRY_DSN is set. In prod the DSN is injected from GCP Secret
 # Manager into the container env (startup.sh -> .env); it is intentionally NOT
-# committed to this repo. With no DSN (local/dev/CI) this whole block is a no-op,
-# so nothing breaks and nothing is sent.
+# committed to this repo. With no DSN (CI, or local without a DSN) this whole
+# block is a no-op. Set SENTRY_DSN in apps/api/.env to enable it locally too —
+# the environment is auto-tagged "development" when DEBUG is on.
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "").strip()
 if SENTRY_DSN:
+    import logging as _logging
+
     import sentry_sdk
+    from sentry_sdk.integrations.logging import LoggingIntegration
+
+
+    def _sentry_bool(name, default):
+        return os.environ.get(name, default).lower() in ("true", "1", "yes")
+
+    def _sentry_level(name, default):
+        return getattr(_logging, os.environ.get(name, default).upper(), _logging.INFO)
 
     sentry_sdk.init(
         dsn=SENTRY_DSN,
-        # The Django integration auto-enables; left implicit. Captures unhandled
-        # exceptions, request context, and (with tracing) per-request spans.
-        environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+        # The Django integration auto-enables (unhandled exceptions, request
+        # context, DB/cache/template spans). environment defaults to
+        # "development" in DEBUG, else "production"; override with SENTRY_ENVIRONMENT.
+        environment=os.environ.get("SENTRY_ENVIRONMENT")
+        or ("development" if DEBUG else "production"),
         release=os.environ.get("SENTRY_RELEASE") or None,
-        # Performance tracing: fraction of requests sampled (0.0–1.0).
-        traces_sample_rate=float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
-        # Attach user/email to events. Set SENTRY_SEND_PII=False to scrub PII.
-        send_default_pii=os.environ.get("SENTRY_SEND_PII", "True").lower()
-        in ("true", "1", "yes"),
+        # --- Performance tracing --- fraction of requests traced (0.0–1.0).
+        # Default 1.0 = trace everything; lower it (e.g. 0.2) to save quota.
+        traces_sample_rate=float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
+        # --- Profiling --- fraction of traced transactions profiled (CPU/line).
+        profiles_sample_rate=float(
+            os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", "1.0")
+        ),
+        # --- Structured logs (Sentry "Logs") --- forward Python logging to Sentry.
+        enable_logs=_sentry_bool("SENTRY_ENABLE_LOGS", "True"),
+        integrations=[
+            LoggingIntegration(
+                # >= this level recorded as breadcrumbs on events
+                level=_sentry_level("SENTRY_BREADCRUMB_LEVEL", "INFO"),
+                # >= this level also captured as standalone Sentry issues
+                event_level=_sentry_level("SENTRY_EVENT_LEVEL", "ERROR"),
+                # >= this level forwarded to the Sentry Logs product
+                sentry_logs_level=_sentry_level("SENTRY_LOGS_LEVEL", "INFO"),
+            ),
+        ],
+        # Attach user/email/request data. Set SENTRY_SEND_PII=False to scrub PII.
+        send_default_pii=_sentry_bool("SENTRY_SEND_PII", "True"),
     )

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -113,11 +113,14 @@ services:
       # suffix" error in prod.
       WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-localhost}
       WEBAUTHN_RP_NAME: ${WEBAUTHN_RP_NAME:-APILens}
-      # Sentry error + performance monitoring. DSN comes from GCP Secret Manager
-      # via startup.sh -> .env (never committed); empty = Sentry disabled (no-op).
+      # Sentry: errors + tracing + profiling + logs. DSN comes from GCP Secret
+      # Manager via startup.sh -> .env (never committed); empty = disabled (no-op).
+      # traces/profiles default to 1.0 (capture everything) — lower to save quota.
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.1}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-1.0}
+      SENTRY_PROFILES_SAMPLE_RATE: ${SENTRY_PROFILES_SAMPLE_RATE:-1.0}
+      SENTRY_ENABLE_LOGS: ${SENTRY_ENABLE_LOGS:-True}
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
Builds on #122. Upgrades the backend Sentry integration from errors-only to **full observability**, and enables it for **local dev** too.

## What
- **Tracing**: `traces_sample_rate` defaults to **1.0** (trace every request).
- **Profiling**: `profiles_sample_rate` (CPU/line profiling on traced transactions).
- **Logs**: `enable_logs=True` + `LoggingIntegration` → Python `logging` is forwarded to **Sentry Logs** (INFO→logs, INFO→breadcrumbs, ERROR→issues).
- **Local**: `.env.example` documents enabling Sentry locally (set `SENTRY_DSN`); auto-tagged `environment=development` under DEBUG.
- All tunable via `SENTRY_*` env (`SENTRY_LOGS_LEVEL`, `SENTRY_EVENT_LEVEL`, `SENTRY_PROFILES_SAMPLE_RATE`, …).

## Constraint preserved
DSN stays **only in GCP Secret Manager** (prod) / the gitignored local `.env`. Nothing in GitHub or CI.

## Verified
- Local: `sentry active: True | logs: True | env: development` — message + exception + structured log + stdlib log all flushed to the project.

## Deploy (after merge)
1. Merge → Deploy workflow rebuilds + ships the backend image (new settings).
2. `terraform apply` (pushes the updated compose metadata) + re-run VM startup (so the container gets the new `SENTRY_*` env).
3. Trigger a prod error/log → confirm traces + logs in Sentry.

> Note: traces/profiles at 1.0 capture **everything** — great for visibility, but watch Sentry quota; lower `SENTRY_TRACES_SAMPLE_RATE` to e.g. 0.2 if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)