### PR TITLE
fix(dev): serve auth surface on the core runserver in DEBUG

### DIFF
--- a/apps/api/config/urls.py
+++ b/apps/api/config/urls.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import path, include
 
-from routers.router import api
+from routers.router import api, identity_api
 
 
 def root(request):
@@ -25,10 +25,21 @@ def root(request):
 urlpatterns = [
     path("", root),
     path("admin/", admin.site.urls),
-    # Control plane (dashboard backend) — served on api.apilens.ai.
-    # Telemetry ingestion lives in the separate apps/ingest service.
-    path("api/v1/", api.urls),
 ]
+
+if settings.DEBUG:
+    # Local-dev convenience: serve the identity/auth surface (magic-link,
+    # passkey, 2FA, tokens, JWKS, OIDC discovery) at /api/v1/auth/* so a single
+    # `manage.py runserver` runs the WHOLE app on :8000 and the frontend's
+    # default AUTH_API_URL (= ${DJANGO_API_URL}/auth) resolves here. Listed
+    # BEFORE the core mount so /api/v1/auth/* routes to identity. In production
+    # auth is a SEPARATE service (config.urls_identity / auth.apilens.ai) and
+    # the core API does NOT expose /auth.
+    urlpatterns += [path("api/v1/auth/", identity_api.urls)]
+
+# Control plane (dashboard backend) — served on api.apilens.ai.
+# Telemetry ingestion lives in the separate apps/ingest service.
+urlpatterns += [path("api/v1/", api.urls)]
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Problem
Running the frontend + a single `manage.py runserver` locally, login broke:
```
Identify error: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
  at async POST (src/app/api/auth/identify/route.ts)
POST /api/auth/identify 500
```
After the auth split, the core urlconf (`config.urls`) no longer serves `/auth` (it moved to the identity service / `config.urls_identity`). But local dev runs **one** server, so the BFF's `http://localhost:8000/api/v1/auth/*` calls hit Django's **HTML 404** → `response.json()` throws.

## Fix
In **DEBUG only**, mount `identity_api` at `/api/v1/auth/*` (before the core mount) so a single `runserver` serves the whole app and the frontend's default `AUTH_API_URL` (= `${DJANGO_API_URL}/auth`) resolves.

**Production is unaffected**: `DEBUG=False`, so auth stays a separate service (`auth.apilens.ai`) and the core API does **not** expose `/auth`.

## Verification (local)
- `POST /api/v1/auth/identify` → `200` JSON `{"method":"no_account",...}`
- `POST /api/v1/auth/magic-link` → resolves (`200`)
- core `GET /api/v1/projects/` → `401 application/problem+json` (unchanged)
- `manage.py check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)