### PR TITLE
feat(infra): serve core + identity under app.apilens.ai paths; retire api/auth subdomains

### DIFF
--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -21,7 +21,7 @@ SECRET_KEY = os.environ.get(
 JWT_PRIVATE_KEY = os.environ.get("JWT_PRIVATE_KEY", "")
 
 # OIDC issuer/audience for access tokens (the identity service is the issuer).
-JWT_ISSUER = os.environ.get("JWT_ISSUER", "https://auth.apilens.ai")
+JWT_ISSUER = os.environ.get("JWT_ISSUER") or "https://app.apilens.ai"
 JWT_AUDIENCE = os.environ.get("JWT_AUDIENCE", "apilens-api")
 
 # Which Django URLconf this process serves: the default full app, or the

--- a/infra/gcp/vm/Caddyfile
+++ b/infra/gcp/vm/Caddyfile
@@ -25,11 +25,30 @@
 {$APP_SITE} {
 	encode gzip zstd
 
-	@backend path /api/v1/* /admin/* /static/* /media/*
-	handle @backend {
+	# Identity (IAM) service — served under app.apilens.ai instead of a separate
+	# auth.* host. OIDC discovery + JWKS live at the well-known root (so the
+	# issuer = https://app.apilens.ai), and the auth API is under /auth/v1/*
+	# (rewritten onto the service's canonical /v1/*).
+	handle /.well-known/openid-configuration {
+		reverse_proxy identity:8000
+	}
+	handle /.well-known/jwks.json {
+		reverse_proxy identity:8000
+	}
+	handle /auth/v1/* {
+		uri replace /auth/v1 /v1
+		reverse_proxy identity:8000
+	}
+
+	# Core control-plane API + Django admin/static/media.
+	@core path /api/v1/* /admin/* /static/* /media/*
+	handle @core {
 		reverse_proxy api:8000
 	}
 
+	# Everything else: the Next.js app + its OWN server route handlers under
+	# /api/* (e.g. /api/auth/magic-link, /api/account/*, /api/projects) which
+	# proxy to the services server-side. Routing those to Django would 404 them.
 	handle {
 		reverse_proxy web:3000
 	}

--- a/infra/gcp/vm/docker-compose.prod.yml
+++ b/infra/gcp/vm/docker-compose.prod.yml
@@ -89,6 +89,10 @@ services:
       # from Secret Manager via startup.sh -> .env; empty falls back to HS256.
       JWT_PRIVATE_KEY: ${JWT_PRIVATE_KEY:-}
       INTERNAL_INTROSPECT_SECRET: ${INTERNAL_INTROSPECT_SECRET:-}
+      # IdP issuer (token `iss` + OIDC discovery). Defaults to the app origin
+      # now that identity is served under app.apilens.ai; falls back in-app to
+      # https://auth.apilens.ai if unset.
+      JWT_ISSUER: ${JWT_ISSUER:-}
       # Authorization decisions delegated to the OPA policy engine (sidecar).
       OPA_URL: ${OPA_URL:-http://opa:8181/v1/data/apilens/authz/allow}
       FRONTEND_URL: ${FRONTEND_URL}

--- a/infra/gcp/vm/startup.sh
+++ b/infra/gcp/vm/startup.sh
@@ -238,10 +238,13 @@ IMAGE_TAG=${IMAGE_TAG}
 APP_SITE=${APP_SITE}
 API_SITE=${API_SITE}
 INGEST_SITE=${INGEST_SITE}
-DJANGO_ALLOWED_HOSTS=${ALLOWED_HOSTS},api,web,localhost,127.0.0.1
+DJANGO_ALLOWED_HOSTS=${ALLOWED_HOSTS},api,identity,ingest,web,localhost,127.0.0.1
 CSRF_TRUSTED_ORIGINS=${CSRF_ORIGINS}
 CORS_ALLOWED_ORIGINS=${CORS_ORIGINS}
 FRONTEND_URL=${FRONTEND_URL}
+# IdP issuer = the app's public origin now that identity is served under
+# app.apilens.ai (/.well-known/* + /auth/v1/*) instead of a separate auth.* host.
+JWT_ISSUER=${FRONTEND_URL}
 MEDIA_BUCKET=${MEDIA_BUCKET}
 GS_PROJECT_ID=${PROJECT_ID}
 DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}


### PR DESCRIPTION
## Goal
Collapse all UI-facing services onto **one host** (`app.apilens.ai`); only **ingest** keeps its own domain (SDK traffic, no UI). Matches the requested structure.

```
app.apilens.ai/            -> web (UI) + Next BFF (/api/auth/*, /api/account/*, ...)
app.apilens.ai/api/v1/*    -> core API
app.apilens.ai/auth/v1/*   -> identity (rewritten to /v1/*)
app.apilens.ai/.well-known/openid-configuration|jwks.json -> identity
ingest.apilens.ai/*        -> ingest (SDKs only)
# api.apilens.ai + auth.apilens.ai retired
# JWT issuer -> https://app.apilens.ai
```

## Changes
- **Caddy (app_site)**: route `/.well-known/*` + `/auth/v1/*` → identity, `/api/v1/*` + admin/static/media → core, everything else → web. Caddy sorts `handle` by specificity, so the auth/well-known paths win over the catch-all.
- **JWT issuer = app origin**: `startup.sh` writes `JWT_ISSUER=${FRONTEND_URL}`, compose passes `JWT_ISSUER` to api+identity, settings.py falls back to `https://app.apilens.ai` (empty env treated as unset). OIDC discovery + token `iss` + `jwks_uri` all under `app.apilens.ai`.
- **ALLOWED_HOSTS** `.env` line also includes `identity,ingest`.
- **terraform.tfvars** (local, gitignored): `api_domain=""`, `auth_domain=""` → Caddy stops emitting those site blocks.

The browser BFF already used the internal network (`identity:8000`/`api:8000`), so the UI is unaffected — this just collapses the public surface.

## Validation
- `caddy validate` OK · `terraform validate` OK · `manage.py check` OK
- `JWT_ISSUER` empty→`https://app.apilens.ai`, set→matches; OIDC `jwks_uri = https://app.apilens.ai/.well-known/jwks.json`

## Activation
Caddy/compose come from instance metadata, so this needs the gated step: `terraform apply` + VM `startup` re-run. The settings.py issuer fallback ships via the normal image roll (harmless half-state until activated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)