### PR TITLE
Minimal SDK setup: single app-scoped API key (derive project + app)

### DIFF
--- a/apps/api/apps/auth/authentication.py
+++ b/apps/api/apps/auth/authentication.py
@@ -80,7 +80,7 @@ class ApiKeyAuth(APIKeyHeader):
             key_hash = hashlib.sha256(key.encode()).hexdigest()
             api_key = (
                 ApiKey.objects.active()
-                .select_related("project", "project__owner")
+                .select_related("project", "project__owner", "app")
                 .filter(
                     key_hash=key_hash,
                     project__is_active=True,
@@ -92,12 +92,16 @@ class ApiKeyAuth(APIKeyHeader):
                 return None
 
             user = api_key.project.owner
+            # App-scoped keys carry their app so ingestion needs only the key.
+            app_is_active = api_key.app is not None and api_key.app.is_active
             request.tenant_context = TenantContext(
                 tenant_id=str(user.id),
                 user_id=str(user.id),
                 email=user.email,
                 project_id=str(api_key.project_id),
                 project_slug=api_key.project.slug,
+                app_id=str(api_key.app_id) if app_is_active else "",
+                app_slug=api_key.app.slug if app_is_active else "",
             )
             request._auth_method = "api_key"
 

--- a/apps/api/apps/auth/models.py
+++ b/apps/api/apps/auth/models.py
@@ -137,6 +137,16 @@ class ApiKey(models.Model):
         on_delete=models.CASCADE,
         related_name="api_keys",
     )
+    # App-scoped keys bind directly to one app, so SDKs need only the key
+    # (project + app are derived server-side). Null = legacy project-scoped key
+    # that identifies the app per-record via app_id.
+    app = models.ForeignKey(
+        "projects.App",
+        on_delete=models.CASCADE,
+        related_name="api_keys",
+        null=True,
+        blank=True,
+    )
     key_hash = models.CharField(max_length=64, unique=True, db_index=True)
     prefix = models.CharField(max_length=16)
     name = models.CharField(max_length=100)

--- a/apps/api/apps/auth/services/api_keys.py
+++ b/apps/api/apps/auth/services/api_keys.py
@@ -10,7 +10,13 @@ from ._constants import API_KEY_PREFIX, MAX_API_KEYS_PER_PROJECT, hash_token
 
 class ApiKeyService:
     @staticmethod
-    def create_key(project, name: str) -> tuple[str, ApiKey]:
+    def create_key(project, name: str, app=None) -> tuple[str, ApiKey]:
+        """Create an API key.
+
+        Pass ``app`` to mint an app-scoped key: the server then derives both
+        project and app from the key alone, so SDKs only need the key. Omit it
+        for a legacy project-scoped key (app identified per-record via app_id).
+        """
         active_count = ApiKey.objects.for_project(project).count()
         if active_count >= MAX_API_KEYS_PER_PROJECT:
             raise RateLimitError(
@@ -23,11 +29,16 @@ class ApiKeyService:
 
         api_key = ApiKey.objects.create(
             project=project,
+            app=app,
             key_hash=hash_token(raw_key),
             prefix=prefix,
             name=name[:100],
         )
         return raw_key, api_key
+
+    @staticmethod
+    def list_keys_for_app(app) -> list[ApiKey]:
+        return list(ApiKey.objects.active().filter(app=app).order_by("-created_at"))
 
     @staticmethod
     def list_keys(project) -> list[ApiKey]:

--- a/apps/api/core/auth/context.py
+++ b/apps/api/core/auth/context.py
@@ -17,7 +17,11 @@ class TenantContext:
     email: str
     project_id: str = ""
     project_slug: str = ""
-    app_id: str = ""  # Deprecated: kept for backwards compatibility
+    # Set only for app-scoped API keys, so ingestion can derive the app from
+    # the key alone (no per-record app_id needed). Empty for JWT / legacy
+    # project-scoped keys.
+    app_id: str = ""
+    app_slug: str = ""
     role: str = "member"
     permissions: list[str] = field(default_factory=list)
 

--- a/apps/api/routers/ingest/router.py
+++ b/apps/api/routers/ingest/router.py
@@ -80,67 +80,79 @@ def resolve_app_identifiers(project_id: str, app_identifiers: set[str]) -> dict[
     return identifier_to_uuid
 
 
+def group_records_by_app(request: HttpRequest, records: list) -> dict[str, list]:
+    """Map each record to its target app UUID, grouped for batch insert.
+
+    - App-scoped API key: every record goes to the key's app (the SDK can omit
+      app_id/project_slug entirely). Any explicit id provided must still match.
+    - Legacy project-scoped key: each record must carry an app_id (UUID or slug)
+      resolved within the key's project, and project_slug must match.
+    """
+    ctx = request.tenant_context
+    if not ctx.project_id:
+        raise AuthenticationError("API key must be scoped to a project")
+
+    grouped: dict[str, list] = defaultdict(list)
+
+    if ctx.app_id:
+        for record in records:
+            rec_app = (record.app_id or "").strip()
+            if rec_app and rec_app not in (ctx.app_id, ctx.app_slug):
+                raise ValidationError(
+                    f"app_id must match the API key's app '{ctx.app_slug}'"
+                )
+            rec_project = (record.project_slug or "").strip()
+            if rec_project and rec_project != ctx.project_slug:
+                raise ValidationError(
+                    f"project_slug must match the API key project '{ctx.project_slug}'"
+                )
+            grouped[ctx.app_id].append(record)
+        return grouped
+
+    # Legacy project-scoped key: the app must be identified per record.
+    validate_project_slug(ctx.project_slug, {r.project_slug for r in records})
+    app_identifiers = {(r.app_id or "").strip() for r in records}
+    if "" in app_identifiers:
+        raise ValidationError("app_id is required for every record with a project-scoped key")
+    identifier_to_uuid = resolve_app_identifiers(ctx.project_id, app_identifiers)
+    for record in records:
+        grouped[identifier_to_uuid[record.app_id]].append(record)
+    return grouped
+
+
 @router.post("/requests", response=IngestResponse)
 def ingest_requests(request: HttpRequest, data: IngestRequest):
-    """
-    Ingest API request records.
-    API key provides project_id, payload provides app_id (UUID or slug) for each record.
+    """Ingest API request records.
+
+    App-scoped keys derive project + app from the key; project-scoped keys
+    identify the app per-record via app_id.
     """
     if len(data.requests) > MAX_BATCH_SIZE:
         raise ValidationError(f"Batch size exceeds maximum of {MAX_BATCH_SIZE}")
 
-    project_id = request.tenant_context.project_id
-    project_slug = request.tenant_context.project_slug
-    if not project_id:
-        raise AuthenticationError("API key must be scoped to a project")
-    validate_project_slug(project_slug, {record.project_slug for record in data.requests})
-
-    # Resolve app identifiers (UUID or slug) to UUIDs
-    app_identifiers = {record.app_id for record in data.requests}
-    identifier_to_uuid = resolve_app_identifiers(project_id, app_identifiers)
-
-    # Group records by resolved app UUID for batch processing
-    records_by_app = defaultdict(list)
-    for record in data.requests:
-        app_uuid = identifier_to_uuid[record.app_id]
-        records_by_app[app_uuid].append(record)
+    records_by_app = group_records_by_app(request, data.requests)
 
     total_accepted = 0
     for app_uuid, records in records_by_app.items():
-        accepted = IngestService.ingest(app_uuid, records)
-        total_accepted += accepted
+        total_accepted += IngestService.ingest(app_uuid, records)
 
     return IngestResponse(accepted=total_accepted)
 
 
 @router.post("/logs", response=IngestLogsResponse)
 def ingest_logs(request: HttpRequest, data: IngestLogsRequest):
-    """
-    Ingest application log records.
-    API key provides project_id, payload provides app_id (UUID or slug) for each log.
+    """Ingest application log records.
+
+    App-scoped keys derive project + app from the key; project-scoped keys
+    identify the app per-record via app_id.
     """
     if len(data.logs) > MAX_BATCH_SIZE:
         raise ValidationError(f"Batch size exceeds maximum of {MAX_BATCH_SIZE}")
 
-    project_id = request.tenant_context.project_id
-    project_slug = request.tenant_context.project_slug
-    if not project_id:
-        raise AuthenticationError("API key must be scoped to a project")
-    validate_project_slug(project_slug, {log.project_slug for log in data.logs})
-
-    # Resolve app identifiers (UUID or slug) to UUIDs
-    app_identifiers = {log.app_id for log in data.logs}
-    identifier_to_uuid = resolve_app_identifiers(project_id, app_identifiers)
-
-    # Group logs by resolved app UUID for batch processing
-    logs_by_app = defaultdict(list)
-    for log in data.logs:
-        app_uuid = identifier_to_uuid[log.app_id]
-        logs_by_app[app_uuid].append(log)
+    logs_by_app = group_records_by_app(request, data.logs)
 
     total_accepted = 0
     for app_uuid, logs in logs_by_app.items():
-        accepted = IngestService.ingest_logs(app_uuid, logs)
-        total_accepted += accepted
+        total_accepted += IngestService.ingest_logs(app_uuid, logs)
 
     return IngestLogsResponse(accepted=total_accepted)

--- a/apps/api/routers/ingest/schemas.py
+++ b/apps/api/routers/ingest/schemas.py
@@ -5,8 +5,10 @@ from ninja import Schema
 
 
 class RequestRecord(Schema):
-    project_slug: str  # Explicit project identifier (slug, required)
-    app_id: str  # Explicit app identifier (required)
+    # Optional: app-scoped API keys supply project + app server-side. Legacy
+    # project-scoped keys must still send app_id (and project_slug must match).
+    project_slug: str = ""
+    app_id: str = ""
     timestamp: datetime
     environment: str
     method: str
@@ -33,8 +35,10 @@ class IngestResponse(Schema):
 
 
 class LogRecord(Schema):
-    project_slug: str  # Explicit project identifier (slug, required)
-    app_id: str  # Explicit app identifier (required)
+    # Optional: app-scoped API keys supply project + app server-side. Legacy
+    # project-scoped keys must still send app_id (and project_slug must match).
+    project_slug: str = ""
+    app_id: str = ""
     timestamp: datetime
     environment: str
     level: str

--- a/apps/api/routers/projects/router.py
+++ b/apps/api/routers/projects/router.py
@@ -31,6 +31,7 @@ from .schemas import (
     CreateApiKeyRequest,
     CreateApiKeyResponse,
     ApiKeyResponse,
+    AppApiKeysListResponse,
     MessageResponse,
     LogsQueryResponse,
     RequestsQueryResponse,
@@ -159,6 +160,49 @@ def create_api_key(request: HttpRequest, project_slug: str, data: CreateApiKeyRe
         prefix=api_key.prefix,
         created_at=api_key.created_at,
     )
+
+
+@router.post("/{project_slug}/apps/{app_slug}/api-keys", response={201: CreateApiKeyResponse})
+def create_app_api_key(request: HttpRequest, project_slug: str, app_slug: str, data: CreateApiKeyRequest):
+    """Create an app-scoped API key.
+
+    The key derives both project and app server-side, so SDKs only need the key
+    (no project_slug / app_id required).
+    """
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    app = AppService.get_app_by_slug(project, app_slug)
+    raw_key, api_key = ApiKeyService.create_key(project, data.name.strip(), app=app)
+    return 201, CreateApiKeyResponse(
+        key=raw_key,
+        id=api_key.id,
+        name=api_key.name,
+        prefix=api_key.prefix,
+        created_at=api_key.created_at,
+    )
+
+
+@router.get("/{project_slug}/apps/{app_slug}/api-keys", response=AppApiKeysListResponse)
+def list_app_api_keys(request: HttpRequest, project_slug: str, app_slug: str):
+    """List the app-scoped API keys for an app."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    app = AppService.get_app_by_slug(project, app_slug)
+    keys = ApiKeyService.list_keys_for_app(app)
+    return AppApiKeysListResponse(keys=[ApiKeyResponse.from_orm(k) for k in keys])
+
+
+@router.delete("/{project_slug}/apps/{app_slug}/api-keys/{key_id}", response=MessageResponse)
+def revoke_app_api_key(request: HttpRequest, project_slug: str, app_slug: str, key_id: str):
+    """Revoke an app-scoped API key."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    # Confirm the app belongs to the user's project before revoking.
+    AppService.get_app_by_slug(project, app_slug)
+    success = ApiKeyService.revoke_key(project, key_id)
+    if not success:
+        return MessageResponse(message="API key not found or already revoked")
+    return MessageResponse(message="API key revoked successfully")
 
 
 @router.get("/{project_slug}/api-keys", response=list[ApiKeyResponse])

--- a/apps/api/routers/projects/schemas.py
+++ b/apps/api/routers/projects/schemas.py
@@ -157,6 +157,10 @@ class ApiKeyResponse(Schema):
         )
 
 
+class AppApiKeysListResponse(Schema):
+    keys: list[ApiKeyResponse]
+
+
 # ── Data Query Schemas ──────────────────────────────────────────────
 
 class LogItemResponse(Schema):

--- a/apps/web/src/components/apps/AppSetupGuide.tsx
+++ b/apps/web/src/components/apps/AppSetupGuide.tsx
@@ -19,136 +19,49 @@ const FRAMEWORK_OPTIONS: Record<
 
 const PYTHON_KEYWORDS = new Set(["from", "import", "app", "True", "False", "None"]);
 
-function getDefaultBaseUrl(): string {
-  // Telemetry ingestion is served on its own host, separate from the dashboard
-  // API (api.apilens.ai). SDKs POST to <ingest host>/v1/requests.
-  if (typeof window !== "undefined" && window.location.hostname === "localhost") {
-    return "http://localhost:8000/ingest/v1";
-  }
-  return "https://ingest.apilens.ai/v1";
-}
-
-function buildFrameworkSnippet(
-  framework: FrameworkId,
-  apiKey: string,
-  appSlug: string,
-  projectSlug?: string,
-  projectLabel?: string,
-): string {
-  const baseUrl = getDefaultBaseUrl();
-  const projectSlugValue = projectSlug?.trim() || "your-project-slug";
-  const projectComment = projectLabel?.trim()
-    ? framework === "express"
-      ? `// Project: ${projectLabel}\n// This API key must come from the same project.\n`
-      : `# Project: ${projectLabel}\n# This API key must come from the same project.\n`
-    : "";
-
+function buildFrameworkSnippet(framework: FrameworkId, apiKey: string): string {
+  // App-scoped key: the server derives project + app from the key, so the only
+  // value the SDK needs is the key itself. base_url defaults to the ingest host
+  // (override with APILENS_BASE_URL for local dev).
   if (framework === "express") {
-    return `${projectComment}import express from "express";
+    return `import express from "express";
 import { useApiLens } from "apilens-js-sdk/express";
 
 const app = express();
 app.use(express.json());
 
-useApiLens(app, {
-  // Project-scoped key for ${projectLabel || "this app's project"}
-  apiKey: "${apiKey}",
-  // Project slug from the dashboard
-  projectSlug: "${projectSlugValue}",
-  // App slug inside that project
-  appId: "${appSlug}",
-  baseUrl: "${baseUrl}",
-  environment: "production",
-  requestLogging: {
-    logRequestBody: true,
-    logResponseBody: true,
-    maxPayloadBytes: 8192,
-  },
-});`;
+useApiLens(app, { apiKey: "${apiKey}" });`;
   }
   if (framework === "fastapi") {
-    return `${projectComment}from fastapi import FastAPI
+    return `from fastapi import FastAPI
 from apilens.fastapi import ApiLensMiddleware
 
 app = FastAPI()
-
-app.add_middleware(
-    ApiLensMiddleware,
-    # Project-scoped key for ${projectLabel || "this app's project"}
-    api_key="${apiKey}",
-    # Project slug from the dashboard
-    project_slug="${projectSlugValue}",
-    # App slug inside that project
-    app_id="${appSlug}",
-    base_url="${baseUrl}",
-    env="production",
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
-)`;
+app.add_middleware(ApiLensMiddleware, api_key="${apiKey}")`;
   }
   if (framework === "flask") {
-    return `${projectComment}from flask import Flask
+    return `from flask import Flask
 from apilens import ApiLensClient, ApiLensConfig
 from apilens.flask import instrument_app
 
 app = Flask(__name__)
-
-client = ApiLensClient(
-    ApiLensConfig(
-        # Project-scoped key for ${projectLabel || "this app's project"}
-        api_key="${apiKey}",
-        project_slug="${projectSlugValue}",
-        base_url="${baseUrl}",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="${projectSlugValue}",
-    app_id="${appSlug}",
-)`;
+instrument_app(app, ApiLensClient(ApiLensConfig(api_key="${apiKey}")))`;
   }
   if (framework === "starlette") {
-    return `${projectComment}from starlette.applications import Starlette
+    return `from starlette.applications import Starlette
 from apilens import ApiLensClient, ApiLensConfig
 from apilens.starlette import instrument_app
 
 app = Starlette()
-
-client = ApiLensClient(
-    ApiLensConfig(
-        # Project-scoped key for ${projectLabel || "this app's project"}
-        api_key="${apiKey}",
-        project_slug="${projectSlugValue}",
-        base_url="${baseUrl}",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="${projectSlugValue}",
-    app_id="${appSlug}",
-)`;
+instrument_app(app, ApiLensClient(ApiLensConfig(api_key="${apiKey}")))`;
   }
-  return `${projectComment}# settings.py
+  return `# settings.py
 MIDDLEWARE = [
     # ...
     "apilens.django.ApiLensDjangoMiddleware",
 ]
 
-# Project-scoped key for ${projectLabel || "this app's project"}
-APILENS_API_KEY = "${apiKey}"
-# Project slug from the dashboard
-APILENS_PROJECT_SLUG = "${projectSlugValue}"
-# App slug inside that project
-APILENS_APP_ID = "${appSlug}"
-APILENS_BASE_URL = "${baseUrl}"
-APILENS_ENVIRONMENT = "production"`;
+APILENS_API_KEY = "${apiKey}"`;
 }
 
 function buildInstallCommand(framework: FrameworkId): string {
@@ -286,7 +199,7 @@ export default function AppSetupGuide({
   const installCmd = buildInstallCommand(framework);
   const projectLabel = projectName?.trim() || projectSlug;
   const projectSlugValue = projectSlug?.trim() || "your-project-slug";
-  const snippet = buildFrameworkSnippet(framework, apiKey, appSlug, projectSlug, projectLabel);
+  const snippet = buildFrameworkSnippet(framework, apiKey);
   const snippetLanguage = frameworkOption.packageLanguage === "python" ? "python" : "javascript";
 
   const copyText = async (text: string, item: "install" | "snippet" | "project-slug" | "app-id") => {

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -2,7 +2,17 @@
 
 Production-ready Python ingest client for API Lens with OpenTelemetry integration.
 
-> **⚠️ Breaking Change in v0.1.6:** Both `project_slug` and `app_id` are now required for all ingest paths. Make sure both match the same project in your dashboard.
+> **Minimal setup:** with an **app-scoped API key** (create one from the app's page in the dashboard), the only value you need is the key — the server derives the project and app from it:
+>
+> ```python
+> from fastapi import FastAPI
+> from apilens.fastapi import ApiLensMiddleware
+>
+> app = FastAPI()
+> app.add_middleware(ApiLensMiddleware, api_key="apilens_xxx")
+> ```
+>
+> `project_slug` / `app_id` are **optional** — provide them only with a legacy project-scoped key (one not bound to a single app). `base_url` defaults to `https://ingest.apilens.ai/v1`; set `APILENS_BASE_URL` to override for local dev.
 
 ## Framework support matrix
 

--- a/packages/sdk-python/apilens/client/client.py
+++ b/packages/sdk-python/apilens/client/client.py
@@ -44,8 +44,9 @@ class ApiLensClient:
     def __init__(self, config: ApiLensConfig, *, start_worker: bool = True) -> None:
         if not config.api_key:
             raise ValueError("api_key is required")
-        if not config.project_slug:
-            raise ValueError("project_slug is required")
+        # project_slug / app_id are optional: app-scoped API keys let the server
+        # derive both from the key alone. Provide them only for legacy
+        # project-scoped keys.
 
         if config.batch_size <= 0:
             raise ValueError("batch_size must be > 0")

--- a/packages/sdk-python/apilens/django.py
+++ b/packages/sdk-python/apilens/django.py
@@ -23,9 +23,8 @@ def _get_client_from_settings() -> ApiLensClient:
     api_key = getattr(settings, "APILENS_API_KEY", "")
     if not api_key:
         raise RuntimeError("APILENS_API_KEY is required in Django settings")
+    # Optional: app-scoped keys derive project + app server-side.
     project_slug = getattr(settings, "APILENS_PROJECT_SLUG", "")
-    if not project_slug:
-        raise RuntimeError("APILENS_PROJECT_SLUG is required in Django settings")
 
     cfg = ApiLensConfig(
         api_key=api_key,
@@ -47,10 +46,9 @@ class ApiLensDjangoMiddleware:
 
         self.get_response = get_response
         self.client = _get_client_from_settings()
+        # Optional: app-scoped keys derive project + app server-side.
         self.project_slug = getattr(settings, "APILENS_PROJECT_SLUG", "")
         self.app_id = getattr(settings, "APILENS_APP_ID", "")
-        if not self.app_id:
-            raise RuntimeError("APILENS_APP_ID is required in Django settings")
         self.max_payload_bytes = 8192
 
     def __call__(self, request):

--- a/packages/sdk-python/apilens/fastapi.py
+++ b/packages/sdk-python/apilens/fastapi.py
@@ -43,8 +43,7 @@ class ApiLensGatewayMiddleware(ApiLensASGIMiddleware):
         if client is None:
             if not resolved_key:
                 raise ValueError("api_key (or client_id) is required")
-            if not resolved_project_slug:
-                raise ValueError("project_slug is required")
+            # project_slug / app_id optional: app-scoped keys derive them server-side.
             client = ApiLensClient(
                 ApiLensConfig(
                     api_key=resolved_key,

--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -16,6 +16,8 @@ npm install ./packages/sdk-typescript
 
 ## Quick start
 
+> With an **app-scoped API key** the only required option is `apiKey` — the server derives the project and app from the key. `projectSlug` / `appId` are optional (legacy project-scoped keys only); `baseUrl` defaults to `https://ingest.apilens.ai/v1`.
+
 ```js
 import express from "express";
 import { useApiLens, setConsumer } from "apilens-js-sdk/express";

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -134,12 +134,8 @@ class ApiLensClient {
     if (!isNonEmptyString(this.config.apiKey)) {
       throw new Error("apiKey is required");
     }
-    if (!isNonEmptyString(this.config.projectSlug)) {
-      throw new Error("projectSlug is required");
-    }
-    if (!isNonEmptyString(this.config.appId)) {
-      throw new Error("appId is required");
-    }
+    // projectSlug / appId are optional: app-scoped API keys let the server
+    // derive both from the key alone. Set them only for legacy project-scoped keys.
 
     this.queue = [];
     this.droppedCount = 0;

--- a/sidecar-testing/README.md
+++ b/sidecar-testing/README.md
@@ -20,4 +20,4 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Set `APILENS_API_KEY`, `APILENS_PROJECT_SLUG`, and `APILENS_APP_ID` in `.env`, then run the app.
+Set `APILENS_API_KEY` (an app-scoped key) in `.env`, then run the app — the server derives the project and app from the key.

--- a/sidecar-testing/django-ninja/.env.example
+++ b/sidecar-testing/django-ninja/.env.example
@@ -1,8 +1,9 @@
+# Minimal: an app-scoped API key is all you need (project + app derived server-side).
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
-APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
+# Optional (legacy project-scoped keys only):
+# APILENS_PROJECT_SLUG=
+# APILENS_APP_ID=
 PORT=8013
 DJANGO_SECRET_KEY=sidecar-dev-key
 DJANGO_DEBUG=true

--- a/sidecar-testing/django-ninja/README.md
+++ b/sidecar-testing/django-ninja/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY in .env (an app-scoped key; project + app derived server-side)
 source .venv/bin/activate
 python manage.py migrate
 python manage.py runserver 0.0.0.0:${PORT:-8013}

--- a/sidecar-testing/django-ninja/project/settings.py
+++ b/sidecar-testing/django-ninja/project/settings.py
@@ -48,8 +48,7 @@ USE_TZ = True
 STATIC_URL = "/static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Minimal setup: an app-scoped API key is all you need — the server derives the
+# project and app from the key.
 APILENS_API_KEY = os.getenv("APILENS_API_KEY", "")
-APILENS_PROJECT_SLUG = os.getenv("APILENS_PROJECT_SLUG", "")
-APILENS_APP_ID = os.getenv("APILENS_APP_ID", "")
 APILENS_BASE_URL = os.getenv("APILENS_BASE_URL", "https://ingest.apilens.ai/v1")
-APILENS_ENVIRONMENT = os.getenv("APILENS_ENVIRONMENT", "development")

--- a/sidecar-testing/fastapi/.env.example
+++ b/sidecar-testing/fastapi/.env.example
@@ -1,6 +1,7 @@
+# Minimal: an app-scoped API key is all you need (project + app derived server-side).
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
-APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
+# Optional (legacy project-scoped keys only):
+# APILENS_PROJECT_SLUG=
+# APILENS_APP_ID=
 PORT=8011

--- a/sidecar-testing/fastapi/README.md
+++ b/sidecar-testing/fastapi/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY in .env (an app-scoped key; project + app derived server-side)
 source .venv/bin/activate
 uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8011} --reload
 ```

--- a/sidecar-testing/fastapi/app/main.py
+++ b/sidecar-testing/fastapi/app/main.py
@@ -11,16 +11,13 @@ load_dotenv(dotenv_path=env_path)
 
 app = FastAPI()
 
+# Minimal setup: an app-scoped API key is all you need — the server derives the
+# project and app from the key. (base_url just points this example at a local
+# backend; it defaults to https://ingest.apilens.ai/v1 in production.)
 app.add_middleware(
     ApiLensMiddleware,
     api_key=os.getenv("APILENS_API_KEY"),
-    project_slug=os.getenv("APILENS_PROJECT_SLUG"),
-    app_id=os.getenv("APILENS_APP_ID"),
     base_url=os.getenv("APILENS_BASE_URL", "http://localhost:8000/ingest/v1"),
-    env=os.getenv("APILENS_ENVIRONMENT", "production"),
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
 )
 
 @app.get("/v1/orders")

--- a/sidecar-testing/flask/.env.example
+++ b/sidecar-testing/flask/.env.example
@@ -1,6 +1,7 @@
+# Minimal: an app-scoped API key is all you need (project + app derived server-side).
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
-APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
+# Optional (legacy project-scoped keys only):
+# APILENS_PROJECT_SLUG=
+# APILENS_APP_ID=
 PORT=8012

--- a/sidecar-testing/flask/README.md
+++ b/sidecar-testing/flask/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY in .env (an app-scoped key; project + app derived server-side)
 source .venv/bin/activate
 python app/main.py
 ```

--- a/sidecar-testing/flask/app/main.py
+++ b/sidecar-testing/flask/app/main.py
@@ -10,21 +10,16 @@ load_dotenv()
 
 app = Flask(__name__)
 
+# Minimal setup: an app-scoped API key is all you need — the server derives the
+# project and app from the key.
 client = ApiLensClient(
     ApiLensConfig(
         api_key=os.getenv("APILENS_API_KEY", ""),
-        project_slug=os.getenv("APILENS_PROJECT_SLUG", ""),
         base_url=os.getenv("APILENS_BASE_URL", "https://ingest.apilens.ai/v1"),
-        environment=os.getenv("APILENS_ENVIRONMENT", "development"),
     )
 )
 
-instrument_app(
-    app,
-    client,
-    project_slug=os.getenv("APILENS_PROJECT_SLUG", ""),
-    app_id=os.getenv("APILENS_APP_ID", ""),
-)
+instrument_app(app, client)
 
 
 @app.get("/health")


### PR DESCRIPTION
## What & why
Make SDK integration **minimal** — with an **app-scoped API key** the server derives both project and app from the key, so setup is just the key:

```python
app.add_middleware(ApiLensMiddleware, api_key="apilens_xxx")
```

(`project_slug` / `app_id` are now optional — needed only for legacy project-scoped keys. `base_url` defaults to `https://ingest.apilens.ai/v1`.)

## Changes
**Backend**
- `ApiKey` gains a nullable `app` FK. Null = legacy project-scoped key (unchanged behavior).
- `ApiKeyService.create_key(project, name, app=None)` + `list_keys_for_app()`.
- Auth populates `TenantContext.app_id` / `app_slug` for app-scoped keys.
- Ingest: `project_slug`/`app_id` optional; router derives the app from the key when app-scoped (validates any explicit id matches), else falls back to per-record `app_id` (legacy).
- Mounted projects router gains **POST/GET/DELETE `/projects/{slug}/apps/{app_slug}/api-keys`** — fills the gap the frontend `AppApiKeysSection` already calls (app-keys UI was effectively broken).

**SDK (Python + TS)** — `project_slug`/`app_id` optional; `api_key` alone works. READMEs updated.

**Dashboard** — onboarding snippets reduced to a one-liner per framework.

## Verified locally (end-to-end)
- App-scoped key + **key-only** SDK → `POST /ingest/v1/requests` → **200** → row in ClickHouse with the correct app derived from the key.
- Legacy project-scoped key + `app_id` → **200** (backward compatible).
- App-scoped key + wrong `app_id` → **422**; legacy key without `app_id` → **422**.
- `manage.py check` clean; TS SDK vitest **8/8**; no new tsc errors.

## ⚠️ DEPLOY BLOCKER — migration handling
This adds an `ApiKey.app` column, but **migrations are gitignored repo-wide** (`.gitignore: **/migrations/`) and `apps/api/scripts/start.sh` runs only `migrate` (no `makemigrations`). So the CI-built image **won't include the migration**, and the column won't be created by the normal deploy. The prod schema currently persists via the data volume from earlier manual migrations.

To deploy this, pick one (your call — touches prod DB):
1. **Apply on the VM**: SSH in, `makemigrations apps_auth && migrate apps_auth` (matches how the stack already gets its schema).
2. **Start tracking migrations**: remove `**/migrations/` from `.gitignore`, commit all migration files, so future model changes deploy automatically (standard Django practice).

I did **not** force-commit the single migration file — without the rest of the (gitignored) chain it would break `migrate` on a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)