### PR TITLE
feat(infra): single API gateway on api.apilens.ai with path-routed services

### DIFF
--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -21,7 +21,7 @@ SECRET_KEY = os.environ.get(
 JWT_PRIVATE_KEY = os.environ.get("JWT_PRIVATE_KEY", "")
 
 # OIDC issuer/audience for access tokens (the identity service is the issuer).
-JWT_ISSUER = os.environ.get("JWT_ISSUER") or "https://app.apilens.ai"
+JWT_ISSUER = os.environ.get("JWT_ISSUER") or "https://api.apilens.ai/auth"
 JWT_AUDIENCE = os.environ.get("JWT_AUDIENCE", "apilens-api")
 
 # Which Django URLconf this process serves: the default full app, or the

--- a/infra/gcp/vm/Caddyfile
+++ b/infra/gcp/vm/Caddyfile
@@ -25,30 +25,16 @@
 {$APP_SITE} {
 	encode gzip zstd
 
-	# Identity (IAM) service — served under app.apilens.ai instead of a separate
-	# auth.* host. OIDC discovery + JWKS live at the well-known root (so the
-	# issuer = https://app.apilens.ai), and the auth API is under /auth/v1/*
-	# (rewritten onto the service's canonical /v1/*).
-	handle /.well-known/openid-configuration {
-		reverse_proxy identity:8000
-	}
-	handle /.well-known/jwks.json {
-		reverse_proxy identity:8000
-	}
-	handle /auth/v1/* {
-		uri replace /auth/v1 /v1
-		reverse_proxy identity:8000
-	}
-
-	# Core control-plane API + Django admin/static/media.
-	@core path /api/v1/* /admin/* /static/* /media/*
-	handle @core {
+	# The app host serves the Next.js UI + its own BFF route handlers under
+	# /api/* (which proxy to the services server-side over the internal network).
+	# The public, canonical backend lives on the API host (api.apilens.ai) — see
+	# the API_SITE gateway block appended by startup.sh. We still send the legacy
+	# /api/v1, admin, static and media paths to core here for backward-compat.
+	@backend path /api/v1/* /admin/* /static/* /media/*
+	handle @backend {
 		reverse_proxy api:8000
 	}
 
-	# Everything else: the Next.js app + its OWN server route handlers under
-	# /api/* (e.g. /api/auth/magic-link, /api/account/*, /api/projects) which
-	# proxy to the services server-side. Routing those to Django would 404 them.
 	handle {
 		reverse_proxy web:3000
 	}

--- a/infra/gcp/vm/startup.sh
+++ b/infra/gcp/vm/startup.sh
@@ -54,6 +54,15 @@ else
   FRONTEND_URL="https://${APP_SITE}"
 fi
 
+# IdP issuer = the identity service's public namespace on the API host
+# (https://api.apilens.ai/auth). Discovery + JWKS resolve under /auth/.well-known/*
+# there. Falls back to the app origin if no dedicated API host is configured.
+if [[ -n "${API_SITE}" && "${API_SITE}" != :* ]]; then
+  JWT_ISSUER="https://${API_SITE}/auth"
+else
+  JWT_ISSUER="${FRONTEND_URL}/auth"
+fi
+
 # Browser CORS origins: the app origin plus localhost for dev tooling.
 CORS_ORIGINS="${FRONTEND_URL},http://localhost:3000,http://127.0.0.1:3000"
 
@@ -166,20 +175,38 @@ if [[ -n "${API_SITE}" ]]; then
 
 ${API_SITE} {
 	encode gzip zstd
-	# Ingestion is served only on the dedicated ingest host.
+
+	# API gateway: one backend host, services namespaced by path (/<service>/v1).
+	# Ingestion is NOT here — it has its own host (SDK-only traffic).
 	handle /ingest/* {
 		respond 404
 	}
-	# Legacy auth path -> identity service (rewritten onto its canonical /v1/*).
-	# The identity service's own host is auth.apilens.ai; this alias keeps
-	# existing clients working during the cutover.
-	handle /api/v1/auth/* {
-		uri replace /api/v1/auth /v1
+
+	# Identity (IAM) under /auth/* — covers /auth/v1/* (the auth API) AND
+	# /auth/.well-known/* (OIDC discovery + JWKS). Strip the /auth prefix so it
+	# maps onto the service's own /v1/* and /.well-known/* routes. The JWT issuer
+	# is https://${API_SITE}/auth, so discovery + jwks_uri resolve here.
+	handle /auth/* {
+		uri strip_prefix /auth
 		reverse_proxy identity:8000
 	}
-	# Everything else (dashboard control plane) -> core api.
-	handle {
+
+	# Core control plane under /core/v1/* -> the service's canonical /api/v1/*.
+	handle /core/v1/* {
+		uri replace /core/v1 /api/v1
 		reverse_proxy api:8000
+	}
+
+	# Django admin + its static/media (kept at the root so admin's absolute URLs
+	# resolve). The dashboard API itself is only under /core/v1/*.
+	@coreroot path /admin/* /static/* /media/*
+	handle @coreroot {
+		reverse_proxy api:8000
+	}
+
+	# Nothing else is exposed on the API host.
+	handle {
+		respond 404
 	}
 }
 CADDY
@@ -242,9 +269,9 @@ DJANGO_ALLOWED_HOSTS=${ALLOWED_HOSTS},api,identity,ingest,web,localhost,127.0.0.
 CSRF_TRUSTED_ORIGINS=${CSRF_ORIGINS}
 CORS_ALLOWED_ORIGINS=${CORS_ORIGINS}
 FRONTEND_URL=${FRONTEND_URL}
-# IdP issuer = the app's public origin now that identity is served under
-# app.apilens.ai (/.well-known/* + /auth/v1/*) instead of a separate auth.* host.
-JWT_ISSUER=${FRONTEND_URL}
+# IdP issuer = https://<api_site>/auth (computed above), now that identity is
+# served under the API gateway at api.apilens.ai/auth/*.
+JWT_ISSUER=${JWT_ISSUER}
 MEDIA_BUCKET=${MEDIA_BUCKET}
 GS_PROJECT_ID=${PROJECT_ID}
 DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}


### PR DESCRIPTION
## Approach
One backend host (`api.apilens.ai`), services namespaced by path — the classic API-gateway pattern.

```
app.apilens.ai/           -> web (UI + BFF)
api.apilens.ai/auth/v1/*  -> identity   (+ /auth/.well-known/* for OIDC discovery + JWKS)
api.apilens.ai/core/v1/*  -> core        (rewritten to its /api/v1/*)
ingest.apilens.ai/v1/*    -> ingest      (only service kept on its own host — SDK-only)
JWT issuer -> https://api.apilens.ai/auth
```

Supersedes the un-activated #138 (everything-under-app). No frontend change — the BFF still reaches services over the internal network; `api.apilens.ai` is the public/canonical gateway.

## Changes
- **Caddyfile**: `app_site` back to UI + legacy backend paths.
- **startup.sh**: `api.apilens.ai` gateway — `/auth/*` (strip prefix) → identity, `/core/v1/*` (→ `/api/v1/*`) → core, admin/static/media → core, else `404`.
- **JWT issuer** = `https://<api_site>/auth`: startup computes it, compose passes `JWT_ISSUER`, settings falls back to `https://api.apilens.ai/auth`.
- **tfvars** (local): `api_domain="api.apilens.ai"` re-enabled, `auth_domain=""` retired.

## Validation
- `caddy validate` OK · `terraform validate` OK
- **Functional path-rewrite test** (mock upstreams): `/auth/v1/identify→/v1/identify`, `/auth/.well-known/jwks.json→/.well-known/jwks.json`, `/core/v1/projects→/api/v1/projects`, admin passthrough, `/ingest`+unknown→`404`
- issuer `https://api.apilens.ai/auth` ↔ jwks_uri `https://api.apilens.ai/auth/.well-known/jwks.json` consistent with the Caddy strip

## Activation
Caddy/compose come from instance metadata → needs the gated `terraform apply` + VM `startup` re-run. `api.apilens.ai` DNS already resolves to the VM (existed before), so Caddy reuses its cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)