### PR TITLE
fix(api): allow internal docker hostnames in ALLOWED_HOSTS (fixes prod login 500)

### DIFF
--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -40,6 +40,15 @@ ALLOWED_HOSTS = [
 if DEBUG:
     ALLOWED_HOSTS += [".ngrok-free.app", ".ngrok.io"]
 
+# Internal docker-network hostnames used for container-to-container traffic
+# (the web BFF -> api/identity/ingest) and container healthchecks (localhost).
+# These are never publicly routable, so always allow them — otherwise Django
+# rejects internal requests with 400 DisallowedHost even when
+# DJANGO_ALLOWED_HOSTS lists only the public domains, which silently breaks the
+# BFF->service calls and the healthchecks.
+ALLOWED_HOSTS += ["localhost", "127.0.0.1", "api", "identity", "ingest"]
+ALLOWED_HOSTS = list(dict.fromkeys(ALLOWED_HOSTS))  # de-dupe, keep order
+
 if not DEBUG and SECRET_KEY == "django-insecure-change-me-in-production":
     raise RuntimeError("DJANGO_SECRET_KEY must be set to a strong value in production")
 


### PR DESCRIPTION
## Root cause (finally nailed it)
Prod `DJANGO_ALLOWED_HOSTS` = the 4 public domains only (`backend_allowed_hosts=""` in tfvars). But the **web BFF talks to services over the internal docker network by service name** (`http://identity:8000`, `http://api:8000`), and healthchecks hit `localhost:8000`. With `DEBUG=False`, Django rejected those with **`400 DisallowedHost` (HTML)** → the BFF's `response.json()` threw `Unexpected token '<'` → **`500`**.

This is why login (web→identity) AND the internal core calls AND the container healthchecks were all failing — and why my earlier image/env fixes (all correct) still didn't surface it: the missing piece was on the **receiving** Django side, not the caller.

Reproduced with the real backend image + prod's exact `ALLOWED_HOSTS`:
- `Host: identity:8000` → **400** (HTML DisallowedHost)
- `Host: auth.apilens.ai` → got past the host check

## Fix
Always allow the non-routable internal hostnames (`api`, `identity`, `ingest`, `localhost`, `127.0.0.1`) on top of whatever `DJANGO_ALLOWED_HOSTS` lists. Deploys via the normal image roll — no gated infra.

## Verification (prod's exact ALLOWED_HOSTS)
- `Host: identity:8000` → `/v1/livez` **200**, `/v1/identify` **200**
- `Host: localhost:8000` → **200** (healthcheck fixed)
- `Host: evil.example.com` → **400** (security intact)

After merge, CI rebuilds the backend + identity images and `deploy.sh` rolls them → web→identity passes → login works. I'll verify live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)