### PR TITLE
feat(web): endpoint analytics detail panel, passkey Safari fix, payload UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This is interactive — it checks your environment, asks before overwriting anyt
 2. **JS/TS deps** — runs `pnpm install` across all workspaces
 3. **Python venv** — creates `apps/api/.venv` and installs backend deps with `uv`
 4. **Environment files** — copies `.env.example` → `.env` with real secrets auto-generated (no copy-paste placeholders)
-5. **Databases** — starts postgres + clickhouse + redis via Docker, detects port conflicts and offers to remap them
+5. **Databases** — starts postgres + clickhouse + redis + the OPA authz engine via Docker, detects port conflicts and offers to remap them
 6. **Migrations** — optionally runs Django migrations to get the DB schema ready
 
 Re-run `pnpm bootstrap` after pulling changes that touch dependencies, env templates, or Docker config. It skips steps that are already done.
@@ -91,27 +91,33 @@ Re-run `pnpm bootstrap` after pulling changes that touch dependencies, env templ
 pnpm dev
 ```
 
-That's it. Turborepo starts both the Next.js frontend (http://localhost:3002) and the Django backend (http://localhost:8000) together in one terminal via the turbo TUI.
+That's it. This starts the **whole local stack** in one terminal via `mprocs` — one tab per service: postgres, clickhouse, redis, authz (OPA), api (http://localhost:8000), ingest (http://localhost:8001), and web (http://localhost:3002). Each tab has its own live logs.
 
-Magic links print to the Django pane in the TUI — copy the link from the logs to sign in.
+Navigation: **`Ctrl+a`** toggles focus between the process list and the output pane; `q` quits (must be focused on the process list), `Q` force-quits, `r` restarts the selected proc.
+
+Magic links print to the `api` tab — copy the link from the logs to sign in.
+
+> Want just the app servers (frontend + Django) the old way, with the databases already up via `pnpm db:up`? Use `pnpm dev:apps` (turbo).
 
 ### Once you're done
 
-```bash
-pnpm db:down       # stop the local databases
-```
+Quitting `pnpm dev` (`q`) stops the **app servers** (api/ingest/web) instantly. The datastore containers keep running in the background — the same model as `pnpm db:up` — so the next `pnpm dev` starts fast. Stop them when you're fully done:
 
-To resume the next day: `pnpm db:up` brings the databases back, then run either dev option above.
+```bash
+pnpm db:down       # stop postgres + clickhouse + redis + opa
+```
 
 ## Common commands
 
 ```bash
-pnpm dev                # run JS/TS dev servers
+pnpm dev                # run the full local stack (mprocs: db + authz + api + ingest + web)
+pnpm dev:apps           # run just the app servers (frontend + Django) via turbo
+pnpm stack              # alias of `pnpm dev`
 pnpm build              # build everything (turbo, cached)
 pnpm typecheck          # TS type-check
 pnpm lint               # lint JS/TS workspaces
 
