### PR TITLE
Project-level API key setup (drop required project_slug)

### DIFF
--- a/apps/api/routers/ingest/router.py
+++ b/apps/api/routers/ingest/router.py
@@ -18,12 +18,12 @@ MAX_BATCH_SIZE = 1000
 
 
 def validate_project_slug(authenticated_project_slug: str, payload_project_slugs: set[str]) -> None:
-    normalized = {slug.strip() for slug in payload_project_slugs}
     if not authenticated_project_slug:
         raise AuthenticationError("API key must be scoped to a project")
-    if not normalized or "" in normalized:
-        raise ValidationError("project_slug is required for every record")
-    if normalized != {authenticated_project_slug}:
+    # The API key is project-level, so project_slug is optional — the key
+    # already identifies the project. If any record does send one, it must match.
+    provided = {slug.strip() for slug in payload_project_slugs if slug and slug.strip()}
+    if provided and provided != {authenticated_project_slug}:
         raise ValidationError(
             f"project_slug must match the API key project '{authenticated_project_slug}'"
         )
@@ -35,6 +35,9 @@ def resolve_app_identifiers(project_id: str, app_identifiers: set[str]) -> dict[
     Returns a mapping of {identifier: uuid_string}.
     Raises ValidationError if any identifiers are invalid.
     """
+    if any(not (i or "").strip() for i in app_identifiers):
+        raise ValidationError("app_id is required for every record")
+
     # Separate UUIDs from slugs
     uuids = set()
     slugs = set()

--- a/apps/api/routers/ingest/schemas.py
+++ b/apps/api/routers/ingest/schemas.py
@@ -5,8 +5,10 @@ from ninja import Schema
 
 
 class RequestRecord(Schema):
-    project_slug: str  # Explicit project identifier (slug, required)
-    app_id: str  # Explicit app identifier (required)
+    # The API key is project-level, so project_slug is optional (derived from
+    # the key; validated only if sent). app_id selects which app in the project.
+    project_slug: str = ""
+    app_id: str
     timestamp: datetime
     environment: str
     method: str
@@ -33,8 +35,10 @@ class IngestResponse(Schema):
 
 
 class LogRecord(Schema):
-    project_slug: str  # Explicit project identifier (slug, required)
-    app_id: str  # Explicit app identifier (required)
+    # The API key is project-level, so project_slug is optional (derived from
+    # the key; validated only if sent). app_id selects which app in the project.
+    project_slug: str = ""
+    app_id: str
     timestamp: datetime
     environment: str
     level: str

--- a/apps/web/src/components/apps/AppSetupGuide.tsx
+++ b/apps/web/src/components/apps/AppSetupGuide.tsx
@@ -19,136 +19,62 @@ const FRAMEWORK_OPTIONS: Record<
 
 const PYTHON_KEYWORDS = new Set(["from", "import", "app", "True", "False", "None"]);
 
-function getDefaultBaseUrl(): string {
-  // Telemetry ingestion is served on its own host, separate from the dashboard
-  // API (api.apilens.ai). SDKs POST to <ingest host>/v1/requests.
-  if (typeof window !== "undefined" && window.location.hostname === "localhost") {
-    return "http://localhost:8000/ingest/v1";
-  }
-  return "https://ingest.apilens.ai/v1";
-}
-
 function buildFrameworkSnippet(
   framework: FrameworkId,
   apiKey: string,
   appSlug: string,
-  projectSlug?: string,
-  projectLabel?: string,
 ): string {
-  const baseUrl = getDefaultBaseUrl();
-  const projectSlugValue = projectSlug?.trim() || "your-project-slug";
-  const projectComment = projectLabel?.trim()
-    ? framework === "express"
-      ? `// Project: ${projectLabel}\n// This API key must come from the same project.\n`
-      : `# Project: ${projectLabel}\n# This API key must come from the same project.\n`
-    : "";
-
+  // The API key is project-level, so setup needs just the key + which app it's
+  // for (app_id). base_url defaults to https://ingest.apilens.ai/v1.
   if (framework === "express") {
-    return `${projectComment}import express from "express";
+    return `import express from "express";
 import { useApiLens } from "apilens-js-sdk/express";
 
 const app = express();
 app.use(express.json());
 
 useApiLens(app, {
-  // Project-scoped key for ${projectLabel || "this app's project"}
-  apiKey: "${apiKey}",
-  // Project slug from the dashboard
-  projectSlug: "${projectSlugValue}",
-  // App slug inside that project
-  appId: "${appSlug}",
-  baseUrl: "${baseUrl}",
-  environment: "production",
-  requestLogging: {
-    logRequestBody: true,
-    logResponseBody: true,
-    maxPayloadBytes: 8192,
-  },
+  apiKey: "${apiKey}",   // project-level key
+  appId: "${appSlug}",   // which app
 });`;
   }
   if (framework === "fastapi") {
-    return `${projectComment}from fastapi import FastAPI
+    return `from fastapi import FastAPI
 from apilens.fastapi import ApiLensMiddleware
 
 app = FastAPI()
-
 app.add_middleware(
     ApiLensMiddleware,
-    # Project-scoped key for ${projectLabel || "this app's project"}
-    api_key="${apiKey}",
-    # Project slug from the dashboard
-    project_slug="${projectSlugValue}",
-    # App slug inside that project
-    app_id="${appSlug}",
-    base_url="${baseUrl}",
-    env="production",
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
+    api_key="${apiKey}",   # project-level key
+    app_id="${appSlug}",   # which app
 )`;
   }
   if (framework === "flask") {
-    return `${projectComment}from flask import Flask
+    return `from flask import Flask
 from apilens import ApiLensClient, ApiLensConfig
 from apilens.flask import instrument_app
 
 app = Flask(__name__)
-
-client = ApiLensClient(
-    ApiLensConfig(
-        # Project-scoped key for ${projectLabel || "this app's project"}
-        api_key="${apiKey}",
-        project_slug="${projectSlugValue}",
-        base_url="${baseUrl}",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="${projectSlugValue}",
-    app_id="${appSlug}",
-)`;
+client = ApiLensClient(ApiLensConfig(api_key="${apiKey}"))
+instrument_app(app, client, app_id="${appSlug}")`;
   }
   if (framework === "starlette") {
-    return `${projectComment}from starlette.applications import Starlette
+    return `from starlette.applications import Starlette
 from apilens import ApiLensClient, ApiLensConfig
 from apilens.starlette import instrument_app
 
 app = Starlette()
-
-client = ApiLensClient(
-    ApiLensConfig(
-        # Project-scoped key for ${projectLabel || "this app's project"}
-        api_key="${apiKey}",
-        project_slug="${projectSlugValue}",
-        base_url="${baseUrl}",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="${projectSlugValue}",
-    app_id="${appSlug}",
-)`;
+client = ApiLensClient(ApiLensConfig(api_key="${apiKey}"))
+instrument_app(app, client, app_id="${appSlug}")`;
   }
-  return `${projectComment}# settings.py
+  return `# settings.py
 MIDDLEWARE = [
     # ...
     "apilens.django.ApiLensDjangoMiddleware",
 ]
 
-# Project-scoped key for ${projectLabel || "this app's project"}
-APILENS_API_KEY = "${apiKey}"
-# Project slug from the dashboard
-APILENS_PROJECT_SLUG = "${projectSlugValue}"
-# App slug inside that project
-APILENS_APP_ID = "${appSlug}"
-APILENS_BASE_URL = "${baseUrl}"
-APILENS_ENVIRONMENT = "production"`;
+APILENS_API_KEY = "${apiKey}"   # project-level key
+APILENS_APP_ID = "${appSlug}"   # which app`;
 }
 
 function buildInstallCommand(framework: FrameworkId): string {
@@ -286,7 +212,7 @@ export default function AppSetupGuide({
   const installCmd = buildInstallCommand(framework);
   const projectLabel = projectName?.trim() || projectSlug;
   const projectSlugValue = projectSlug?.trim() || "your-project-slug";
-  const snippet = buildFrameworkSnippet(framework, apiKey, appSlug, projectSlug, projectLabel);
+  const snippet = buildFrameworkSnippet(framework, apiKey, appSlug);
   const snippetLanguage = frameworkOption.packageLanguage === "python" ? "python" : "javascript";
 
   const copyText = async (text: string, item: "install" | "snippet" | "project-slug" | "app-id") => {

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -2,7 +2,19 @@
 
 Production-ready Python ingest client for API Lens with OpenTelemetry integration.
 
-> **⚠️ Breaking Change in v0.1.6:** Both `project_slug` and `app_id` are now required for all ingest paths. Make sure both match the same project in your dashboard.
+> **Easy setup:** your API key is **project-level**. You only need two values —
+> the project's `api_key` and the `app_id` of the app you're instrumenting.
+> (`project_slug` is no longer required — the server derives the project from the key.)
+>
+> ```python
+> from fastapi import FastAPI
+> from apilens.fastapi import ApiLensMiddleware
+>
+> app = FastAPI()
+> app.add_middleware(ApiLensMiddleware, api_key="apilens_xxx", app_id="orders-api")
+> ```
+>
+> `base_url` defaults to `https://ingest.apilens.ai/v1` (override with `APILENS_BASE_URL` for local dev).
 
 ## Framework support matrix
 
@@ -45,22 +57,27 @@ pip install ./packages/sdk-python
 pip install './packages/sdk-python[all]'
 ```
 
+## The two values you need
+
+- **`api_key`** — created on a project in the dashboard. It is **project-level**:
+  one key works for every app in that project.
+- **`app_id`** — the slug of the specific app you're instrumenting, so the SDK
+  knows which app the traffic belongs to.
+
+Find both in the [API Lens Dashboard](https://app.apilens.ai): the API key on the
+project's API-keys page, the app slug on the app's page.
+
 ## Quick start (manual capture)
 
 ```python
 from apilens import ApiLensClient, ApiLensConfig
 
 client = ApiLensClient(
-    ApiLensConfig(
-        api_key="your_app_api_key",
-        project_slug="your-project-slug",
-        base_url="https://ingest.apilens.ai/v1",
-        environment="production",
-    )
+    ApiLensConfig(api_key="apilens_xxx")  # project-level key
 )
 
 client.capture(
-    app_id="my-api-service",  # Required: App slug inside that project
+    app_id="orders-api",  # which app in the project
     method="GET",
     path="/health",
     status_code=200,
@@ -70,52 +87,24 @@ client.capture(
 client.shutdown(flush=True)
 ```
 
-### Getting your Project Slug and App ID
-
-You now need both:
-
-```python
-project_slug = "astra"
-app_id = "sidecar"
-```
-
-Use the project slug from the project page, and the app slug from the app page in that same project.
-
 ## FastAPI
 
 No OpenTelemetry instrumentation is required for endpoint + payload monitoring.
 
 ```python
 from fastapi import FastAPI
-from typing import Annotated
-from fastapi import Depends, Request
 from apilens.fastapi import ApiLensMiddleware, set_consumer
 
 app = FastAPI()
 
 app.add_middleware(
     ApiLensMiddleware,
-    api_key="your_app_api_key",      # Required: Your API key
-    project_slug="your-project-slug",  # Required: Project slug from dashboard
-    app_id="my-api-service",           # Required: App slug inside that project
-    base_url="https://ingest.apilens.ai/v1",
-    env="production",
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
+    api_key="apilens_xxx",   # project-level key
+    app_id="orders-api",     # which app
 )
-
-def identify_consumer(request: Request, user_id: Annotated[str, Depends(lambda: "user_123")]):
-    set_consumer(request, identifier=user_id, name="Demo User", group="starter")
-
-app.router.dependencies.append(Depends(identify_consumer))
-
-@app.get("/v1/orders")
-def list_orders():
-    return {"ok": True}
 ```
 
-**Environment Variables (Recommended):**
+**Environment variables (recommended):**
 
 ```python
 import os
@@ -127,15 +116,11 @@ app = FastAPI()
 app.add_middleware(
     ApiLensMiddleware,
     api_key=os.getenv("APILENS_API_KEY"),
-    project_slug=os.getenv("APILENS_PROJECT_SLUG"),
     app_id=os.getenv("APILENS_APP_ID"),
-    base_url=os.getenv("APILENS_BASE_URL", "https://ingest.apilens.ai/v1"),
-    env=os.getenv("APILENS_ENVIRONMENT", "production"),
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
 )
 ```
+
+Capture the calling consumer per request with `set_consumer(request, identifier=..., name=..., group=...)`.
 
 ## Starlette
 
@@ -145,22 +130,8 @@ from apilens import ApiLensClient, ApiLensConfig
 from apilens.starlette import instrument_app
 
 app = Starlette()
-
-client = ApiLensClient(
-    ApiLensConfig(
-        api_key="your_app_api_key",
-        project_slug="your-project-slug",
-        base_url="https://ingest.apilens.ai/v1",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="your-project-slug",
-    app_id="your_app_id"
-)
+client = ApiLensClient(ApiLensConfig(api_key="apilens_xxx"))
+instrument_app(app, client, app_id="orders-api")
 ```
 
 ## Flask
@@ -171,31 +142,13 @@ from apilens import ApiLensClient, ApiLensConfig
 from apilens.flask import instrument_app
 
 app = Flask(__name__)
-
-client = ApiLensClient(
-    ApiLensConfig(
-        api_key="your_app_api_key",
-        project_slug="your-project-slug",
-        base_url="https://ingest.apilens.ai/v1",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    project_slug="your-project-slug",
-    app_id="your_app_id"
-)
-
-@app.get("/v1/invoices")
-def invoices():
-    return {"ok": True}
+client = ApiLensClient(ApiLensConfig(api_key="apilens_xxx"))
+instrument_app(app, client, app_id="orders-api")
 ```
 
 ## Django (DRF + Django Ninja)
 
-Add middleware in Django settings:
+Add the middleware and two settings:
 
 ```python
 MIDDLEWARE = [
@@ -203,12 +156,8 @@ MIDDLEWARE = [
     "apilens.django.ApiLensDjangoMiddleware",
 ]
 
-# Required configuration
-APILENS_API_KEY = "your_app_api_key"
-APILENS_PROJECT_SLUG = "your-project-slug"
-APILENS_APP_ID = "your_app_id"
-APILENS_BASE_URL = "https://ingest.apilens.ai/v1"
-APILENS_ENVIRONMENT = "production"
+APILENS_API_KEY = "apilens_xxx"   # project-level key
+APILENS_APP_ID = "orders-api"     # which app
 ```
 
 ## Litestar
@@ -218,21 +167,8 @@ from litestar import Litestar
 from apilens import ApiLensClient, ApiLensConfig
 from apilens.litestar import ApiLensPlugin
 
-client = ApiLensClient(
-    ApiLensConfig(
-        api_key="your_app_api_key",
-        base_url="https://ingest.apilens.ai/v1",
-        environment="production",
-    )
-)
-
-app = Litestar(
-    route_handlers=[],
-    plugins=[ApiLensPlugin(
-        client=client,
-        app_id="your_app_id"  # Required: Your app ID from dashboard
-    )]
-)
+client = ApiLensClient(ApiLensConfig(api_key="apilens_xxx"))
+app = Litestar(route_handlers=[], plugins=[ApiLensPlugin(client=client, app_id="orders-api")])
 ```
 
 ## BlackSheep
@@ -243,29 +179,17 @@ from apilens import ApiLensClient, ApiLensConfig
 from apilens.blacksheep import instrument_app
 
 app = Application()
-
-client = ApiLensClient(
-    ApiLensConfig(
-        api_key="your_app_api_key",
-        base_url="https://ingest.apilens.ai/v1",
-        environment="production",
-    )
-)
-
-instrument_app(
-    app,
-    client,
-    app_id="your_app_id"  # Required: Your app ID from dashboard
-)
+client = ApiLensClient(ApiLensConfig(api_key="apilens_xxx"))
+instrument_app(app, client, app_id="orders-api")
 ```
 
 ## Configuration Options
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `api_key` | Yes | - | Your API key from API Lens dashboard |
-| `project_slug` | Yes | - | Your project slug from API Lens dashboard |
-| `app_id` | Yes | - | Your app slug inside that project |
+| `api_key` | Yes | - | Project-level API key from the dashboard |
+| `app_id` | Yes | - | Slug of the app being instrumented |
+| `project_slug` | No | derived from key | Only needed for clarity/validation; the key already identifies the project |
 | `base_url` | No | `https://ingest.apilens.ai/v1` | API Lens ingest endpoint |
 | `environment` | No | `production` | Environment name (e.g., production, staging, dev) |
 | `enable_request_logging` | No | `True` | Enable request/response logging |
@@ -281,66 +205,18 @@ instrument_app(
 
 ## Troubleshooting
 
-### 422 Unprocessable Entity Error
+### Data not appearing in the dashboard
 
-If you're getting 422 errors, make sure you've included both `project_slug` and `app_id`:
+1. Verify `api_key` is valid (and belongs to the right project).
+2. Verify `app_id` matches an app in that project.
+3. Ensure `base_url` points to the correct endpoint.
+4. Check application logs for SDK errors.
+5. Wait up to ~30s for data to appear (batching delay).
 
-```python
-# ❌ Old way (will fail)
-app.add_middleware(
-    ApiLensMiddleware,
-    api_key="your_key",
-)
+### 422 Unprocessable Entity
 
-# ✅ New way (required since v0.1.6)
-app.add_middleware(
-    ApiLensMiddleware,
-    api_key="your_key",
-    project_slug="your-project-slug",
-    app_id="your_app_id",
-)
-```
-
-### Finding Your Project Slug and App ID
-
-1. Log in to [API Lens Dashboard](https://app.apilens.ai)
-2. Open your project and copy the project slug
-3. Open the app inside that project and copy the app slug
-
-### Data Not Appearing in Dashboard
-
-1. Verify `project_slug` is correct
-2. Verify `app_id` is correct for that project
-3. Check that `api_key` is valid
-4. Ensure `base_url` points to the correct endpoint
-5. Check application logs for SDK errors
-6. Wait up to 30 seconds for data to appear (batching delay)
-
-## Migration from v0.1.5 to v0.1.6
-
-**Breaking change:** `project_slug` is now required alongside `app_id`.
-
-Update all middleware/client configurations to include `project_slug` and `app_id`:
-
-```python
-# Before (v0.1.5)
-client = ApiLensClient(ApiLensConfig(
-    api_key="...",
-))
-
-# After (v0.1.6)
-client = ApiLensClient(ApiLensConfig(
-    api_key="...",
-    project_slug="your-project-slug",
-))
-
-client.capture(
-    app_id="your_app_id",
-    method="GET",
-    path="/health",
-    # ...
-)
-```
+A 422 from the ingest endpoint usually means `app_id` is missing or doesn't match
+an app in your key's project. Set `app_id` to the app's slug from the dashboard.
 
 ## Support
 

--- a/packages/sdk-python/apilens/client/client.py
+++ b/packages/sdk-python/apilens/client/client.py
@@ -37,15 +37,15 @@ class ApiLensConfig:
     retry_backoff_max: float = 5.0
 
     enabled: bool = True
-    user_agent: str = "apilens-python-sdk/0.1.7"
+    user_agent: str = "apilens-python-sdk/0.1.8"
 
 
 class ApiLensClient:
     def __init__(self, config: ApiLensConfig, *, start_worker: bool = True) -> None:
         if not config.api_key:
             raise ValueError("api_key is required")
-        if not config.project_slug:
-            raise ValueError("project_slug is required")
+        # project_slug is optional: the API key is project-level, so the server
+        # derives the project from the key. You still pass app_id (which app).
 
         if config.batch_size <= 0:
             raise ValueError("batch_size must be > 0")

--- a/packages/sdk-python/apilens/django.py
+++ b/packages/sdk-python/apilens/django.py
@@ -23,9 +23,8 @@ def _get_client_from_settings() -> ApiLensClient:
     api_key = getattr(settings, "APILENS_API_KEY", "")
     if not api_key:
         raise RuntimeError("APILENS_API_KEY is required in Django settings")
+    # Optional: the project-level API key identifies the project server-side.
     project_slug = getattr(settings, "APILENS_PROJECT_SLUG", "")
-    if not project_slug:
-        raise RuntimeError("APILENS_PROJECT_SLUG is required in Django settings")
 
     cfg = ApiLensConfig(
         api_key=api_key,

--- a/packages/sdk-python/apilens/fastapi.py
+++ b/packages/sdk-python/apilens/fastapi.py
@@ -43,8 +43,7 @@ class ApiLensGatewayMiddleware(ApiLensASGIMiddleware):
         if client is None:
             if not resolved_key:
                 raise ValueError("api_key (or client_id) is required")
-            if not resolved_project_slug:
-                raise ValueError("project_slug is required")
+            # project_slug is optional: the project-level key identifies it.
             client = ApiLensClient(
                 ApiLensConfig(
                     api_key=resolved_key,

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apilenss"
-version = "0.1.7"
+version = "0.1.8"
 description = "API Lens Python SDK with OpenTelemetry-based ingest forwarding"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -134,9 +134,8 @@ class ApiLensClient {
     if (!isNonEmptyString(this.config.apiKey)) {
       throw new Error("apiKey is required");
     }
-    if (!isNonEmptyString(this.config.projectSlug)) {
-      throw new Error("projectSlug is required");
-    }
+    // projectSlug is optional: the API key is project-level, so the server
+    // derives the project from the key. appId selects which app in the project.
     if (!isNonEmptyString(this.config.appId)) {
       throw new Error("appId is required");
     }

--- a/sidecar-testing/README.md
+++ b/sidecar-testing/README.md
@@ -20,4 +20,4 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Set `APILENS_API_KEY`, `APILENS_PROJECT_SLUG`, and `APILENS_APP_ID` in `.env`, then run the app.
+Set `APILENS_API_KEY` (project-level) and `APILENS_APP_ID` in `.env`, then run the app.

--- a/sidecar-testing/django-ninja/.env.example
+++ b/sidecar-testing/django-ninja/.env.example
@@ -1,8 +1,7 @@
+# Project-level API key + which app it is for.
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
 APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
 PORT=8013
 DJANGO_SECRET_KEY=sidecar-dev-key
 DJANGO_DEBUG=true

--- a/sidecar-testing/django-ninja/README.md
+++ b/sidecar-testing/django-ninja/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY (project-level) and APILENS_APP_ID in .env
 source .venv/bin/activate
 python manage.py migrate
 python manage.py runserver 0.0.0.0:${PORT:-8013}

--- a/sidecar-testing/django-ninja/project/settings.py
+++ b/sidecar-testing/django-ninja/project/settings.py
@@ -48,8 +48,7 @@ USE_TZ = True
 STATIC_URL = "/static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# The API key is project-level, so you only need the key + which app it's for.
 APILENS_API_KEY = os.getenv("APILENS_API_KEY", "")
-APILENS_PROJECT_SLUG = os.getenv("APILENS_PROJECT_SLUG", "")
 APILENS_APP_ID = os.getenv("APILENS_APP_ID", "")
 APILENS_BASE_URL = os.getenv("APILENS_BASE_URL", "https://ingest.apilens.ai/v1")
-APILENS_ENVIRONMENT = os.getenv("APILENS_ENVIRONMENT", "development")

--- a/sidecar-testing/fastapi/.env.example
+++ b/sidecar-testing/fastapi/.env.example
@@ -1,6 +1,5 @@
+# Project-level API key + which app it is for.
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
 APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
 PORT=8011

--- a/sidecar-testing/fastapi/README.md
+++ b/sidecar-testing/fastapi/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY (project-level) and APILENS_APP_ID in .env
 source .venv/bin/activate
 uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8011} --reload
 ```

--- a/sidecar-testing/fastapi/app/main.py
+++ b/sidecar-testing/fastapi/app/main.py
@@ -11,16 +11,14 @@ load_dotenv(dotenv_path=env_path)
 
 app = FastAPI()
 
+# The API key is project-level, so you only need the key + which app it's for.
+# (base_url just points this example at a local backend; it defaults to
+# https://ingest.apilens.ai/v1 in production.)
 app.add_middleware(
     ApiLensMiddleware,
     api_key=os.getenv("APILENS_API_KEY"),
-    project_slug=os.getenv("APILENS_PROJECT_SLUG"),
     app_id=os.getenv("APILENS_APP_ID"),
     base_url=os.getenv("APILENS_BASE_URL", "http://localhost:8000/ingest/v1"),
-    env=os.getenv("APILENS_ENVIRONMENT", "production"),
-    enable_request_logging=True,
-    log_request_body=True,
-    log_response_body=True,
 )
 
 @app.get("/v1/orders")

--- a/sidecar-testing/flask/.env.example
+++ b/sidecar-testing/flask/.env.example
@@ -1,6 +1,5 @@
+# Project-level API key + which app it is for.
 APILENS_API_KEY=
-APILENS_PROJECT_SLUG=
 APILENS_APP_ID=
 APILENS_BASE_URL=http://localhost:8000/ingest/v1
-APILENS_ENVIRONMENT=development
 PORT=8012

--- a/sidecar-testing/flask/README.md
+++ b/sidecar-testing/flask/README.md
@@ -4,7 +4,7 @@ Run:
 
 ```bash
 cp .env.example .env
-# set APILENS_API_KEY, APILENS_PROJECT_SLUG, and APILENS_APP_ID in .env
+# set APILENS_API_KEY (project-level) and APILENS_APP_ID in .env
 source .venv/bin/activate
 python app/main.py
 ```

--- a/sidecar-testing/flask/app/main.py
+++ b/sidecar-testing/flask/app/main.py
@@ -10,21 +10,15 @@ load_dotenv()
 
 app = Flask(__name__)
 
+# The API key is project-level, so you only need the key + which app it's for.
 client = ApiLensClient(
     ApiLensConfig(
         api_key=os.getenv("APILENS_API_KEY", ""),
-        project_slug=os.getenv("APILENS_PROJECT_SLUG", ""),
         base_url=os.getenv("APILENS_BASE_URL", "https://ingest.apilens.ai/v1"),
-        environment=os.getenv("APILENS_ENVIRONMENT", "development"),
     )
 )
 
-instrument_app(
-    app,
-    client,
-    project_slug=os.getenv("APILENS_PROJECT_SLUG", ""),
-    app_id=os.getenv("APILENS_APP_ID", ""),
-)
+instrument_app(app, client, app_id=os.getenv("APILENS_APP_ID", ""))
 
 
 @app.get("/health")


### PR DESCRIPTION
## What & why
Your API key is **project-level**, so setup should need only the key + which app it's for. This drops the redundant `project_slug` requirement.

```python
app.add_middleware(ApiLensMiddleware, api_key="apilens_xxx", app_id="orders-api")
```

- `api_key` → identifies the project (one key per project, all its apps)
- `app_id` → which app in that project
- `project_slug` → no longer required (server derives project from the key; validated only if sent)

**No DB migration** (unlike the app-scoped approach in #125, which this supersedes).

## Changes
- **Backend**: ingest `project_slug` optional (validate-if-present); `app_id` still required (clear 422 if missing).
- **SDK (Python + TS)**: `project_slug`/`APILENS_PROJECT_SLUG` optional; `app_id` still required. `apilenss` 0.1.7 → **0.1.8**.
- **Docs**: rewrote the apilenss **PyPI README** around `api_key + app_id`; updated dashboard onboarding snippets + sidecar example apps.

## Verified locally
- Project-level key + `app_id` (no `project_slug`) → **200** → row in ClickHouse.
- Missing `app_id` → **422**; mismatched `project_slug` → **422**.
- Existing SDKs that still send `project_slug` + `app_id` → **200** (backward compatible).
- `manage.py check` clean; TS SDK vitest **8/8**.

## Rollout
Backend has no migration, so it deploys via the normal pipeline. After merge: CI builds + rolls the backend; then `apilens-sdk-v0.1.8` tag publishes the SDK + new README to PyPI (backend first so prod accepts the new contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)