### PR TITLE
feat(identity): first-class apps/identity service folder + frontend cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "apps/api/**"
+      - "apps/identity/**"
       - "apps/web/**"
       - "apps/ingest/**"
       - "pnpm-lock.yaml"
@@ -57,6 +58,30 @@ jobs:
           tags: |
             ${{ secrets.GCP_BACKEND_IMAGE_PATH }}:${{ github.sha }}
             ${{ secrets.GCP_BACKEND_IMAGE_PATH }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Identity (IAM) service (apps/identity). It is the backend image with the
+      # auth-only urlconf baked in, so it builds FROM the backend image we just
+      # pushed (BACKEND_IMAGE build-arg) — one source of truth, zero drift. Its
+      # image path is the same Artifact Registry repo with /identity instead of
+      # /backend. compose pulls ${REGISTRY_BASE}/identity.
+      - name: Derive identity image path
+        run: echo "IDENTITY_IMAGE_PATH=${GCP_BACKEND_IMAGE_PATH%/backend}/identity" >> "$GITHUB_ENV"
+        env:
+          GCP_BACKEND_IMAGE_PATH: ${{ secrets.GCP_BACKEND_IMAGE_PATH }}
+
+      - name: Build & push identity image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/identity
+          file: apps/identity/Dockerfile
+          push: true
+          build-args: |
+            BACKEND_IMAGE=${{ secrets.GCP_BACKEND_IMAGE_PATH }}:${{ github.sha }}
+          tags: |
+            ${{ env.IDENTITY_IMAGE_PATH }}:${{ github.sha }}
+            ${{ env.IDENTITY_IMAGE_PATH }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/apps/identity/Dockerfile
+++ b/apps/identity/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+# ============================================================================
+# APILens Identity (IAM) service image.
+#
+# Identity is NOT a separate codebase. It shares the Django `User` model and the
+# Postgres database with the core API (`Project.owner` FKs `User`), so it reuses
+# the backend image verbatim and only changes which urlconf Django loads:
+#
+#   ROOT_URLCONF=config.urls_identity  ->  bounded auth-only surface
+#     (login, magic-link, passkey, TOTP/2FA, JWT issuance, JWKS, OIDC discovery)
+#
+# Projects / users / analytics are NOT exposed here — those stay on the core API
+# (config.urls). The shared source of truth lives in apps/api; CI builds this
+# image FROM the freshly-pushed backend image (the BACKEND_IMAGE build-arg), so
+# there is exactly one copy of the auth code and zero drift.
+#
+# Everything else (entrypoint -> scripts/start.sh -> gunicorn config.wsgi,
+# EXPOSE 8000, the venv, DJANGO_SETTINGS_MODULE) is inherited from the backend
+# image unchanged.
+# ============================================================================
+ARG BACKEND_IMAGE
+FROM ${BACKEND_IMAGE}
+
+# Bound this container to the auth-only urlconf. config.urls_identity already
+# ships inside the backend image (apps/api/config/urls_identity.py); we only
+# flip the default ROOT_URLCONF so the identity container serves the IdP surface
+# without any compose-level override.
+ENV ROOT_URLCONF=config.urls_identity

--- a/apps/identity/README.md
+++ b/apps/identity/README.md
@@ -1,0 +1,67 @@
+# Identity (IAM) service — `apps/identity`
+
+The APILens **identity provider**. Owns authentication and token issuance for the
+whole platform and serves the dedicated host **`auth.apilens.ai`**.
+
+## What it does
+
+- Login & sign-up: passwordless **magic-link**, **passkey / WebAuthn**, password
+- **TOTP 2-factor** + backup codes + account recovery
+- **JWT issuance** — RS256 access tokens + DB-backed rotating refresh tokens
+- **JWKS** (`/.well-known/jwks.json`) and **OIDC discovery**
+  (`/.well-known/openid-configuration`) so other services verify tokens without
+  a shared secret
+- **API-key introspection** (`POST /v1/introspect`, internal-only) — the ingest
+  service calls this instead of querying the key table directly
+- Liveness/readiness probes (`/v1/livez`, `/v1/readyz`); RFC 9457
+  `application/problem+json` errors
+
+## Why this is a thin folder (and not its own codebase)
+
+`User` is Django's `AUTH_USER_MODEL` and `Project.owner` is a foreign key to it,
+so identity and the core API **share the same `User` data in Postgres**. Forking
+a separate auth codebase would duplicate the User model and every battle-tested
+auth flow (magic-link, passkey, TOTP, recovery) and invite drift.
+
+So identity is a **deployment role of the shared backend**: the source lives in
+`apps/api` (`apps/auth/*`, `routers/auth/*`, `core/auth/*`, `config/urls_identity.py`),
+and this folder is just the service's image definition. The `Dockerfile` builds
+`FROM` the backend image and flips `ROOT_URLCONF=config.urls_identity`, which
+bounds the exposed surface to auth-only. One source of truth, zero duplication,
+but still a first-class service: its own image (`${REGISTRY_BASE}/identity`), its
+own container, its own host, and its own OpenAPI.
+
+```
+apps/api        # shared Django backend  -> core API (config.urls)        -> api.apilens.ai
+apps/identity   # FROM backend + urlconf -> identity   (config.urls_identity) -> auth.apilens.ai
+apps/ingest     # standalone FastAPI     -> telemetry ingest               -> ingest.apilens.ai
+apps/web        # Next.js BFF                                               -> app.apilens.ai
+```
+
+## Build
+
+CI builds this image right after the backend image and passes the backend image
+ref as a build-arg:
+
+```bash
+docker build \
+  --build-arg BACKEND_IMAGE=<registry>/backend:<tag> \
+  -t <registry>/identity:<tag> \
+  apps/identity
+```
+
+`docker-compose.prod.yml` runs it as the `identity` service on the internal
+network; Caddy reverse-proxies `auth.apilens.ai` (and the legacy
+`api.apilens.ai/api/v1/auth/*` alias) to `identity:8000`.
+
+## Endpoints (served under `/v1`, OIDC docs at the root)
+
+| Path | Purpose |
+|------|---------|
+| `/.well-known/openid-configuration` | OIDC discovery |
+| `/.well-known/jwks.json` | Public signing keys (RS256) |
+| `/v1/magic-link`, `/v1/verify`, `/v1/refresh`, `/v1/logout` | Auth flows |
+| `/v1/passkey/*`, `/v1/2fa/*` | WebAuthn + TOTP |
+| `/v1/introspect` | API-key introspection (internal, shared-secret) |
+| `/v1/livez`, `/v1/readyz` | Health probes |
+| `/v1/docs`, `/v1/openapi.json` | Bounded auth-only API docs |

--- a/apps/web/src/app/api/auth/2fa/exchange/route.ts
+++ b/apps/web/src/app/api/auth/2fa/exchange/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createCipheriv, randomBytes, createHash } from "crypto";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 const COOKIE_NAME = "apilens_session";
 
 function encryptSession(data: object): string {
@@ -25,7 +30,7 @@ export async function POST(request: NextRequest) {
       || request.headers.get("x-real-ip")
       || "unknown";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/2fa/exchange`, {
+    const response = await fetch(`${AUTH_API_URL}/2fa/exchange`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/auth/identify/route.ts
+++ b/apps/web/src/app/api/auth/identify/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,7 +19,7 @@ export async function POST(request: NextRequest) {
       request.headers.get("x-real-ip") ||
       "";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/identify`, {
+    const response = await fetch(`${AUTH_API_URL}/identify`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createCipheriv, randomBytes, createHash } from "crypto";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 const COOKIE_NAME = "apilens_session";
 
 function encryptSession(data: object): string {
@@ -26,7 +31,7 @@ export async function POST(request: NextRequest) {
       || request.headers.get("x-real-ip")
       || "unknown";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/login`, {
+    const response = await fetch(`${AUTH_API_URL}/login`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 const COOKIE_NAME = "apilens_session";
 
 export async function POST() {
@@ -10,7 +15,7 @@ export async function POST() {
 
     if (session) {
       // Revoke refresh token on Django side
-      await fetch(`${DJANGO_API_URL}/auth/logout`, {
+      await fetch(`${AUTH_API_URL}/logout`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: session.refreshToken }),

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/magic-link`, {
+    const response = await fetch(`${AUTH_API_URL}/magic-link`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: body.email }),

--- a/apps/web/src/app/api/auth/passkey/login/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/login/options/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/passkey/login/options`, {
+    const response = await fetch(`${AUTH_API_URL}/passkey/login/options`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: body.email || null }),

--- a/apps/web/src/app/api/auth/passkey/login/verify/route.ts
+++ b/apps/web/src/app/api/auth/passkey/login/verify/route.ts
@@ -1,13 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { setSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
+
+// Core API base — the user lookup (/users/me) stays on the control-plane API,
+// not the identity service.
+const DJANGO_API_URL =
+  process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/passkey/login/verify`, {
+    const response = await fetch(`${AUTH_API_URL}/passkey/login/verify`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/apps/web/src/app/api/auth/password-reset/request/route.ts
+++ b/apps/web/src/app/api/auth/password-reset/request/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/password-reset/request`, {
+    const response = await fetch(`${AUTH_API_URL}/password-reset/request`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: body.email }),

--- a/apps/web/src/app/api/auth/password-reset/reset/route.ts
+++ b/apps/web/src/app/api/auth/password-reset/reset/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/password-reset/reset`, {
+    const response = await fetch(`${AUTH_API_URL}/password-reset/reset`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/apps/web/src/app/api/auth/password-reset/verify/route.ts
+++ b/apps/web/src/app/api/auth/password-reset/verify/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/password-reset/verify`, {
+    const response = await fetch(`${AUTH_API_URL}/password-reset/verify`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token: body.token }),

--- a/apps/web/src/app/api/auth/recovery/cancel/route.ts
+++ b/apps/web/src/app/api/auth/recovery/cancel/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -9,7 +14,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Token is required" }, { status: 400 });
     }
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/recovery/cancel`, {
+    const response = await fetch(`${AUTH_API_URL}/recovery/cancel`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token: body.token }),

--- a/apps/web/src/app/api/auth/recovery/confirm/route.ts
+++ b/apps/web/src/app/api/auth/recovery/confirm/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,7 +20,7 @@ export async function POST(request: NextRequest) {
       request.headers.get("x-real-ip") ||
       "";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/recovery/confirm`, {
+    const response = await fetch(`${AUTH_API_URL}/recovery/confirm`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/auth/recovery/request/route.ts
+++ b/apps/web/src/app/api/auth/recovery/request/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,7 +19,7 @@ export async function POST(request: NextRequest) {
       request.headers.get("x-real-ip") ||
       "";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/recovery/request`, {
+    const response = await fetch(`${AUTH_API_URL}/recovery/request`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/auth/recovery/status/route.ts
+++ b/apps/web/src/app/api/auth/recovery/status/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,7 +16,7 @@ export async function GET(request: NextRequest) {
     }
 
     const response = await fetch(
-      `${DJANGO_API_URL}/auth/recovery/status?token=${encodeURIComponent(token)}`,
+      `${AUTH_API_URL}/recovery/status?token=${encodeURIComponent(token)}`,
       { method: "GET" },
     );
 

--- a/apps/web/src/app/api/auth/verify/route.ts
+++ b/apps/web/src/app/api/auth/verify/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createCipheriv, randomBytes, createHash } from "crypto";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Identity (IAM) service base. In production AUTH_API_URL points at the
+// dedicated identity service (internal http://identity:8000/v1); when unset
+// it falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 const COOKIE_NAME = "apilens_session";
 
 function encryptSession(data: object): string {
@@ -25,7 +30,7 @@ export async function POST(request: NextRequest) {
       || request.headers.get("x-real-ip")
       || "unknown";
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/verify`, {
+    const response = await fetch(`${AUTH_API_URL}/verify`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3,6 +3,14 @@ import type { FrameworkId } from "@/types/app";
 
 const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
 
+// Identity (IAM) service base for token issuance/validation. In production
+// AUTH_API_URL points at the dedicated identity service (internal
+// http://identity:8000/v1); when unset it falls back to the core API's /auth
+// path so local dev is unchanged. (Authenticated settings calls — 2FA, etc. —
+// keep flowing through fetchDjango / the back-compat alias.)
+const AUTH_API_URL =
+  process.env.AUTH_API_URL || `${DJANGO_API_URL}/auth`;
+
 export interface ApiResponse<T> {
   data?: T;
   error?: string;
@@ -300,7 +308,7 @@ async function refreshTokens(
 
   refreshInflight = (async () => {
     try {
-      const response = await fetch(`${DJANGO_API_URL}/auth/refresh`, {
+      const response = await fetch(`${AUTH_API_URL}/refresh`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken }),
@@ -1004,7 +1012,7 @@ export const apiClient = {
 
   async validateSession(refreshToken: string): Promise<ApiResponse<{ valid: boolean }>> {
     try {
-      const response = await fetch(`${DJANGO_API_URL}/auth/validate`, {
+      const response = await fetch(`${AUTH_API_URL}/validate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken }),

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -65,11 +65,15 @@ services:
       NODE_ENV: production
       PORT: "3000"
       DJANGO_API_URL: http://api:8000/api/v1
+      # Auth/token calls go straight to the identity service over the internal
+      # network (not back out through the public auth host). Bounded to /v1.
+      AUTH_API_URL: http://identity:8000/v1
       SESSION_SECRET: ${SESSION_SECRET}
       # NOTE: NEXT_PUBLIC_API_URL is baked into the frontend image at BUILD
       # time (apps/web/Dockerfile + the deploy workflow). It is not set here.
     depends_on:
       - api
+      - identity
 
   api:
     image: "${REGISTRY_BASE}/backend:${IMAGE_TAG:-latest}"
@@ -140,15 +144,17 @@ services:
   # /api/v1/auth/* here (login, magic-link, passkey, JWT issuance + JWKS, API-key
   # introspection). A separate container isolates auth and lets it scale apart.
   identity:
-    image: "${REGISTRY_BASE}/backend:${IMAGE_TAG:-latest}"
+    # Dedicated identity (IAM) image, built from apps/identity (the backend
+    # image with ROOT_URLCONF=config.urls_identity baked in) — so the bounded
+    # auth-only surface is a property of the image, not a compose override.
+    image: "${REGISTRY_BASE}/identity:${IMAGE_TAG:-latest}"
     restart: unless-stopped
     logging: *default-logging
     environment:
-      # Bounded identity surface (auth + JWKS + discovery only) via the
-      # auth-only urlconf; everything else (DB, JWT key, email for magic-link,
-      # WebAuthn, introspect secret) comes from the shared api env.
+      # Everything the auth flows need (DB, JWT key, email for magic-link,
+      # WebAuthn, introspect secret) comes from the shared api env. The bounded
+      # surface itself is baked into the identity image (ROOT_URLCONF).
       <<: *api-env
-      ROOT_URLCONF: config.urls_identity
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/v1/livez',timeout=4).status==200 else 1)\""]
       interval: 15s


### PR DESCRIPTION
## What & why
You asked why there was no `apps/identity/` folder when every microservice should live under `apps/`. Fixed — identity is now a first-class service folder, and the frontend talks to it directly.

### `apps/identity/` (thin service, zero duplication)
Identity shares the Django `User` model + Postgres with core (`Project.owner` FKs `User`), so a separate codebase would duplicate every auth flow and invite drift. Instead:
- `apps/identity/Dockerfile` builds **`FROM` the backend image** and bakes `ROOT_URLCONF=config.urls_identity` → bounded **auth-only** surface (login, magic-link, passkey, 2FA, JWT/JWKS, OIDC discovery).
- Shared source stays in `apps/api` (one source of truth). But identity is now a real service: its own image (`${REGISTRY}/identity`), container, host (`auth.apilens.ai`), and OpenAPI.
- `apps/identity/README.md` documents the pattern.

```
apps/api        shared Django backend -> core API (config.urls)          -> api.apilens.ai
apps/identity   FROM backend + urlconf -> identity (config.urls_identity) -> auth.apilens.ai
apps/ingest     standalone FastAPI     -> telemetry ingest                -> ingest.apilens.ai
apps/web        Next.js BFF                                               -> app.apilens.ai
```

### CI + compose
- `deploy.yml`: builds & pushes `${REGISTRY}/identity` FROM the freshly-pushed backend image; `apps/identity/**` added to the path filter.
- compose: `identity` service runs the dedicated `${REGISTRY}/identity` image (urlconf baked into the image, no compose override).

### Frontend cutover
- All BFF auth route handlers + `api-client` token refresh/validate now hit **`AUTH_API_URL`** (the identity service) instead of the core `/auth` path.
- **Safe default**: unset → falls back to core `/auth`, so local dev is unchanged. The prod web container sets `AUTH_API_URL=http://identity:8000/v1` (internal network). User lookup (`/users/me`) stays on the core API.

## Verification
- Built identity image `FROM` backend; container serves **only** the auth surface (31 ops, OIDC discovery, `/v1/livez` → 200) and core endpoints return **404**.
- `docker compose config` validates.
- `tsc --noEmit` on `apps/web` — no type errors.

## Deploy (gated prod steps)
compose/env come from instance metadata, so rollout = merge (CI builds the `identity` image) → `terraform apply` (new compose metadata) → re-run `startup.sh` on the VM. Back-compat alias `api.apilens.ai/api/v1/auth/*` stays, so no downtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)