-pnpm db:up              # start postgres + clickhouse + redis
+pnpm db:up              # start postgres + clickhouse + redis + opa (detached)
 pnpm db:down            # stop them
 pnpm db:logs            # tail their logs
 ```

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,16 +22,21 @@ APILENS_POSTGRES_URL=postgresql://apilens:apilens_dev@localhost:5432/apilens
 # =============================================================================
 # ClickHouse (analytics for endpoint stats)
 # =============================================================================
-# Primary connection URL
-APILENS_CLICKHOUSE_URL=clickhouse://default:@localhost:9000/apilens
+# Primary connection URL. Password must match CLICKHOUSE_PASSWORD in
+# infra/docker/docker-compose.local.yml (clickhouse_dev) or the dashboard's
+# analytics queries fail auth and every metric reads 0.
+APILENS_CLICKHOUSE_URL=clickhouse://default:clickhouse_dev@localhost:9000/apilens
 # Optional TLS verify control when URL uses https/clickhouses
 APILENS_CLICKHOUSE_VERIFY=True
 
 # =============================================================================
 # CORS Configuration
 # =============================================================================
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
-FRONTEND_URL=http://localhost:3000
+# NOTE: the local web dev server runs on :3002 (apps/web → `next dev -p 3002`).
+# These must match that port or WebAuthn/passkey origin checks and magic-link
+# emails will point at the wrong host.
+CORS_ALLOWED_ORIGINS=http://localhost:3002,http://127.0.0.1:3002
+FRONTEND_URL=http://localhost:3002
 
 # =============================================================================
 # Email (console backend for local dev — emails print to terminal)
@@ -51,6 +56,18 @@ DEFAULT_FROM_EMAIL=no-reply@apilens.ai
 # =============================================================================
 LOG_LEVEL=INFO
 ENVIRONMENT=development
+
+# =============================================================================
+# Internal services (CNCF split: identity introspection + OPA authz)
+# =============================================================================
+# Shared secret the ingest service presents when calling this API's
+# /auth/introspect endpoint to validate API keys. Must match the ingest
+# process's INTERNAL_INTROSPECT_SECRET. Change for any non-local use.
+INTERNAL_INTROSPECT_SECRET=dev-secret
+# OPA policy decision point. The `opa` service is started by
+# infra/docker/docker-compose.local.yml (pnpm db:up); the host-run API reaches
+# it on the published port. Leave UNSET to skip OPA and use only the DB guard.
+OPA_URL=http://localhost:8181/v1/data/apilens/authz/allow
 
 # =============================================================================
 # Sentry — errors + tracing + profiling + logs (https://sentry.io)

--- a/apps/api/apps/projects/services.py
+++ b/apps/api/apps/projects/services.py
@@ -2968,10 +2968,432 @@ class AnalyticsService:
 
         try:
             rows = client.execute(query, params)
-            return [row[0] for row in rows if row[0]]
+            return [row["environment"] for row in rows if row.get("environment")]
         except Exception as exc:
             logger.warning("ClickHouse query failed for project environments; returning empty list: %s", exc)
             return []
+
+    # ── Project-Level Endpoint Detail Methods ─────────────────────────────
+    # These mirror the per-app endpoint detail methods but aggregate a single
+    # (method, path) endpoint across every app in a project (optionally a
+    # filtered subset of apps), so they can back the endpoint detail panel on
+    # the project endpoints page.
+
+    @staticmethod
+    def _project_endpoint_filters(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None,
+        environment: str | None,
+        since_dt,
+        until_dt,
+    ) -> tuple[list[str], dict]:
+        params = {
+            "project_id": project_id,
+            "method": method.upper(),
+            "path": path,
+            "since": since_dt,
+            "until": until_dt,
+        }
+        filters = [
+            "WHERE project_id = %(project_id)s",
+            "AND method = %(method)s",
+            "AND path = %(path)s",
+            "AND timestamp >= %(since)s",
+            "AND timestamp <= %(until)s",
+        ]
+        if app_ids:
+            filters.append("AND app_id IN %(app_ids)s")
+            params["app_ids"] = app_ids
+        if environment:
+            filters.append("AND environment = %(environment)s")
+            params["environment"] = environment
+        return filters, params
+
+    @staticmethod
+    def get_project_endpoint_detail(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        threshold_ms: float = 500.0,
+    ) -> dict:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        window_minutes = max(1.0, (until_dt - since_dt).total_seconds() / 60.0)
+
+        # Description comes from the registered endpoint records (PostgreSQL).
+        description = ""
+        try:
+            from apps.projects.models import Endpoint
+            ep_qs = Endpoint.objects.filter(
+                app__project_id=project_id,
+                method=method.upper(),
+                path=path,
+            )
+            if app_ids:
+                ep_qs = ep_qs.filter(app_id__in=app_ids)
+            ep = ep_qs.exclude(description="").first() or ep_qs.first()
+            if ep:
+                description = ep.description or ""
+        except Exception as exc:
+            logger.warning("Failed to load endpoint description: %s", exc)
+
+        empty = {
+            "method": method.upper(),
+            "path": path,
+            "description": description,
+            "total_requests": 0,
+            "successful_requests": 0,
+            "client_errors": 0,
+            "server_errors": 0,
+            "error_count": 0,
+            "error_rate": 0.0,
+            "requests_per_minute": 0.0,
+            "avg_response_time_ms": 0.0,
+            "p50_response_time_ms": 0.0,
+            "p75_response_time_ms": 0.0,
+            "p95_response_time_ms": 0.0,
+            "slow_requests": 0,
+            "apdex": 0.0,
+            "threshold_ms": threshold_ms,
+            "total_request_bytes": 0,
+            "total_response_bytes": 0,
+            "total_data_transferred": 0,
+            "avg_response_size": 0.0,
+            "last_seen_at": None,
+        }
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint detail: %s", exc)
+            return empty
+
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        params["threshold"] = threshold_ms
+        params["threshold4"] = threshold_ms * 4
+
+        query = f"""
+            SELECT
+                count() AS total_requests,
+                countIf(status_code < 400) AS successful_requests,
+                countIf(status_code >= 400 AND status_code < 500) AS client_errors,
+                countIf(status_code >= 500) AS server_errors,
+                countIf(status_code >= 400) AS error_count,
+                if(count() > 0, countIf(status_code >= 400) / count() * 100, 0) AS error_rate,
+                avg(response_time_ms) AS avg_response_time_ms,
+                quantile(0.50)(response_time_ms) AS p50_response_time_ms,
+                quantile(0.75)(response_time_ms) AS p75_response_time_ms,
+                quantile(0.95)(response_time_ms) AS p95_response_time_ms,
+                countIf(response_time_ms > %(threshold)s) AS slow_requests,
+                if(
+                    count() > 0,
+                    (countIf(response_time_ms <= %(threshold)s)
+                        + countIf(response_time_ms > %(threshold)s AND response_time_ms <= %(threshold4)s) / 2)
+                    / count(),
+                    0
+                ) AS apdex,
+                sum(request_size) AS total_request_bytes,
+                sum(response_size) AS total_response_bytes,
+                avg(response_size) AS avg_response_size,
+                max(timestamp) AS last_seen_at
+            FROM api_requests
+            {' '.join(filters)}
+        """
+        try:
+            rows = client.execute(query, params)
+            if rows and rows[0].get("total_requests"):
+                row = AnalyticsService._clean_nan_values(rows[0])
+                row["method"] = method.upper()
+                row["path"] = path
+                row["description"] = description
+                row["threshold_ms"] = threshold_ms
+                row["requests_per_minute"] = (row.get("total_requests") or 0) / window_minutes
+                row["total_data_transferred"] = (row.get("total_request_bytes") or 0) + (row.get("total_response_bytes") or 0)
+                row["last_seen_at"] = _as_utc(row.get("last_seen_at"))
+                return row
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint detail; returning empty detail: %s", exc)
+
+        return empty
+
+    @staticmethod
+    def get_project_endpoint_timeseries(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        timezone_name: str | None = None,
+    ) -> list[dict]:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint timeseries: %s", exc)
+            return []
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        params["timezone"] = _resolve_bucket_timezone(timezone_name)
+
+        query = f"""
+            SELECT
+                toTimeZone(toStartOfHour(toTimeZone(timestamp, %(timezone)s)), 'UTC') AS bucket,
+                count() AS total_requests,
+                countIf(status_code >= 400) AS error_count,
+                countIf(status_code >= 400 AND status_code < 500) AS client_errors,
+                countIf(status_code >= 500) AS server_errors,
+                avg(response_time_ms) AS avg_response_time_ms,
+                sum(request_size) AS total_request_bytes,
+                sum(response_size) AS total_response_bytes
+            FROM api_requests
+            {' '.join(filters)}
+            GROUP BY bucket
+            ORDER BY bucket ASC
+        """
+        try:
+            rows = []
+            for r in client.execute(query, params):
+                row = AnalyticsService._clean_nan_values(r)
+                row["bucket"] = _as_utc(row.get("bucket"))
+                rows.append(row)
+            return rows
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint timeseries; returning empty list: %s", exc)
+            return []
+
+    @staticmethod
+    def get_project_endpoint_consumers(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint consumers: %s", exc)
+            return []
+        IngestService.ensure_consumer_columns(client)
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        params["limit"] = max(1, min(limit, 50))
+
+        query = f"""
+            SELECT
+                if(
+                    consumer_name != '',
+                    consumer_name,
+                    if(
+                        consumer_id != '',
+                        consumer_id,
+                        if(user_agent != '', user_agent, if(ip_address != '', ip_address, 'unknown'))
+                    )
+                ) AS consumer,
+                count() AS total_requests,
+                countIf(status_code >= 400) AS error_count,
+                if(count() > 0, countIf(status_code >= 400) / count() * 100, 0) AS error_rate,
+                avg(response_time_ms) AS avg_response_time_ms
+            FROM api_requests
+            {' '.join(filters)}
+            GROUP BY consumer
+            ORDER BY total_requests DESC
+            LIMIT %(limit)s
+        """
+        try:
+            return [AnalyticsService._clean_nan_values(r) for r in client.execute(query, params)]
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint consumers; returning empty list: %s", exc)
+            return []
+
+    @staticmethod
+    def get_project_endpoint_status_codes(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint status-code stats: %s", exc)
+            return []
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        params["limit"] = max(1, min(limit, 50))
+
+        query = f"""
+            SELECT
+                status_code,
+                count() AS total_requests
+            FROM api_requests
+            {' '.join(filters)}
+            GROUP BY status_code
+            ORDER BY total_requests DESC
+            LIMIT %(limit)s
+        """
+        try:
+            return client.execute(query, params)
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint status-code stats; returning empty list: %s", exc)
+            return []
+
+    @staticmethod
+    def get_project_endpoint_requests(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 20,
+        errors_only: bool = False,
+    ) -> list[dict]:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint requests: %s", exc)
+            return []
+        IngestService.ensure_consumer_columns(client)
+        IngestService.ensure_payload_columns(client)
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        if errors_only:
+            filters.append("AND status_code >= 400")
+        params["limit"] = max(1, min(limit, 100))
+
+        query = f"""
+            SELECT
+                timestamp,
+                method,
+                path,
+                status_code,
+                response_time_ms,
+                environment,
+                ip_address,
+                user_agent,
+                consumer_id,
+                consumer_name,
+                request_payload,
+                response_payload,
+                if(
+                    consumer_name != '',
+                    consumer_name,
+                    if(
+                        consumer_id != '',
+                        consumer_id,
+                        if(user_agent != '', user_agent, if(ip_address != '', ip_address, 'unknown'))
+                    )
+                ) AS consumer
+            FROM api_requests
+            {' '.join(filters)}
+            ORDER BY timestamp DESC
+            LIMIT %(limit)s
+        """
+        try:
+            rows = client.execute(query, params)
+            for row in rows:
+                row["timestamp"] = _as_utc(row.get("timestamp"))
+            return rows
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint requests; returning empty list: %s", exc)
+            return []
+
+    @staticmethod
+    def get_project_endpoint_histograms(
+        project_id: str,
+        method: str,
+        path: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        bins: int = 30,
+    ) -> dict:
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        result = {"response_time": [], "response_size": []}
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty endpoint histograms: %s", exc)
+            return result
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        filters, params = AnalyticsService._project_endpoint_filters(
+            project_id, method, path, app_ids, environment, since_dt, until_dt
+        )
+        bins = max(5, min(bins, 60))
+
+        query = f"""
+            SELECT
+                histogram({bins})(response_time_ms) AS response_time_hist,
+                histogram({bins})(response_size) AS response_size_hist
+            FROM api_requests
+            {' '.join(filters)}
+        """
+
+        def _to_buckets(raw) -> list[dict]:
+            buckets = []
+            for item in raw or []:
+                try:
+                    lower, upper, height = item[0], item[1], item[2]
+                except (TypeError, IndexError, KeyError):
+                    continue
+                buckets.append({
+                    "lower": float(lower),
+                    "upper": float(upper),
+                    "count": float(height),
+                })
+            return buckets
+
+        try:
+            rows = client.execute(query, params)
+            if rows:
+                result["response_time"] = _to_buckets(rows[0].get("response_time_hist"))
+                result["response_size"] = _to_buckets(rows[0].get("response_size_hist"))
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project endpoint histograms; returning empty histograms: %s", exc)
+
+        return result
 
     @staticmethod
     def get_project_logs(

--- a/apps/api/routers/projects/router.py
+++ b/apps/api/routers/projects/router.py
@@ -362,6 +362,188 @@ def get_environments(
     return {"environments": environments}
 
 
+# ── Project-level Endpoint Detail ────────────────────────────────────
+
+def _resolve_endpoint_app_ids(project, app_slugs: str | None) -> list[str] | None:
+    """Resolve a comma-separated list of app slugs to app ids within a project."""
+    if not app_slugs:
+        return None
+    slugs = [s.strip() for s in app_slugs.split(",") if s.strip()]
+    if not slugs:
+        return None
+    apps = AppService.get_apps_by_slugs(project, slugs)
+    return [str(app.id) for app in apps]
+
+
+@router.get("/{project_slug}/analytics/endpoint-detail", response=dict)
+def get_project_endpoint_detail(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    threshold_ms: float = 500.0,
+):
+    """Get an aggregated summary for a single endpoint across a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_endpoint_detail(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        threshold_ms=threshold_ms,
+    )
+
+
+@router.get("/{project_slug}/analytics/endpoint-timeseries", response=list[dict])
+def get_project_endpoint_timeseries(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    timezone: str = None,
+):
+    """Get hourly time-series for a single endpoint across a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    bucket_timezone = (
+        UserService.normalize_timezone(timezone)
+        if timezone
+        else UserService.get_timezone(user)
+    )
+    return AnalyticsService.get_project_endpoint_timeseries(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        timezone_name=bucket_timezone,
+    )
+
+
+@router.get("/{project_slug}/analytics/endpoint-consumers", response=list[dict])
+def get_project_endpoint_consumers(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    limit: int = 10,
+):
+    """Get the top consumers for a single endpoint across a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_endpoint_consumers(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+
+
+@router.get("/{project_slug}/analytics/endpoint-status-codes", response=list[dict])
+def get_project_endpoint_status_codes(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    limit: int = 20,
+):
+    """Get the status-code breakdown for a single endpoint across a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_endpoint_status_codes(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+
+
+@router.get("/{project_slug}/analytics/endpoint-requests", response=list[dict])
+def get_project_endpoint_requests(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    limit: int = 20,
+    errors_only: bool = False,
+):
+    """Get the most recent requests for a single endpoint across a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_endpoint_requests(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        limit=limit,
+        errors_only=errors_only,
+    )
+
+
+@router.get("/{project_slug}/analytics/endpoint-histograms", response=dict)
+def get_project_endpoint_histograms(
+    request: HttpRequest,
+    project_slug: str,
+    method: str,
+    path: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    bins: int = 30,
+):
+    """Get response-time and response-size histograms for a single endpoint."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_endpoint_histograms(
+        project_id=str(project.id),
+        method=method,
+        path=path,
+        app_ids=_resolve_endpoint_app_ids(project, app_slugs),
+        environment=environment,
+        since=since,
+        until=until,
+        bins=bins,
+    )
+
+
 # ── Project-level Data Query (raw telemetry access) ──────────────────
 
 @router.get("/{project_slug}/data/logs", response=LogsQueryResponse)

--- a/apps/ingest/.env.example
+++ b/apps/ingest/.env.example
@@ -1,0 +1,11 @@
+# APILens ingestion service — local dev environment.
+# Copied to apps/ingest/.env by `pnpm bootstrap`; loaded via `uvicorn --env-file`.
+
+# Datastores (same local stack as the core API).
+APILENS_POSTGRES_URL=postgresql://apilens:apilens_dev@localhost:5432/apilens
+APILENS_CLICKHOUSE_URL=clickhouse://default:clickhouse_dev@localhost:9000/apilens
+
+# API-key validation is delegated to the core API's introspection endpoint.
+# The secret MUST match INTERNAL_INTROSPECT_SECRET in apps/api/.env.
+APILENS_INTROSPECT_URL=http://localhost:8000/api/v1/auth/introspect
+INTERNAL_INTROSPECT_SECRET=dev-secret

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-consumers${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-detail${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-histograms${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-requests/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-requests/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-requests${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-status-codes${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-timeseries${qs ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(upstream, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/auth/login/page.tsx
+++ b/apps/web/src/app/auth/login/page.tsx
@@ -91,6 +91,10 @@ function LoginPageContent() {
   // Cached passkey options so the user can retry the passkey prompt without
   // making another identify round-trip.
   const [passkeyOptions, setPasskeyOptions] = useState<any>(null);
+  // Pre-fetched identify result keyed by email. Lets us skip the fetch inside
+  // the button click handler so navigator.credentials.get() fires within the
+  // original user gesture — required by Safari to trigger Touch ID.
+  const [prefetchedIdentify, setPrefetchedIdentify] = useState<{ email: string; data: any } | null>(null);
 
   // Abort controller for the passive conditional-UI passkey listener.
   // We abort it before doing anything that needs WebAuthn explicitly.
@@ -157,6 +161,27 @@ function LoginPageContent() {
     window.location.href = "/";
   };
 
+  // Pre-fetch the identify result when the user leaves the email field.
+  // This lets handleIdentify skip the fetch entirely when the user clicks
+  // "Continue", so navigator.credentials.get() fires without any prior await
+  // — Safari requires this to honour the user gesture and show Touch ID.
+  const handleEmailBlur = async () => {
+    const trimmed = email.trim();
+    if (!trimmed || prefetchedIdentify?.email === trimmed) return;
+    try {
+      const res = await fetch("/api/auth/identify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmed }),
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setPrefetchedIdentify({ email: trimmed, data });
+    } catch {
+      // Silently ignore — handleIdentify will fall back to a fresh fetch.
+    }
+  };
+
   const handleIdentify = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -169,6 +194,22 @@ function LoginPageContent() {
     abortConditionalAuth();
     setIsSubmitting(true);
 
+    // Fast path: use the pre-fetched result so navigator.credentials.get() is
+    // called immediately within the user gesture (required by Safari for Touch ID).
+    const prefetched = prefetchedIdentify?.email === email ? prefetchedIdentify.data : null;
+    if (prefetched?.method === "passkey" && prefetched.passkey_options) {
+      const incomingFallbacks: Method[] = Array.isArray(prefetched.fallbacks) ? prefetched.fallbacks : [];
+      setFallbacks(incomingFallbacks);
+      setPasskeyOptions(prefetched.passkey_options);
+      try {
+        await runPasskeyFlow(prefetched.passkey_options, incomingFallbacks);
+      } finally {
+        setIsSubmitting(false);
+      }
+      return;
+    }
+
+    // Slow path: fetch then handle (non-passkey methods, or prefetch missed).
     try {
       const response = await fetch("/api/auth/identify", {
         method: "POST",
@@ -835,7 +876,9 @@ function LoginPageContent() {
                   onChange={(e) => {
                     setEmail(e.target.value);
                     setError("");
+                    setPrefetchedIdentify(null);
                   }}
+                  onBlur={handleEmailBlur}
                   placeholder="you@company.com"
                   className="auth-input"
                   required

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -10456,3 +10456,570 @@ a.settings-btn {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ── Endpoint detail panel ─────────────────────────────────────────── */
+.endpoints-row-clickable {
+  cursor: pointer;
+}
+.endpoints-row-clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.endpoint-detail-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100dvh;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  justify-content: flex-end;
+  /* Reset values leaked from the older `.endpoint-detail-overlay` modal rule
+     (shared class name) — padding here would push the drawer off the edges. */
+  align-items: stretch;
+  padding: 0;
+  animation: endpoint-detail-fade 0.15s ease;
+}
+
+@keyframes endpoint-detail-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.endpoint-detail-panel {
+  position: relative;
+  width: min(720px, 100%);
+  max-width: 100%;
+  height: 100dvh;
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -16px 0 48px rgba(0, 0, 0, 0.4);
+  animation: endpoint-detail-slide 0.2s ease;
+}
+
+/* Left-edge drag handle for resizing the drawer. Straddles the edge and shows
+   a persistent grip so the resize affordance is visible without hovering. */
+.endpoint-detail-resizer {
+  position: absolute;
+  left: -6px;
+  top: 0;
+  bottom: 0;
+  width: 14px;
+  cursor: col-resize;
+  z-index: 7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+/* Always-visible vertical track line along the edge. */
+.endpoint-detail-resizer::before {
+  content: "";
+  position: absolute;
+  right: 5px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border-color);
+  transition: background 0.12s ease;
+}
+/* Centered grip pill that holds the icon — the visible "handle". */
+.endpoint-detail-resizer-grip {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 44px;
+  border-radius: 999px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: background 0.12s ease, color 0.12s ease, height 0.12s ease, border-color 0.12s ease;
+}
+.endpoint-detail-resizer:hover .endpoint-detail-resizer-grip,
+.endpoint-detail-resizer:active .endpoint-detail-resizer-grip {
+  background: #14b8a6;
+  border-color: #14b8a6;
+  color: #fff;
+  height: 60px;
+}
+.endpoint-detail-resizer:hover::before,
+.endpoint-detail-resizer:active::before {
+  background: #14b8a6;
+}
+
+.endpoint-detail-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+@keyframes endpoint-detail-slide {
+  from { transform: translateX(24px); opacity: 0.4; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+.endpoint-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 4px;
+  margin-bottom: 0; /* reset leak from the older modal `.endpoint-detail-header` */
+  gap: 12px;
+}
+
+.endpoint-detail-breadcrumb {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.endpoint-detail-close {
+  width: 30px;
+  height: 30px;
+  background: none;
+  border: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 6px;
+}
+.endpoint-detail-close:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.endpoint-detail-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 20px 12px;
+}
+.endpoint-detail-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.endpoint-detail-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-color);
+  overflow-x: auto;
+}
+.endpoint-detail-tab {
+  background: none;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 10px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.endpoint-detail-tab:hover {
+  color: var(--text-primary);
+}
+.endpoint-detail-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: #14b8a6;
+}
+
+.endpoint-detail-period {
+  padding: 12px 20px 0;
+}
+.endpoint-detail-period-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.endpoint-detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px 32px;
+}
+
+.endpoint-detail-section {
+  margin-bottom: 24px;
+}
+.endpoint-detail-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 10px;
+}
+
+.endpoint-detail-summary-box {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 14px 16px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+.endpoint-detail-muted,
+.endpoint-detail-note {
+  color: var(--text-muted);
+}
+.endpoint-detail-note {
+  font-size: 11px;
+  margin: 10px 0 0;
+}
+
+.endpoint-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.endpoint-stat-card {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: var(--bg-secondary);
+}
+.endpoint-stat-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 0 0 6px;
+}
+.endpoint-stat-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+.endpoint-stat-value.tone-good { color: #22c55e; }
+.endpoint-stat-value.tone-warn { color: #f59e0b; }
+.endpoint-stat-value.tone-bad { color: #ef4444; }
+
+.endpoint-detail-empty {
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  padding: 28px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.endpoint-chart-tooltip {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 11px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+.endpoint-chart-tooltip-label {
+  color: var(--text-secondary);
+  margin: 0 0 4px;
+}
+.endpoint-chart-tooltip p {
+  margin: 2px 0;
+}
+
+.endpoint-detail-table-wrapper {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.endpoint-detail-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.endpoint-detail-table thead th {
+  text-align: left;
+  padding: 9px 12px;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 11px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+.endpoint-detail-table tbody td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+.endpoint-detail-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.endpoint-detail-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.endpoint-detail-consumer {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.endpoint-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 38px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid transparent;
+}
+.endpoint-status-2xx { color: #22c55e; background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.25); }
+.endpoint-status-3xx { color: #60a5fa; background: rgba(96,165,250,0.12); border-color: rgba(96,165,250,0.25); }
+.endpoint-status-4xx { color: #f59e0b; background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.25); }
+.endpoint-status-5xx { color: #ef4444; background: rgba(239,68,68,0.12); border-color: rgba(239,68,68,0.25); }
+
+.endpoint-status-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.endpoint-status-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.endpoint-status-bar-track {
+  flex: 1;
+  height: 8px;
+  background: var(--bg-secondary);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.endpoint-status-bar {
+  height: 100%;
+  border-radius: 999px;
+}
+.endpoint-status-bar.is-client { background: #f59e0b; }
+.endpoint-status-bar.is-server { background: #ef4444; }
+.endpoint-status-count {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  min-width: 48px;
+  text-align: right;
+}
+
+/* Chart frame — guarantees a resolved width/height so recharts'
+   ResponsiveContainer never collapses to 0×0 inside the flex panel. */
+.endpoint-chart-frame {
+  width: 100%;
+  min-width: 0;
+}
+
+/* Loading shimmer used while a tab's data is in flight. */
+.endpoint-skeleton {
+  width: 100%;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-secondary) 25%,
+    rgba(148, 163, 184, 0.12) 37%,
+    var(--bg-secondary) 63%
+  );
+  background-size: 400% 100%;
+  animation: endpoint-skeleton-shimmer 1.4s ease infinite;
+}
+@keyframes endpoint-skeleton-shimmer {
+  from { background-position: 100% 0; }
+  to { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .endpoint-skeleton { animation: none; }
+  .endpoint-detail-overlay,
+  .endpoint-detail-panel { animation: none; }
+}
+
+.endpoints-row-clickable {
+  transition: background 0.12s ease;
+}
+.endpoints-row-clickable:hover {
+  background: rgba(148, 163, 184, 0.06);
+}
+
+/* Clickable request rows (open the payload popup). */
+.request-row-clickable {
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.request-row-clickable:hover {
+  background: rgba(20, 184, 166, 0.07);
+}
+.request-row-clickable:focus-visible {
+  outline: 2px solid var(--accent, #14b8a6);
+  outline-offset: -2px;
+}
+.request-row-chevron {
+  width: 24px;
+  text-align: right;
+  color: var(--text-muted);
+}
+.request-row-clickable:hover .request-row-chevron {
+  color: #14b8a6;
+}
+
+/* ── Request/response payload popup ───────────────────────────────────── */
+.request-payload-overlay {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  z-index: 2100;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: endpoint-detail-fade 0.12s ease;
+}
+.request-payload-modal {
+  width: min(900px, calc(100vw - 48px));
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: 0 26px 80px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+.request-payload-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+.request-payload-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.request-payload-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.request-payload-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+.request-payload-meta-consumer {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.request-payload-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 16px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+.request-payload-section {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+.request-payload-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.request-payload-section-head h4 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.request-payload-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+.request-payload-copy:hover {
+  color: var(--text-primary);
+  border-color: #14b8a6;
+}
+.request-payload-pre {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: calc(60vh - 120px);
+  overflow: auto;
+  flex: 1;
+}
+/* JSON syntax highlight tokens */
+.json-key    { color: #60a5fa; }
+.json-string { color: #86efac; }
+.json-number { color: #fb923c; }
+.json-bool   { color: #c084fc; }
+.json-null   { color: #94a3b8; }
+
+@media (max-width: 768px) {
+  .endpoint-detail-panel { width: 100% !important; }
+  .endpoint-detail-resizer { display: none; }
+  .request-payload-body { grid-template-columns: 1fr; }
+  .request-payload-pre { max-height: 260px; }
+}

--- a/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Layers, Search, SlidersHorizontal, X } from "lucide-react";
+import EndpointDetailPanel, { type EndpointDetailTarget } from "@/components/endpoints/EndpointDetailPanel";
 
 interface ProjectEndpointsContentProps {
   projectSlug: string;
@@ -98,6 +99,7 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
 
   const customPopoverRef = useRef<HTMLDivElement | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [selectedEndpoint, setSelectedEndpoint] = useState<EndpointDetailTarget | null>(null);
 
   // Fetch project info
   useEffect(() => {
@@ -988,7 +990,19 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
                 const errorClass = errorRate < 1 ? "low" : errorRate < 5 ? "medium" : "high";
                 const hasTraffic = row.total_requests > 0;
                 return (
-                  <tr key={`${row.method}-${row.path}-${index}`}>
+                  <tr
+                    key={`${row.method}-${row.path}-${index}`}
+                    className="endpoints-row-clickable"
+                    onClick={() => setSelectedEndpoint({ method: row.method, path: row.path })}
+                    tabIndex={0}
+                    role="button"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedEndpoint({ method: row.method, path: row.path });
+                      }
+                    }}
+                  >
                     <td>
                       <span className={`method-badge method-badge-${row.method.toLowerCase()}`}>{row.method}</span>
                       <span className="endpoint-path">{row.path}</span>
@@ -1042,6 +1056,19 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
             </button>
           </div>
         </div>
+      )}
+
+      {selectedEndpoint && (
+        <EndpointDetailPanel
+          projectSlug={projectSlug}
+          endpoint={selectedEndpoint}
+          appSlugs={selectedAppSlugs}
+          environment={selectedEnv}
+          since={timeParams.since}
+          until={timeParams.until}
+          rangeLabel={activeRangeLabel}
+          onClose={() => setSelectedEndpoint(null)}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/endpoints/EndpointDetailPanel.tsx
+++ b/apps/web/src/components/endpoints/EndpointDetailPanel.tsx
@@ -1,0 +1,1023 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Check, ChevronRight, Copy, GripVertical, Maximize2, Minimize2, X } from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface EndpointDetailTarget {
+  method: string;
+  path: string;
+}
+
+interface EndpointDetailPanelProps {
+  projectSlug: string;
+  endpoint: EndpointDetailTarget;
+  appSlugs: string[];
+  environment: string;
+  since: string;
+  until?: string;
+  rangeLabel: string;
+  onClose: () => void;
+}
+
+type TabKey = "requests" | "errors" | "response-times" | "data-transferred";
+
+const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: "requests", label: "Requests" },
+  { key: "errors", label: "Errors" },
+  { key: "response-times", label: "Response times" },
+  { key: "data-transferred", label: "Data transferred" },
+];
+
+interface EndpointDetail {
+  method: string;
+  path: string;
+  description: string;
+  total_requests: number;
+  successful_requests: number;
+  client_errors: number;
+  server_errors: number;
+  error_count: number;
+  error_rate: number;
+  requests_per_minute: number;
+  avg_response_time_ms: number;
+  p50_response_time_ms: number;
+  p75_response_time_ms: number;
+  p95_response_time_ms: number;
+  slow_requests: number;
+  apdex: number;
+  threshold_ms: number;
+  total_request_bytes: number;
+  total_response_bytes: number;
+  total_data_transferred: number;
+  avg_response_size: number;
+  last_seen_at: string | null;
+}
+
+interface TimeseriesPoint {
+  bucket: string;
+  total_requests: number;
+  error_count: number;
+  client_errors: number;
+  server_errors: number;
+  avg_response_time_ms: number;
+  total_request_bytes: number;
+  total_response_bytes: number;
+}
+
+interface ConsumerRow {
+  consumer: string;
+  total_requests: number;
+  error_count: number;
+  error_rate: number;
+  avg_response_time_ms: number;
+}
+
+interface StatusCodeRow {
+  status_code: number;
+  total_requests: number;
+}
+
+interface RequestRow {
+  timestamp: string;
+  method: string;
+  path: string;
+  status_code: number;
+  response_time_ms: number;
+  environment: string;
+  consumer: string;
+  request_payload?: string;
+  response_payload?: string;
+}
+
+interface HistogramBucket {
+  lower: number;
+  upper: number;
+  count: number;
+}
+
+interface Histograms {
+  response_time: HistogramBucket[];
+  response_size: HistogramBucket[];
+}
+
+const ACCENT = "#14b8a6";
+const CLIENT_ERR = "#f59e0b";
+const SERVER_ERR = "#f87171";
+const GRID = "rgba(148, 163, 184, 0.12)";
+const AXIS_TICK = { fontSize: 10, fill: "var(--text-muted)" } as const;
+
+const PANEL_MIN_WIDTH = 460;
+const PANEL_DEFAULT_WIDTH = 720;
+const PANEL_WIDTH_KEY = "apilens:endpoint-panel-width";
+
+function panelMaxWidth(): number {
+  if (typeof window === "undefined") return 1600;
+  return Math.round(window.innerWidth * 0.95);
+}
+
+// Fallback used when a detail request fails, so the panel degrades to an empty
+// state instead of a stuck skeleton.
+const EMPTY_DETAIL: EndpointDetail = {
+  method: "",
+  path: "",
+  description: "",
+  total_requests: 0,
+  successful_requests: 0,
+  client_errors: 0,
+  server_errors: 0,
+  error_count: 0,
+  error_rate: 0,
+  requests_per_minute: 0,
+  avg_response_time_ms: 0,
+  p50_response_time_ms: 0,
+  p75_response_time_ms: 0,
+  p95_response_time_ms: 0,
+  slow_requests: 0,
+  apdex: 0,
+  threshold_ms: 0,
+  total_request_bytes: 0,
+  total_response_bytes: 0,
+  total_data_transferred: 0,
+  avg_response_size: 0,
+  last_seen_at: null,
+};
+const EMPTY_HISTOGRAMS: Histograms = { response_time: [], response_size: [] };
+
+function formatNumber(n: number): string {
+  return Math.round(n || 0).toLocaleString();
+}
+
+function formatMs(n: number): string {
+  if (!n) return "0 ms";
+  return `${Math.round(n)} ms`;
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return "0 B";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatBucketTime(bucket: string): string {
+  const d = new Date(bucket);
+  if (isNaN(d.getTime())) return bucket;
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDateTime(ts: string): string {
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function statusTone(status: number): string {
+  if (status >= 500) return "endpoint-status-5xx";
+  if (status >= 400) return "endpoint-status-4xx";
+  if (status >= 300) return "endpoint-status-3xx";
+  return "endpoint-status-2xx";
+}
+
+export default function EndpointDetailPanel({
+  projectSlug,
+  endpoint,
+  appSlugs,
+  environment,
+  since,
+  until,
+  rangeLabel,
+  onClose,
+}: EndpointDetailPanelProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>("requests");
+
+  // Resizable / expandable drawer width (persisted across opens).
+  const [panelWidth, setPanelWidth] = useState<number>(PANEL_DEFAULT_WIDTH);
+  const [expanded, setExpanded] = useState(false);
+  const draggingRef = useRef(false);
+  const widthRef = useRef(PANEL_DEFAULT_WIDTH);
+  widthRef.current = panelWidth;
+
+  // Restore the saved width once mounted (avoids SSR/localStorage mismatch).
+  useEffect(() => {
+    const saved = Number(window.localStorage.getItem(PANEL_WIDTH_KEY));
+    if (saved && saved >= PANEL_MIN_WIDTH) {
+      setPanelWidth(Math.min(saved, panelMaxWidth()));
+    }
+  }, []);
+
+  // Drag-to-resize from the left edge.
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const next = Math.min(panelMaxWidth(), Math.max(PANEL_MIN_WIDTH, window.innerWidth - e.clientX));
+      setExpanded(false);
+      setPanelWidth(next);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      window.localStorage.setItem(PANEL_WIDTH_KEY, String(Math.round(widthRef.current)));
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, []);
+
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+  }, []);
+
+  const resetWidth = useCallback(() => {
+    setExpanded(false);
+    setPanelWidth(PANEL_DEFAULT_WIDTH);
+    window.localStorage.setItem(PANEL_WIDTH_KEY, String(PANEL_DEFAULT_WIDTH));
+  }, []);
+
+  const panelStyleWidth = expanded ? "95vw" : `${panelWidth}px`;
+
+  const [detail, setDetail] = useState<EndpointDetail | null>(null);
+  const [timeseries, setTimeseries] = useState<TimeseriesPoint[] | null>(null);
+  const [consumers, setConsumers] = useState<ConsumerRow[] | null>(null);
+  const [statusCodes, setStatusCodes] = useState<StatusCodeRow[] | null>(null);
+  const [recentRequests, setRecentRequests] = useState<RequestRow[] | null>(null);
+  const [errorRequests, setErrorRequests] = useState<RequestRow[] | null>(null);
+  const [histograms, setHistograms] = useState<Histograms | null>(null);
+
+  const loadingRef = useRef<Set<string>>(new Set());
+  // Bumped on every endpoint/filter change so in-flight responses from a prior
+  // selection can be detected and discarded (prevents stale data overwrites).
+  const reqIdRef = useRef(0);
+  const [, forceRender] = useState(0);
+
+  const baseParams = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("method", endpoint.method);
+    params.set("path", endpoint.path);
+    if (appSlugs.length) params.set("app_slugs", appSlugs.join(","));
+    params.set("since", since);
+    if (until) params.set("until", until);
+    if (environment) params.set("environment", environment);
+    return params;
+  }, [endpoint.method, endpoint.path, appSlugs, since, until, environment]);
+
+  // Reset all cached data whenever the endpoint or filters change.
+  useEffect(() => {
+    reqIdRef.current += 1;
+    setDetail(null);
+    setTimeseries(null);
+    setConsumers(null);
+    setStatusCodes(null);
+    setRecentRequests(null);
+    setErrorRequests(null);
+    setHistograms(null);
+    loadingRef.current = new Set();
+  }, [baseParams]);
+
+  const fetchResource = useCallback(
+    async <T,>(
+      key: string,
+      endpointPath: string,
+      setter: (val: T) => void,
+      emptyValue: T,
+      extra?: Record<string, string>,
+    ) => {
+      if (loadingRef.current.has(key)) return;
+      loadingRef.current.add(key);
+      const reqId = reqIdRef.current;
+      forceRender((n) => n + 1);
+      try {
+        const params = new URLSearchParams(baseParams);
+        if (extra) {
+          for (const [k, v] of Object.entries(extra)) params.set(k, v);
+        }
+        const res = await fetch(
+          `/api/projects/${projectSlug}/analytics/${endpointPath}?${params.toString()}`,
+        );
+        // Discard responses superseded by a newer endpoint/filter selection.
+        if (reqId !== reqIdRef.current) return;
+        setter(res.ok ? ((await res.json()) as T) : emptyValue);
+      } catch {
+        // Surface an empty state (not a stuck skeleton) on transient failures.
+        if (reqId === reqIdRef.current) setter(emptyValue);
+      } finally {
+        // Always clear the key so a later dep change can retry this resource.
+        loadingRef.current.delete(key);
+        forceRender((n) => n + 1);
+      }
+    },
+    [baseParams, projectSlug],
+  );
+
+  // Load the data each active tab needs (shared resources are cached).
+  useEffect(() => {
+    if (detail === null) {
+      fetchResource<EndpointDetail>("detail", "endpoint-detail", setDetail, EMPTY_DETAIL);
+    }
+    if (activeTab === "requests") {
+      if (timeseries === null) fetchResource<TimeseriesPoint[]>("timeseries", "endpoint-timeseries", setTimeseries, []);
+      if (consumers === null) fetchResource<ConsumerRow[]>("consumers", "endpoint-consumers", setConsumers, [], { limit: "8" });
+      if (recentRequests === null) fetchResource<RequestRow[]>("requests", "endpoint-requests", setRecentRequests, [], { limit: "10" });
+    } else if (activeTab === "errors") {
+      if (timeseries === null) fetchResource<TimeseriesPoint[]>("timeseries", "endpoint-timeseries", setTimeseries, []);
+      if (statusCodes === null) fetchResource<StatusCodeRow[]>("status-codes", "endpoint-status-codes", setStatusCodes, []);
+      if (errorRequests === null) fetchResource<RequestRow[]>("error-requests", "endpoint-requests", setErrorRequests, [], { limit: "10", errors_only: "true" });
+    } else if (activeTab === "response-times") {
+      if (timeseries === null) fetchResource<TimeseriesPoint[]>("timeseries", "endpoint-timeseries", setTimeseries, []);
+      if (histograms === null) fetchResource<Histograms>("histograms", "endpoint-histograms", setHistograms, EMPTY_HISTOGRAMS);
+    } else if (activeTab === "data-transferred") {
+      if (timeseries === null) fetchResource<TimeseriesPoint[]>("timeseries", "endpoint-timeseries", setTimeseries, []);
+      if (histograms === null) fetchResource<Histograms>("histograms", "endpoint-histograms", setHistograms, EMPTY_HISTOGRAMS);
+    }
+  }, [activeTab, detail, timeseries, consumers, statusCodes, recentRequests, errorRequests, histograms, fetchResource]);
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Lock background scroll while the drawer is open.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  const isLoading = (key: string) => loadingRef.current.has(key) &&
+    ((key === "detail" && detail === null) ||
+      (key === "timeseries" && timeseries === null) ||
+      (key === "consumers" && consumers === null) ||
+      (key === "status-codes" && statusCodes === null) ||
+      (key === "requests" && recentRequests === null) ||
+      (key === "error-requests" && errorRequests === null) ||
+      (key === "histograms" && histograms === null));
+
+  const overlay = (
+    <div className="endpoint-detail-overlay" onClick={onClose}>
+      <aside
+        className="endpoint-detail-panel"
+        style={{ width: panelStyleWidth }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="endpoint-detail-resizer"
+          onMouseDown={startResize}
+          onDoubleClick={resetWidth}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize panel (double-click to reset)"
+          title="Drag to resize · double-click to reset"
+        >
+          <span className="endpoint-detail-resizer-grip">
+            <GripVertical size={14} />
+          </span>
+        </div>
+        <header className="endpoint-detail-header">
+          <div className="endpoint-detail-breadcrumb">
+            <span>Endpoint details</span>
+          </div>
+          <div className="endpoint-detail-header-actions">
+            <button
+              type="button"
+              className="endpoint-detail-close"
+              onClick={() => setExpanded((v) => !v)}
+              aria-label={expanded ? "Restore panel width" : "Expand panel"}
+              title={expanded ? "Restore width" : "Expand"}
+            >
+              {expanded ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            </button>
+            <button type="button" className="endpoint-detail-close" onClick={onClose} aria-label="Close">
+              <X size={18} />
+            </button>
+          </div>
+        </header>
+
+        <div className="endpoint-detail-title">
+          <span className={`method-badge method-badge-${endpoint.method.toLowerCase()}`}>{endpoint.method}</span>
+          <span className="endpoint-detail-path">{endpoint.path}</span>
+        </div>
+
+        <nav className="endpoint-detail-tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              className={`endpoint-detail-tab${activeTab === tab.key ? " active" : ""}`}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="endpoint-detail-period">
+          <span className="endpoint-detail-period-chip">Period · {rangeLabel}{environment ? ` · ${environment}` : ""}</span>
+        </div>
+
+        <div className="endpoint-detail-body">
+          {activeTab === "requests" && (
+            <RequestsTab
+              detail={detail}
+              timeseries={timeseries}
+              consumers={consumers}
+              requests={recentRequests}
+            />
+          )}
+          {activeTab === "errors" && (
+            <ErrorsTab timeseries={timeseries} statusCodes={statusCodes} errorRequests={errorRequests} />
+          )}
+          {activeTab === "response-times" && (
+            <ResponseTimesTab detail={detail} timeseries={timeseries} histograms={histograms} />
+          )}
+          {activeTab === "data-transferred" && (
+            <DataTransferredTab detail={detail} timeseries={timeseries} histograms={histograms} />
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+
+  // Portal to <body> so no transformed/stacking ancestor can offset or clip the
+  // drawer — guarantees it spans the full viewport height from the very top.
+  if (typeof document === "undefined") return null;
+  return createPortal(overlay, document.body);
+}
+
+/* ── Shared building blocks ──────────────────────────────────────────── */
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="endpoint-detail-section">
+      <h4 className="endpoint-detail-section-title">{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function StatCard({ label, value, tone }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="endpoint-stat-card">
+      <p className="endpoint-stat-label">{label}</p>
+      <p className={`endpoint-stat-value${tone ? ` ${tone}` : ""}`}>{value}</p>
+    </div>
+  );
+}
+
+function EmptyBlock({ message }: { message: string }) {
+  return <div className="endpoint-detail-empty">{message}</div>;
+}
+
+/**
+ * Fixed-height frame for recharts. recharts 3's ResponsiveContainer collapses
+ * to 0×0 when its parent has no resolved height (common inside flex/animated
+ * panels), so we pin an explicit height here and let it fill 100% — this is
+ * what stops charts from rendering blank.
+ */
+function ChartBox({ height = 220, children }: { height?: number; children: React.ReactElement }) {
+  return (
+    <div className="endpoint-chart-frame" style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        {children}
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function Skeleton({ height = 120 }: { height?: number }) {
+  return <div className="endpoint-skeleton" style={{ height }} aria-hidden="true" />;
+}
+
+function ChartTooltip({ active, payload, label, valueFormatter }: any) {
+  if (!active || !payload || !payload.length) return null;
+  return (
+    <div className="endpoint-chart-tooltip">
+      <p className="endpoint-chart-tooltip-label">{label}</p>
+      {payload.map((entry: any) => (
+        <p key={entry.dataKey} style={{ color: entry.color }}>
+          {entry.name}: {valueFormatter ? valueFormatter(entry.value) : formatNumber(entry.value)}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/* ── Info tab ────────────────────────────────────────────────────────── */
+
+function InfoTab({ detail, loading }: { detail: EndpointDetail | null; loading: boolean }) {
+  if (loading && !detail) return <Skeleton height={72} />;
+  return (
+    <Section title="Summary">
+      <div className="endpoint-detail-summary-box">
+        {detail?.description ? detail.description : <span className="endpoint-detail-muted">No description provided for this endpoint.</span>}
+      </div>
+    </Section>
+  );
+}
+
+/* ── Requests tab ────────────────────────────────────────────────────── */
+
+function RequestsTab({
+  detail,
+  timeseries,
+  consumers,
+  requests,
+}: {
+  detail: EndpointDetail | null;
+  timeseries: TimeseriesPoint[] | null;
+  consumers: ConsumerRow[] | null;
+  requests: RequestRow[] | null;
+}) {
+  const chartData = (timeseries || []).map((p) => ({
+    label: formatBucketTime(p.bucket),
+    requests: p.total_requests,
+  }));
+  const consumerData = (consumers || []).map((c) => ({
+    label: c.consumer.length > 28 ? `${c.consumer.slice(0, 28)}…` : c.consumer,
+    requests: c.total_requests,
+  }));
+
+  return (
+    <>
+      <Section title="Summary">
+        <div className="endpoint-stat-grid">
+          <StatCard label="Total requests" value={formatNumber(detail?.total_requests || 0)} />
+          <StatCard label="Requests per minute" value={(detail?.requests_per_minute || 0).toFixed(2)} />
+          <StatCard label="Successful requests" value={formatNumber(detail?.successful_requests || 0)} tone="tone-good" />
+          <StatCard label="Client errors" value={formatNumber(detail?.client_errors || 0)} tone={detail?.client_errors ? "tone-warn" : undefined} />
+          <StatCard label="Server errors" value={formatNumber(detail?.server_errors || 0)} tone={detail?.server_errors ? "tone-bad" : undefined} />
+        </div>
+      </Section>
+
+      <Section title="Requests over time">
+        {timeseries === null ? (
+          <Skeleton height={220} />
+        ) : chartData.length === 0 ? (
+          <EmptyBlock message="No requests in the selected period." />
+        ) : (
+          <ChartBox height={220}>
+            <BarChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={AXIS_TICK} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} allowDecimals={false} tickLine={false} axisLine={false} width={36} />
+              <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(20,184,166,0.08)" }} />
+              <Bar dataKey="requests" name="Requests" fill={ACCENT} radius={[3, 3, 0, 0]} maxBarSize={40} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+
+      <Section title="Requests per consumer">
+        {consumers === null ? (
+          <Skeleton height={180} />
+        ) : consumerData.length === 0 ? (
+          <EmptyBlock message="No consumer data in the selected period." />
+        ) : (
+          <ChartBox height={Math.max(150, consumerData.length * 36)}>
+            <BarChart data={consumerData} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 8 }}>
+              <CartesianGrid stroke={GRID} horizontal={false} />
+              <XAxis type="number" tick={AXIS_TICK} allowDecimals={false} tickLine={false} axisLine={false} />
+              <YAxis type="category" dataKey="label" width={170} tick={{ fontSize: 11, fill: "var(--text-secondary)" }} tickLine={false} axisLine={false} />
+              <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(20,184,166,0.08)" }} />
+              <Bar dataKey="requests" name="Requests" fill={ACCENT} radius={[0, 3, 3, 0]} maxBarSize={22} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+
+      <Section title="Most recent requests">
+        <RequestsTable rows={requests} emptyMessage="No logged requests." />
+      </Section>
+    </>
+  );
+}
+
+function RequestsTable({ rows, emptyMessage }: { rows: RequestRow[] | null; emptyMessage: string }) {
+  const [selected, setSelected] = useState<RequestRow | null>(null);
+
+  if (!rows) return <Skeleton height={140} />;
+  if (rows.length === 0) return <EmptyBlock message={emptyMessage} />;
+  return (
+    <>
+      <div className="endpoint-detail-table-wrapper">
+        <table className="endpoint-detail-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Status</th>
+              <th>Consumer</th>
+              <th>Response</th>
+              <th aria-hidden="true" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr
+                key={`${r.timestamp}-${i}`}
+                className="request-row-clickable"
+                onClick={() => setSelected(r)}
+                tabIndex={0}
+                role="button"
+                aria-label="View request and response payload"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setSelected(r);
+                  }
+                }}
+              >
+                <td className="endpoint-detail-time">{formatDateTime(r.timestamp)}</td>
+                <td>
+                  <span className={`endpoint-status-pill ${statusTone(r.status_code)}`}>{r.status_code}</span>
+                </td>
+                <td className="endpoint-detail-consumer">{r.consumer || "—"}</td>
+                <td className="endpoint-detail-time">{formatMs(r.response_time_ms)}</td>
+                <td className="request-row-chevron"><ChevronRight size={14} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {selected && <RequestPayloadModal row={selected} onClose={() => setSelected(null)} />}
+    </>
+  );
+}
+
+function formatPayload(raw: string | undefined): string {
+  if (!raw || !raw.trim()) return "";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function highlightJson(json: string): string {
+  const escaped = json
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped.replace(
+    /("(?:[^"\\]|\\.)*"(?:\s*:)?|(?<!["\w])-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?(?!["\w])|\btrue\b|\bfalse\b|\bnull\b)/g,
+    (match) => {
+      if (match.endsWith(":")) return `<span class="json-key">${match}</span>`;
+      if (match.startsWith('"')) return `<span class="json-string">${match}</span>`;
+      if (match === "true" || match === "false") return `<span class="json-bool">${match}</span>`;
+      if (match === "null") return `<span class="json-null">${match}</span>`;
+      return `<span class="json-number">${match}</span>`;
+    },
+  );
+}
+
+function PayloadBlock({ title, body }: { title: string; body: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(body);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — silently ignore.
+    }
+  };
+  const isJson = !!body && (() => { try { JSON.parse(body); return true; } catch { return false; } })();
+  return (
+    <section className="request-payload-section">
+      <div className="request-payload-section-head">
+        <h4>{title}</h4>
+        {body ? (
+          <button type="button" className="request-payload-copy" onClick={copy}>
+            {copied ? <Check size={13} /> : <Copy size={13} />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        ) : null}
+      </div>
+      {body ? (
+        isJson ? (
+          <pre
+            className="request-payload-pre"
+            dangerouslySetInnerHTML={{ __html: highlightJson(body) }}
+          />
+        ) : (
+          <pre className="request-payload-pre">{body}</pre>
+        )
+      ) : (
+        <div className="endpoint-detail-empty">No payload captured.</div>
+      )}
+    </section>
+  );
+}
+
+function RequestPayloadModal({ row, onClose }: { row: RequestRow; onClose: () => void }) {
+  // Close on Escape; capture-phase + stopPropagation so it closes this popup
+  // only (not the underlying drawer, which also listens for Escape).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  const content = (
+    <div className="request-payload-overlay" onClick={onClose}>
+      <div className="request-payload-modal" onClick={(e) => e.stopPropagation()}>
+        <header className="request-payload-header">
+          <div className="request-payload-title">
+            <span className={`method-badge method-badge-${row.method.toLowerCase()}`}>{row.method}</span>
+            <span className="request-payload-path">{row.path}</span>
+            <span className={`endpoint-status-pill ${statusTone(row.status_code)}`}>{row.status_code}</span>
+          </div>
+          <button type="button" className="endpoint-detail-close" onClick={onClose} aria-label="Close">
+            <X size={18} />
+          </button>
+        </header>
+        <div className="request-payload-meta">
+          <span>{formatDateTime(row.timestamp)}</span>
+          <span>·</span>
+          <span>{formatMs(row.response_time_ms)}</span>
+          {row.consumer ? (
+            <>
+              <span>·</span>
+              <span className="request-payload-meta-consumer">{row.consumer}</span>
+            </>
+          ) : null}
+          {row.environment ? (
+            <>
+              <span>·</span>
+              <span>{row.environment}</span>
+            </>
+          ) : null}
+        </div>
+        <div className="request-payload-body">
+          <PayloadBlock title="Request payload" body={formatPayload(row.request_payload)} />
+          <PayloadBlock title="Response payload" body={formatPayload(row.response_payload)} />
+        </div>
+      </div>
+    </div>
+  );
+
+  if (typeof document === "undefined") return null;
+  return createPortal(content, document.body);
+}
+
+/* ── Errors tab ──────────────────────────────────────────────────────── */
+
+function ErrorsTab({
+  timeseries,
+  statusCodes,
+  errorRequests,
+}: {
+  timeseries: TimeseriesPoint[] | null;
+  statusCodes: StatusCodeRow[] | null;
+  errorRequests: RequestRow[] | null;
+}) {
+  const errorCodes = (statusCodes || []).filter((s) => s.status_code >= 400);
+  const totalErrors = errorCodes.reduce((acc, s) => acc + s.total_requests, 0);
+  const chartData = (timeseries || []).map((p) => ({
+    label: formatBucketTime(p.bucket),
+    client: p.client_errors,
+    server: p.server_errors,
+  }));
+  const hasErrorsOverTime = chartData.some((d) => d.client > 0 || d.server > 0);
+
+  return (
+    <>
+      <Section title="Errors by status code">
+        {statusCodes === null ? (
+          <Skeleton height={120} />
+        ) : errorCodes.length === 0 ? (
+          <EmptyBlock message="No errors in the selected period." />
+        ) : (
+          <div className="endpoint-status-breakdown">
+            {errorCodes.map((s) => {
+              const pct = totalErrors > 0 ? (s.total_requests / totalErrors) * 100 : 0;
+              return (
+                <div key={s.status_code} className="endpoint-status-row">
+                  <span className={`endpoint-status-pill ${statusTone(s.status_code)}`}>{s.status_code}</span>
+                  <div className="endpoint-status-bar-track">
+                    <div
+                      className={`endpoint-status-bar ${s.status_code >= 500 ? "is-server" : "is-client"}`}
+                      style={{ width: `${Math.max(2, pct)}%` }}
+                    />
+                  </div>
+                  <span className="endpoint-status-count">{formatNumber(s.total_requests)}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+
+      <Section title="Client & server errors over time">
+        {timeseries === null ? (
+          <Skeleton height={220} />
+        ) : !hasErrorsOverTime ? (
+          <EmptyBlock message="No errors in the selected period." />
+        ) : (
+          <ChartBox height={220}>
+            <BarChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={AXIS_TICK} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} allowDecimals={false} tickLine={false} axisLine={false} width={36} />
+              <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(248,113,113,0.08)" }} />
+              <Bar dataKey="client" name="Client (4xx)" stackId="e" fill={CLIENT_ERR} radius={[0, 0, 0, 0]} maxBarSize={40} />
+              <Bar dataKey="server" name="Server (5xx)" stackId="e" fill={SERVER_ERR} radius={[3, 3, 0, 0]} maxBarSize={40} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+
+      <Section title="Most recent client & server errors">
+        <RequestsTable rows={errorRequests} emptyMessage="No logged requests." />
+      </Section>
+    </>
+  );
+}
+
+/* ── Response times tab ──────────────────────────────────────────────── */
+
+function ResponseTimesTab({
+  detail,
+  timeseries,
+  histograms,
+}: {
+  detail: EndpointDetail | null;
+  timeseries: TimeseriesPoint[] | null;
+  histograms: Histograms | null;
+}) {
+  const chartData = (timeseries || []).map((p) => ({
+    label: formatBucketTime(p.bucket),
+    avg: Math.round(p.avg_response_time_ms),
+  }));
+  const histData = (histograms?.response_time || []).map((b) => ({
+    label: `${Math.round(b.lower)} ms`,
+    count: b.count,
+  }));
+
+  return (
+    <>
+      <Section title="Summary">
+        <div className="endpoint-stat-grid">
+          <StatCard label="Apdex score" value={(detail?.apdex || 0).toFixed(3)} />
+          <StatCard
+            label="Slow requests"
+            value={formatNumber(detail?.slow_requests || 0)}
+            tone={detail?.slow_requests ? "tone-warn" : undefined}
+          />
+          <StatCard label="50th percentile" value={formatMs(detail?.p50_response_time_ms || 0)} />
+          <StatCard label="75th percentile" value={formatMs(detail?.p75_response_time_ms || 0)} />
+          <StatCard label="95th percentile" value={formatMs(detail?.p95_response_time_ms || 0)} />
+        </div>
+        {detail ? (
+          <p className="endpoint-detail-note">Response time threshold = {formatMs(detail.threshold_ms)}</p>
+        ) : null}
+      </Section>
+
+      <Section title="Response times over time">
+        {timeseries === null ? (
+          <Skeleton height={220} />
+        ) : chartData.length === 0 ? (
+          <EmptyBlock message="No requests in the selected period." />
+        ) : (
+          <ChartBox height={220}>
+            <AreaChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+              <defs>
+                <linearGradient id="rtGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={ACCENT} stopOpacity={0.35} />
+                  <stop offset="100%" stopColor={ACCENT} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={AXIS_TICK} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} tickLine={false} axisLine={false} width={40} tickFormatter={(v) => `${v}`} />
+              <Tooltip content={<ChartTooltip valueFormatter={formatMs} />} cursor={{ stroke: ACCENT, strokeDasharray: "3 3" }} />
+              <Area type="monotone" dataKey="avg" name="Avg response" stroke={ACCENT} strokeWidth={2} fill="url(#rtGradient)" />
+            </AreaChart>
+          </ChartBox>
+        )}
+      </Section>
+
+      <Section title="Histogram of response times">
+        {histograms === null ? (
+          <Skeleton height={200} />
+        ) : histData.length === 0 ? (
+          <EmptyBlock message="No requests in the selected period." />
+        ) : (
+          <ChartBox height={200}>
+            <BarChart data={histData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 9, fill: "var(--text-muted)" }} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} allowDecimals={false} tickLine={false} axisLine={false} width={32} />
+              <Tooltip content={<ChartTooltip valueFormatter={(v: number) => formatNumber(v)} />} cursor={{ fill: "rgba(20,184,166,0.08)" }} />
+              <Bar dataKey="count" name="Requests" fill={ACCENT} radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+    </>
+  );
+}
+
+/* ── Data transferred tab ────────────────────────────────────────────── */
+
+function DataTransferredTab({
+  detail,
+  timeseries,
+  histograms,
+}: {
+  detail: EndpointDetail | null;
+  timeseries: TimeseriesPoint[] | null;
+  histograms: Histograms | null;
+}) {
+  const chartData = (timeseries || []).map((p) => ({
+    label: formatBucketTime(p.bucket),
+    bytes: (p.total_request_bytes || 0) + (p.total_response_bytes || 0),
+  }));
+  const hasData = chartData.some((d) => d.bytes > 0);
+  const histData = (histograms?.response_size || []).map((b) => ({
+    label: formatBytes(b.lower),
+    count: b.count,
+  }));
+
+  return (
+    <>
+      <Section title="Summary">
+        <div className="endpoint-stat-grid">
+          <StatCard label="Total data transferred" value={formatBytes(detail?.total_data_transferred || 0)} />
+          <StatCard label="Average response size" value={formatBytes(detail?.avg_response_size || 0)} />
+        </div>
+      </Section>
+
+      <Section title="Data transferred over time">
+        {timeseries === null ? (
+          <Skeleton height={220} />
+        ) : !hasData ? (
+          <EmptyBlock message="No data transferred in the selected period." />
+        ) : (
+          <ChartBox height={220}>
+            <BarChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -4 }}>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={AXIS_TICK} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} tickFormatter={(v) => formatBytes(v)} width={56} tickLine={false} axisLine={false} />
+              <Tooltip content={<ChartTooltip valueFormatter={formatBytes} />} cursor={{ fill: "rgba(20,184,166,0.08)" }} />
+              <Bar dataKey="bytes" name="Transferred" fill={ACCENT} radius={[3, 3, 0, 0]} maxBarSize={40} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+
+      <Section title="Histogram of response sizes">
+        {histograms === null ? (
+          <Skeleton height={200} />
+        ) : histData.length === 0 ? (
+          <EmptyBlock message="No requests in the selected period." />
+        ) : (
+          <ChartBox height={200}>
+            <BarChart data={histData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+              <CartesianGrid stroke={GRID} vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 9, fill: "var(--text-muted)" }} interval="preserveStartEnd" tickLine={false} axisLine={{ stroke: GRID }} />
+              <YAxis tick={AXIS_TICK} allowDecimals={false} tickLine={false} axisLine={false} width={32} />
+              <Tooltip content={<ChartTooltip valueFormatter={(v: number) => formatNumber(v)} />} cursor={{ fill: "rgba(20,184,166,0.08)" }} />
+              <Bar dataKey="count" name="Requests" fill={ACCENT} radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ChartBox>
+        )}
+      </Section>
+    </>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1004,14 +1004,20 @@ export const apiClient = {
     return fetchDjango<EndpointMeta>(`/apps/${slug}/endpoint-meta?${qs.toString()}`);
   },
 
-  async setPassword(data: {
-    new_password: string;
-    confirm_password: string;
-    current_password?: string;
-  }): Promise<ApiResponse<{ message: string; access_token: string; refresh_token: string }>> {
-    return fetchDjango<{ message: string; access_token: string; refresh_token: string }>(
-      "/users/me/password",
-      { method: "POST", body: JSON.stringify(data) },
+  async getEndpointStatusCodes(
+    slug: string,
+    params: { method: string; path: string; environment?: string; since?: string; until?: string; limit?: number },
+  ): Promise<ApiResponse<EndpointStatusCode[]>> {
+    const searchParams = new URLSearchParams();
+    searchParams.set("method", params.method);
+    searchParams.set("path", params.path);
+    if (params.environment) searchParams.set("environment", params.environment);
+    if (params.since) searchParams.set("since", params.since);
+    if (params.until) searchParams.set("until", params.until);
+    if (params.limit) searchParams.set("limit", String(params.limit));
+    const qs = searchParams.toString();
+    return fetchDjango<EndpointStatusCode[]>(
+      `/apps/${slug}/analytics/endpoint-status-codes${qs ? `?${qs}` : ""}`,
     );
   },
 

--- a/apps/web/src/lib/session-edge.ts
+++ b/apps/web/src/lib/session-edge.ts
@@ -1,0 +1,62 @@
+/**
+ * Edge-safe session-cookie verification for middleware.
+ *
+ * `session.ts` decrypts the cookie with Node's `crypto` (Server Components /
+ * route handlers). Middleware runs on the edge runtime where `node:crypto`
+ * isn't available, so we re-verify here with the Web Crypto API.
+ *
+ * Both sides MUST agree on the cookie shape, or the auth gate loops:
+ *   base64url( iv[12] || authTag[16] || ciphertext )  — AES-256-GCM,
+ *   key = SHA-256(SESSION_SECRET).
+ * Keep this in lock-step with `setSession`/`getSession` in `session.ts`.
+ */
+
+const ALGORITHM = "AES-GCM";
+
+function base64urlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+  const bin = atob(b64 + pad);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+async function getKey(): Promise<CryptoKey> {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET environment variable is required");
+  }
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", hash, { name: ALGORITHM }, false, ["decrypt"]);
+}
+
+/**
+ * Returns true only when the cookie decrypts AND carries a usable session.
+ * Anything else (missing, malformed, wrong secret, tampered) → false, so the
+ * caller can treat it as logged-out and clear the stale cookie.
+ */
+export async function verifySessionCookie(value: string | undefined): Promise<boolean> {
+  if (!value) return false;
+  try {
+    const raw = base64urlToBytes(value);
+    if (raw.length <= 28) return false; // need iv(12) + tag(16) + at least 1 byte
+
+    // Copy into fresh ArrayBuffer-backed arrays so they satisfy BufferSource.
+    const iv = new Uint8Array(raw.subarray(0, 12));
+    const tag = raw.subarray(12, 28);
+    const ciphertext = raw.subarray(28);
+
+    // Web Crypto expects ciphertext concatenated with the auth tag.
+    const data = new Uint8Array(ciphertext.length + tag.length);
+    data.set(ciphertext, 0);
+    data.set(tag, ciphertext.length);
+
+    const key = await getKey();
+    const decrypted = await crypto.subtle.decrypt({ name: ALGORITHM, iv }, key, data);
+    const parsed = JSON.parse(new TextDecoder().decode(decrypted));
+    return typeof parsed?.accessToken === "string" && parsed.accessToken.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,14 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
+import { verifySessionCookie } from "@/lib/session-edge";
 
+const COOKIE_NAME = "apilens_session";
 const PUBLIC_PATHS = ["/auth/login", "/auth/signup", "/auth/verify", "/auth/reset-password", "/auth/recovery", "/api/auth/"];
 const AUTH_PAGES = ["/auth/login", "/auth/signup", "/auth/verify", "/auth/reset-password", "/auth/recovery"];
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const session = request.cookies.get("apilens_session");
+  const cookie = request.cookies.get(COOKIE_NAME);
+  // Decrypt-verify the cookie so "has session" means "valid session" — the
+  // same check Server Components make via getSession(). Trusting mere cookie
+  // presence here while pages validate the contents causes a redirect loop
+  // (ERR_TOO_MANY_REDIRECTS) for any stale/undecryptable cookie.
+  const isAuthed = await verifySessionCookie(cookie?.value);
 
   // Logged-in users hitting auth pages → redirect to home
-  if (session && AUTH_PAGES.some((p) => pathname.startsWith(p))) {
+  if (isAuthed && AUTH_PAGES.some((p) => pathname.startsWith(p))) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
@@ -17,9 +24,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Not logged in + not an API route → redirect to login
-  if (!session && !pathname.startsWith("/api/")) {
-    return NextResponse.redirect(new URL("/auth/login", request.url));
+  // Not logged in + not an API route → redirect to login.
+  // Drop any stale/invalid cookie on the way out so we don't bounce again.
+  if (!isAuthed && !pathname.startsWith("/api/")) {
+    const res = NextResponse.redirect(new URL("/auth/login", request.url));
+    if (cookie) res.cookies.delete(COOKIE_NAME);
+    return res;
   }
 
   return NextResponse.next();

--- a/infra/docker/docker-compose.local.yml
+++ b/infra/docker/docker-compose.local.yml
@@ -34,6 +34,12 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24-alpine
     restart: unless-stopped
+    # Docker's default seccomp profile blocks the NUMA syscalls (get_mempolicy,
+    # set_mempolicy, ...) unless CAP_SYS_NICE is present, which makes ClickHouse
+    # log a harmless "get_mempolicy: Operation not permitted" at startup.
+    # Granting this one capability lets those syscalls through and silences it.
+    cap_add:
+      - SYS_NICE
     environment:
       CLICKHOUSE_DB: apilens
       CLICKHOUSE_USER: default
@@ -61,6 +67,26 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       retries: 5
+
+  # Policy Decision Point — mirrors the prod OPA sidecar so local authz behaves
+  # like production instead of always falling back to the DB guard. Loads the
+  # same rego the VM ships via instance metadata (infra/opa/policies).
+  # The host-run core API reaches it at http://localhost:8181 (set OPA_URL in
+  # apps/api/.env).
+  opa:
+    image: openpolicyagent/opa:1.17.0
+    restart: unless-stopped
+    command:
+      - "run"
+      - "--server"
+      - "--addr=0.0.0.0:8181"
+      - "--log-level=info"
+      - "--set=decision_logs.console=true"
+      - "/policies"
+    ports:
+      - "8181:8181"
+    volumes:
+      - ../opa/policies:/policies:ro
 
 volumes:
   postgres_data:

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,0 +1,53 @@
+# Local dev stack for APILens — one tab per service.
+#
+#   pnpm dev      (alias: pnpm stack)
+#
+# Left pane lists every process; arrow keys / mouse switch between them, each
+# with its own live log output.
+#
+# Focus & controls:
+#   <C-a>  toggle focus between the process list and the output pane
+#   q      quit  (must be focused on the process list)
+#   Q      force quit
+#   r      restart selected proc · x stop · s start
+#
+# Lifecycle note: the datastore tabs (postgres/clickhouse/redis/authz) START
+# their containers detached, then just *tail* the logs — so quitting mprocs is
+# instant and leaves the databases running (the same model as `pnpm db:up`).
+# Stop the containers with `pnpm db:down` when you're done for the day.
+# Only api/ingest/web are torn down on quit.
+#
+# SDK sidecar services (fastapi/:8011, flask/:8012, django-ninja/:8013) are
+# listed but NOT auto-started. Select one and press `s` to start it when you
+# need to test SDK integration. Requires: cd sidecar-testing/<name> && pip install -r requirements.txt
+# and a populated .env (APILENS_API_KEY + APILENS_APP_ID).
+procs:
+  postgres:
+    shell: "docker compose -f infra/docker/docker-compose.local.yml up -d postgres && docker compose -f infra/docker/docker-compose.local.yml logs -f --no-log-prefix postgres"
+  clickhouse:
+    shell: "docker compose -f infra/docker/docker-compose.local.yml up -d clickhouse && docker compose -f infra/docker/docker-compose.local.yml logs -f --no-log-prefix clickhouse"
+  redis:
+    shell: "docker compose -f infra/docker/docker-compose.local.yml up -d redis && docker compose -f infra/docker/docker-compose.local.yml logs -f --no-log-prefix redis"
+  authz:
+    shell: "docker compose -f infra/docker/docker-compose.local.yml up -d opa && docker compose -f infra/docker/docker-compose.local.yml logs -f --no-log-prefix opa"
+  api:
+    # Django control plane (core API). Waits briefly so Postgres is accepting
+    # connections before the first request. Loads apps/api/.env via dotenv.
+    shell: "sleep 4 && cd apps/api && .venv/bin/python manage.py runserver 0.0.0.0:8000"
+  ingest:
+    # Standalone FastAPI ingestion service on :8001. --env-file loads the
+    # datastore + introspection settings from apps/ingest/.env.
+    shell: "sleep 5 && cd apps/ingest && .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8001 --env-file .env"
+  web:
+    # Next.js dashboard on :3002.
+    shell: "pnpm --filter frontend dev"
+  # ── SDK integration sidecars (off by default — press `s` to start) ──────────
+  sidecar-fastapi:
+    autostart: false
+    shell: "cd sidecar-testing/fastapi && ([ -d .venv ] || python3 -m venv .venv && .venv/bin/pip install -q -r requirements.txt) && . .venv/bin/activate && PYTHONUNBUFFERED=1 uvicorn app.main:app --host 0.0.0.0 --port 8011 --reload"
+  sidecar-flask:
+    autostart: false
+    shell: "cd sidecar-testing/flask && ([ -d .venv ] || python3 -m venv .venv && .venv/bin/pip install -q -r requirements.txt) && . .venv/bin/activate && PYTHONUNBUFFERED=1 python app/main.py"
+  sidecar-django:
+    autostart: false
+    shell: "cd sidecar-testing/django-ninja && ([ -d .venv ] || python3 -m venv .venv && .venv/bin/pip install -q -r requirements.txt) && . .venv/bin/activate && PYTHONUNBUFFERED=1 python manage.py runserver 0.0.0.0:8013"

--- a/package.json
+++ b/package.json
@@ -9,16 +9,19 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "mprocs",
+    "dev:apps": "turbo run dev",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "db:up": "docker compose -f infra/docker/docker-compose.local.yml up -d",
     "db:down": "docker compose -f infra/docker/docker-compose.local.yml down",
     "db:logs": "docker compose -f infra/docker/docker-compose.local.yml logs -f",
+    "stack": "mprocs",
     "bootstrap": "bash scripts/setup/setup-local.sh"
   },
   "devDependencies": {
+    "mprocs": "^0.9.5",
     "turbo": "^2.3.0",
     "typescript": "^5.7.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      mprocs:
+        specifier: ^0.9.5
+        version: 0.9.5
       turbo:
         specifier: ^2.3.0
         version: 2.9.15
@@ -2591,6 +2594,11 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mprocs@0.9.5:
+    resolution: {integrity: sha512-GGxetNBhZMGZD8RJCa1dK3a8VDahXwYhe2jMeUmgr3OGmCHitMK76TPMBY8aHzmBBDB1tNTtl41NdpH+BPAKQg==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5865,6 +5873,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
+
+  mprocs@0.9.5: {}
 
   ms@2.1.3: {}
 

--- a/scripts/setup/setup-local.sh
+++ b/scripts/setup/setup-local.sh
@@ -365,6 +365,12 @@ step_env() {
              "\"$(gen_hex)\"" \
              "Session encryption key"
 
+  _setup_env "apps/ingest/.env" \
+             "apps/ingest/.env.example" \
+             "INTERNAL_INTROSPECT_SECRET" \
+             "dev-secret" \
+             "Ingest introspection secret"
+
   step_done
 }
 
@@ -397,7 +403,7 @@ DB_CH_TCP=9000
 DB_REDIS=6379
 
 step_databases() {
-  step_start "Local databases" "Starts postgres, clickhouse, and redis via docker compose."
+  step_start "Local databases" "Starts postgres, clickhouse, redis, and the OPA authz engine via docker compose."
 
   if ! command -v docker >/dev/null 2>&1; then
     step_skip_blocked "Docker not found"
@@ -490,7 +496,7 @@ YML
     fi
   fi
 
-  if run_live "Starting postgres + clickhouse + redis" "${compose_cmd[@]}" up -d; then
+  if run_live "Starting postgres + clickhouse + redis + opa" "${compose_cmd[@]}" up -d; then
     STEP_DB_OK=true
     _print_db_ports
     step_done
@@ -648,7 +654,8 @@ _dev_port_warnings() {
 
 _next_steps() {
   printf "\n  ${CY}◆${R}  ${B}Start developing${R}\n\n"
-  printf "%s${CY}${B}pnpm dev${R}                ${D}Next.js (:3002) + Django (:8000) via turbo${R}\n" "$I_CONTENT"
+  printf "%s${CY}${B}pnpm dev${R}                ${D}Full stack in tabs (db + authz + api:8000 + ingest:8001 + web:3002)${R}\n" "$I_CONTENT"
+  printf "%s${CY}pnpm dev:apps${R}           ${D}Just frontend + Django via turbo (DBs must be up)${R}\n" "$I_CONTENT"
 
   printf "\n  ${CY}◆${R}  ${B}Handy commands${R}\n\n"
   printf "%s${CY}pnpm db:down${R}            ${D}Stop databases${R}\n" "$I_CONTENT"
@@ -660,7 +667,7 @@ _footer() {
   printf "\n  ${CY}◆${R}  ${B}Where to get help${R}\n\n"
   printf "%s${D}GitHub${R}         https://github.com/apilens/apilens\n" "$I_CONTENT"
   printf "%s${D}Docs${R}           apps/docs/\n"                          "$I_CONTENT"
-  printf "\n  ${D}Magic-link emails print in the Django pane in turbo.${R}\n"
+  printf "\n  ${D}Magic-link emails print in the api tab when you run pnpm dev.${R}\n"
   printf "  ${D}Copy the link from there to sign in.${R}\n\n"
 }
 


### PR DESCRIPTION
## Summary

- **Endpoint detail panel**: New slide-out drawer (`EndpointDetailPanel`) with 4 tabs — Requests, Errors, Response Times, Data Transferred. Includes charts, stat cards, consumer breakdown, recent requests table, and histograms. 6 new BFF API routes wire it to the backend analytics endpoints.
- **Safari passkey fix**: Touch ID prompt was silently not appearing in Safari because `navigator.credentials.get()` was called after `await fetch(...)`, losing the user gesture context. Fixed by pre-fetching the identify response on email `blur` so the click handler can call WebAuthn immediately with no prior await.
- **Payload modal redesign**: Request/response payloads now display side-by-side (2-column grid), JSON gets syntax highlighting (keys, strings, numbers, booleans, null), modal is wider (900px), and each pane has its own scrollable area.
- **Infra/dev**: session-edge.ts for edge-compatible session reads in middleware, mprocs.yaml for local multi-process dev, updated docker-compose and .env.examples for ingest service.

## Test plan

- [ ] Click an endpoint row → detail panel opens, all 4 tabs load data correctly
- [ ] Click a request row in the panel → payload modal opens with 2-column layout and syntax-highlighted JSON
- [ ] Safari: enter email for a passkey user, tab out, then click Continue → Touch ID prompt appears immediately
- [ ] Chrome/Firefox: passkey login still works (slow path falls back to fetch if no prefetch)
- [ ] Mobile (≤768px): payload modal collapses to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)