### PR TITLE
fix(web): route account passkey + 2FA calls to identity (fix 'Failed to generate registration options')

### DIFF
--- a/apps/web/src/app/api/account/passkeys/[id]/route.ts
+++ b/apps/web/src/app/api/account/passkeys/[id]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Auth/identity calls go to the identity service (AUTH_API_URL); default
+// falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function DELETE(
   request: NextRequest,
@@ -16,7 +20,7 @@ export async function DELETE(
     const { id } = await params;
 
     const response = await fetch(
-      `${DJANGO_API_URL}/auth/passkey/credentials/${id}`,
+      `${AUTH_API_URL}/passkey/credentials/${id}`,
       {
         method: "DELETE",
         headers: {

--- a/apps/web/src/app/api/account/passkeys/register/options/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/options/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession, setSession, clearSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Auth/identity calls go to the identity service (AUTH_API_URL); default
+// falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 async function refreshAccessToken(refreshToken: string): Promise<{ access_token: string; refresh_token: string } | null> {
   try {
-    const response = await fetch(`${DJANGO_API_URL}/auth/refresh`, {
+    const response = await fetch(`${AUTH_API_URL}/refresh`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refresh_token: refreshToken }),
@@ -25,7 +29,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    let response = await fetch(`${DJANGO_API_URL}/auth/passkey/register/options`, {
+    let response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -46,7 +50,7 @@ export async function POST(request: NextRequest) {
 
       console.log("Token refreshed successfully, retrying request...");
       // Retry with new token
-      response = await fetch(`${DJANGO_API_URL}/auth/passkey/register/options`, {
+      response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/apps/web/src/app/api/account/passkeys/register/verify/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/verify/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Auth/identity calls go to the identity service (AUTH_API_URL); default
+// falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,7 +18,7 @@ export async function POST(request: NextRequest) {
     console.log("Verify request - challenge received:", body.challenge);
     console.log("Verify request - credential ID:", body.credential?.id);
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/passkey/register/verify`, {
+    const response = await fetch(`${AUTH_API_URL}/passkey/register/verify`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/web/src/app/api/account/passkeys/route.ts
+++ b/apps/web/src/app/api/account/passkeys/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/session";
 
-const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+// Auth/identity calls go to the identity service (AUTH_API_URL); default
+// falls back to the core API's /auth path so local dev is unchanged.
+const AUTH_API_URL =
+  process.env.AUTH_API_URL ||
+  `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,7 +14,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const response = await fetch(`${DJANGO_API_URL}/auth/passkey/credentials`, {
+    const response = await fetch(`${AUTH_API_URL}/passkey/credentials`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${session.accessToken}`,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -245,7 +245,12 @@ async function fetchDjango<T>(
     return { error: "Not authenticated", status: 401 };
   }
 
-  const url = `${DJANGO_API_URL}${endpoint}`;
+  // Auth/identity endpoints (2FA, etc.) live on the identity service, not the
+  // core API. Route "/auth/*" to AUTH_API_URL (dropping the "/auth" segment,
+  // since AUTH_API_URL is already the auth base); everything else -> core.
+  const url = endpoint.startsWith("/auth/")
+    ? `${AUTH_API_URL}${endpoint.slice("/auth".length)}`
+    : `${DJANGO_API_URL}${endpoint}`;
 
   try {
     let response = await fetch(url, {


### PR DESCRIPTION
## Problem
The account settings section was broken: **"Failed to generate registration options"** when adding a passkey, and 2FA actions failing. These BFF routes still called `${DJANGO_API_URL}/auth/*` → the **core** API, which no longer serves `/auth` after the auth split → 404.

## Fix
- `account/passkeys/*` (list, delete, register/options, register/verify) → use `AUTH_API_URL` (identity) instead of core `/auth`.
- `api-client.fetchDjango` now routes any `"/auth/*"` endpoint to `AUTH_API_URL` (so the 2FA calls hit identity); `/users/me`, `/projects`, etc. still go to core.
- Default `AUTH_API_URL` still falls back to core `/auth` for local dev (served there via the DEBUG mount) — dev unchanged.

WebAuthn config verified correct: `RP_ID=apilens.ai`, `RP_ORIGIN=https://app.apilens.ai`, so passkey option generation/verification work once routing is fixed.

`tsc --noEmit` clean.

## After merge
CI rolls the frontend image → adding a passkey + 2FA in account settings work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)