### PR TITLE
Production-grade identity (auth) microservice: own host, OIDC, RFC 9457

### DIFF
--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -20,6 +20,15 @@ SECRET_KEY = os.environ.get(
 # SECRET_KEY (see core/auth/keys.py + core/auth/jwt.py).
 JWT_PRIVATE_KEY = os.environ.get("JWT_PRIVATE_KEY", "")
 
+# OIDC issuer/audience for access tokens (the identity service is the issuer).
+JWT_ISSUER = os.environ.get("JWT_ISSUER", "https://auth.apilens.ai")
+JWT_AUDIENCE = os.environ.get("JWT_AUDIENCE", "apilens-api")
+
+# Which Django URLconf this process serves: the default full app, or the
+# bounded identity (auth-only) surface. The identity container sets
+# ROOT_URLCONF=config.urls_identity.
+ROOT_URLCONF = os.environ.get("ROOT_URLCONF", "config.urls")
+
 DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
 
 ALLOWED_HOSTS = [
@@ -120,7 +129,8 @@ CORS_ALLOW_HEADERS = [
     "x-requested-with",
 ]
 
-ROOT_URLCONF = "config.urls"
+# ROOT_URLCONF is set above (env-driven: config.urls for the full app, or
+# config.urls_identity for the bounded identity service).
 
 TEMPLATES = [
     {

--- a/apps/api/config/urls_identity.py
+++ b/apps/api/config/urls_identity.py
@@ -1,0 +1,36 @@
+"""URLconf for the bounded **identity** service (auth.apilens.ai).
+
+Serves ONLY the identity/auth surface — no projects/users. Selected via
+ROOT_URLCONF=config.urls_identity in the identity container.
+
+Layout:
+  /.well-known/openid-configuration   OIDC discovery (at the issuer root)
+  /.well-known/jwks.json              public verification keys (root)
+  /v1/*                               the identity API (magic-link, passkey,
+                                      2FA, tokens, introspect, docs, livez/readyz)
+
+The legacy path api.apilens.ai/api/v1/auth/* is preserved by a Caddy rewrite
+(/api/v1/auth -> /v1) so existing clients keep working during the cutover.
+"""
+
+from django.conf import settings
+from django.http import JsonResponse
+from django.urls import path
+
+from routers.router import identity_api
+from core.auth import keys
+
+
+def _discovery(request):
+    return JsonResponse(keys.openid_configuration(getattr(settings, "JWT_ISSUER", "https://auth.apilens.ai")))
+
+
+def _jwks(request):
+    return JsonResponse(keys.jwks())
+
+
+urlpatterns = [
+    path(".well-known/openid-configuration", _discovery),
+    path(".well-known/jwks.json", _jwks),
+    path("v1/", identity_api.urls),
+]

--- a/apps/api/core/auth/jwt.py
+++ b/apps/api/core/auth/jwt.py
@@ -16,9 +16,16 @@ TWOFA_CHALLENGE_LIFETIME = timedelta(minutes=5)
 
 _REQUIRED_CLAIMS = ["sub", "email", "exp", "type"]
 
+# OIDC-style issuer/audience. The identity service is the issuer; the API is the
+# audience. Stamped on every token; validated when present (grace for tokens
+# issued before this rolled out — they simply omit the claims).
+JWT_ISSUER = getattr(settings, "JWT_ISSUER", "") or "https://auth.apilens.ai"
+JWT_AUDIENCE = getattr(settings, "JWT_AUDIENCE", "") or "apilens-api"
+
 
 def _encode(payload: dict[str, Any]) -> str:
     """Sign with RS256 when a JWT private key is configured, else legacy HS256."""
+    payload = {**payload, "iss": JWT_ISSUER, "aud": JWT_AUDIENCE}
     if keys.rsa_enabled():
         return jwt.encode(payload, keys.private_key(), algorithm="RS256", headers={"kid": keys.kid()})
     return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
@@ -28,17 +35,23 @@ def _decode(token: str) -> dict[str, Any]:
     """Verify by the token's own alg: RS256 → public key, HS256 → SECRET_KEY.
 
     Accepting both lets RS256 roll out while short-lived HS256 tokens drain.
+    iss/aud are validated only when present (grace for pre-rollout tokens).
     """
     alg = jwt.get_unverified_header(token).get("alg")
+    # We don't let PyJWT enforce aud (old tokens lack it); we check it ourselves.
+    opts = {"require": _REQUIRED_CLAIMS, "verify_aud": False}
     if alg == "RS256":
         if not keys.rsa_enabled():
             raise TokenInvalidError()
-        return jwt.decode(
-            token, keys.public_key(), algorithms=["RS256"], options={"require": _REQUIRED_CLAIMS}
-        )
-    return jwt.decode(
-        token, settings.SECRET_KEY, algorithms=["HS256"], options={"require": _REQUIRED_CLAIMS}
-    )
+        claims = jwt.decode(token, keys.public_key(), algorithms=["RS256"], options=opts)
+    else:
+        claims = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"], options=opts)
+
+    if "iss" in claims and claims["iss"] != JWT_ISSUER:
+        raise TokenInvalidError("Invalid token issuer")
+    if "aud" in claims and claims["aud"] != JWT_AUDIENCE:
+        raise TokenInvalidError("Invalid token audience")
+    return claims
 
 
 def create_access_token(payload: dict[str, Any]) -> str:

--- a/apps/api/core/auth/keys.py
+++ b/apps/api/core/auth/keys.py
@@ -80,3 +80,21 @@ def jwks() -> dict:
     """JWKS document for the public verification key (empty when RS256 is off)."""
     data = _load()
     return {"keys": [data["jwk"]]} if data else {"keys": []}
+
+
+def openid_configuration(issuer: str) -> dict:
+    """OIDC-style discovery document so resource servers can auto-locate the
+    JWKS + signing alg for token validation. We issue our own session/JWTs (not
+    third-party OAuth2), so only the verification-relevant fields are populated.
+    """
+    issuer = issuer.rstrip("/")
+    return {
+        "issuer": issuer,
+        "jwks_uri": f"{issuer}/.well-known/jwks.json",
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "token_endpoint_auth_signing_alg_values_supported": ["RS256"],
+        "response_types_supported": ["token"],
+        "subject_types_supported": ["public"],
+        "scopes_supported": ["openid", "email"],
+        "claims_supported": ["sub", "email", "iss", "aud", "exp", "iat", "type"],
+    }

--- a/apps/api/routers/router.py
+++ b/apps/api/routers/router.py
@@ -2,6 +2,7 @@ import logging
 
 from ninja import NinjaAPI
 from ninja.errors import AuthenticationError, ValidationError
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.db import IntegrityError, DatabaseError
 
@@ -94,7 +95,6 @@ from routers.auth.router import router as auth_router
 from routers.users.router import router as users_router
 from routers.projects.router import router as projects_router
 
-api.add_router("/auth", auth_router, tags=["Auth"])
 api.add_router("/users", users_router, tags=["Users"])
 api.add_router("/projects", projects_router, tags=["Projects"])
 
@@ -102,3 +102,77 @@ api.add_router("/projects", projects_router, tags=["Projects"])
 
 # Telemetry ingestion is NOT served here anymore — it's a separate service
 # (apps/ingest, served on ingest.apilens.ai). See infra/gcp/vm/startup.sh.
+# Authentication is NOT served here anymore either — it's the identity service
+# (apps auth surface, served on auth.apilens.ai). See identity_api below.
+
+
+# ---------------------------------------------------------------------------
+# Identity (IAM) API — the bounded auth-only surface served by the identity
+# service on auth.apilens.ai (config.urls_identity). Its own OpenAPI; errors as
+# RFC 9457 application/problem+json. Mounts ONLY the auth router.
+# ---------------------------------------------------------------------------
+def _problem(request: HttpRequest, *, status: int, title: str, detail, type_: str = "about:blank"):
+    """RFC 9457 problem+json. Includes a legacy `error` alias (= title) as an
+    extension member so existing clients that read {error, detail} keep working
+    during the cutover."""
+    from django.http import JsonResponse
+    body = {
+        "type": type_, "title": title, "status": status,
+        "detail": detail, "instance": request.path, "error": title,
+    }
+    return JsonResponse(body, status=status, content_type="application/problem+json")
+
+
+identity_api = NinjaAPI(
+    title="APILens Identity API",
+    version="1.0.0",
+    description="Authentication & identity (magic-link, passkey, 2FA, tokens, JWKS).",
+    urls_namespace="identity",
+    docs_url="/docs",
+    openapi_url="/openapi.json",
+)
+
+
+@identity_api.exception_handler(AppError)
+def _identity_app_error(request, exc):
+    return _problem(request, status=exc.status_code, title=exc.error_code, detail=exc.message)
+
+
+@identity_api.exception_handler(AuthenticationError)
+def _identity_auth_error(request, exc):
+    return _problem(request, status=401, title="authentication_error", detail="Authentication required")
+
+
+@identity_api.exception_handler(ValidationError)
+def _identity_validation_error(request, exc):
+    return _problem(request, status=422, title="validation_error", detail=exc.errors)
+
+
+@identity_api.exception_handler(Exception)
+def _identity_unhandled(request, exc):
+    logger.exception("Unhandled identity error: %s", exc)
+    return _problem(request, status=500, title="internal_error", detail="Something went wrong")
+
+
+@identity_api.get("/.well-known/openid-configuration", tags=["Discovery"])
+def openid_configuration(request: HttpRequest):
+    from core.auth import keys
+    return keys.openid_configuration(getattr(settings, "JWT_ISSUER", "https://auth.apilens.ai"))
+
+
+@identity_api.get("/livez", tags=["System"])
+def livez(request: HttpRequest):
+    return {"status": "ok"}
+
+
+@identity_api.get("/readyz", tags=["System"])
+def readyz(request: HttpRequest):
+    from django.db import connections
+    try:
+        connections["default"].cursor().execute("SELECT 1")
+    except Exception:
+        return identity_api.create_response(request, {"status": "not-ready"}, status=503)
+    return {"status": "ready"}
+
+
+identity_api.add_router("", auth_router, tags=["Auth"])

--- a/infra/gcp/terraform/compute.tf
+++ b/infra/gcp/terraform/compute.tf
@@ -51,6 +51,7 @@ resource "google_compute_instance" "app" {
     "apilens-app-site"             = local.app_site
     "apilens-api-site"             = local.api_site
     "apilens-ingest-site"          = local.ingest_site
+    "apilens-auth-site"            = local.auth_site
     "apilens-allowed-hosts"        = local.allowed_hosts
     "apilens-csrf-origins"         = local.csrf_trusted_origins
     "apilens-django-secret-id"     = google_secret_manager_secret.django_secret_key.secret_id

--- a/infra/gcp/terraform/locals.tf
+++ b/infra/gcp/terraform/locals.tf
@@ -11,6 +11,7 @@ locals {
   app_site    = var.app_domain != "" ? var.app_domain : ":80"
   api_site    = var.api_domain
   ingest_site = var.ingest_domain
+  auth_site   = var.auth_domain
 
   # Django ALLOWED_HOSTS + CSRF/CORS origins derived from the domains. Internal
   # service names (api/web) and loopback are appended in startup.sh.
@@ -18,12 +19,14 @@ locals {
     var.app_domain,
     var.api_domain,
     var.ingest_domain,
+    var.auth_domain,
     var.backend_allowed_hosts,
   ]))
 
   csrf_trusted_origins = join(",", compact([
     var.app_domain != "" ? "https://${var.app_domain}" : "",
     var.api_domain != "" ? "https://${var.api_domain}" : "",
+    var.auth_domain != "" ? "https://${var.auth_domain}" : "",
   ]))
 
   # WebAuthn / passkey Relying Party ID. The RP ID must equal the page's domain

--- a/infra/gcp/terraform/terraform.tfvars.example
+++ b/infra/gcp/terraform/terraform.tfvars.example
@@ -23,6 +23,7 @@ data_disk_size = 100
 app_domain    = "app.example.com"
 api_domain    = "api.example.com"
 ingest_domain = "ingest.example.com"
+auth_domain   = "auth.example.com"
 
 ssh_source_ranges = ["0.0.0.0/0"]
 

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -108,6 +108,19 @@ variable "ingest_domain" {
   default     = ""
 }
 
+variable "auth_domain" {
+  description = <<-EOT
+    Optional dedicated hostname for the identity (IAM) service, e.g.
+    "auth.apilens.ai". Serves the bounded auth surface (login, magic-link,
+    passkey, 2FA, JWT issuance, JWKS, OIDC discovery) from the identity
+    container. Caddy reverse-proxies it to identity:8000 and auto-provisions a
+    Let's Encrypt cert. Point this name's DNS A record at the `instance_ip`.
+    Requires app_domain to be set.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "image_tag" {
   description = "Container image tag the VM should run for the api + web images."
   type        = string

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -143,7 +143,17 @@ services:
     image: "${REGISTRY_BASE}/backend:${IMAGE_TAG:-latest}"
     restart: unless-stopped
     logging: *default-logging
-    environment: *api-env
+    environment:
+      # Bounded identity surface (auth + JWKS + discovery only) via the
+      # auth-only urlconf; everything else (DB, JWT key, email for magic-link,
+      # WebAuthn, introspect secret) comes from the shared api env.
+      <<: *api-env
+      ROOT_URLCONF: config.urls_identity
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/v1/livez',timeout=4).status==200 else 1)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -166,7 +176,7 @@ services:
       GUNICORN_WORKERS: "4"
       # Auth via the identity service's introspection endpoint (internal network)
       # instead of a direct key lookup. Same shared secret as identity.
-      APILENS_INTROSPECT_URL: "http://identity:8000/api/v1/auth/introspect"
+      APILENS_INTROSPECT_URL: "http://identity:8000/v1/introspect"
       INTERNAL_INTROSPECT_SECRET: ${INTERNAL_INTROSPECT_SECRET:-}
     depends_on:
       migrate:

--- a/infra/gcp/vm/startup.sh
+++ b/infra/gcp/vm/startup.sh
@@ -29,6 +29,7 @@ IMAGE_TAG="$(attr apilens-image-tag)"
 APP_SITE="$(attr apilens-app-site)"
 API_SITE="$(attr apilens-api-site)"
 INGEST_SITE="$(attr apilens-ingest-site)"
+AUTH_SITE="$(attr apilens-auth-site)"
 ALLOWED_HOSTS="$(attr apilens-allowed-hosts)"
 CSRF_ORIGINS="$(attr apilens-csrf-origins)"
 DJANGO_SECRET_ID="$(attr apilens-django-secret-id)"
@@ -169,8 +170,11 @@ ${API_SITE} {
 	handle /ingest/* {
 		respond 404
 	}
-	# Auth surface (login, JWT issuance + JWKS, introspection) -> identity service.
+	# Legacy auth path -> identity service (rewritten onto its canonical /v1/*).
+	# The identity service's own host is auth.apilens.ai; this alias keeps
+	# existing clients working during the cutover.
 	handle /api/v1/auth/* {
+		uri replace /api/v1/auth /v1
 		reverse_proxy identity:8000
 	}
 	# Everything else (dashboard control plane) -> core api.
@@ -190,6 +194,18 @@ if [[ -n "${INGEST_SITE}" ]]; then
 ${INGEST_SITE} {
 	encode gzip zstd
 	reverse_proxy ingest:8000
+}
+CADDY
+fi
+
+# Append the dedicated auth.<domain> site block — the identity (IAM) service.
+# Serves the OIDC discovery + JWKS at the root and the API under /v1/*.
+if [[ -n "${AUTH_SITE}" ]]; then
+  cat >> /opt/apilens/Caddyfile <<CADDY
+
+${AUTH_SITE} {
+	encode gzip zstd
+	reverse_proxy identity:8000
 }
 CADDY
 fi


### PR DESCRIPTION
Turns the identity service into a complete CNCF-aligned IAM microservice (reusing Django auth — no rewrite). Bounded auth-only API with its own OpenAPI, RFC 9457 `application/problem+json` errors, OIDC discovery + JWKS, iss/aud on tokens, livez/readyz probes, and a dedicated host `auth.apilens.ai` (legacy `api.apilens.ai/api/v1/auth/*` preserved via Caddy rewrite). Verified locally end-to-end. 🤖 Generated with [Claude Code](https://claude.com/claude-code)