### PR TITLE
Fix product workflow validation gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ sidecar-testing/**/db.sqlite3
 
 # Next.js
 .next/
+.codex-run/
 out/
 
 

--- a/apps/api/apps/projects/filters.py
+++ b/apps/api/apps/projects/filters.py
@@ -185,7 +185,10 @@ def _render(pred: Predicate, spec: FieldSpec, key: str, params: dict) -> str:
             lo_key, hi_key = f"{key}_{i}_lo", f"{key}_{i}_hi"
             params[lo_key], params[hi_key] = lo, hi
             ranges.append(f"({col} >= %({lo_key})s AND {col} < %({hi_key})s)")
-        return " OR ".join(ranges)
+        clause = " OR ".join(ranges)
+        if pred.op == "not":
+            return f"NOT ({clause})"
+        return clause
 
     op = pred.op
 

--- a/apps/api/apps/projects/management/commands/synthetic_telemetry.py
+++ b/apps/api/apps/projects/management/commands/synthetic_telemetry.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.text import slugify
+
+from apps.projects.models import App, Environment, Project
+from apps.projects.synthetic.catalog import expand_scenario_keys, get_scenario, list_scenarios
+from apps.projects.synthetic.generator import AppTarget, SyntheticRunConfig, SyntheticTelemetryEngine
+from apps.projects.synthetic.validation import validate_count_and_days
+from apps.projects.synthetic.writers import DirectClickHouseWriter, HttpIngestWriter, JsonlWriter
+
+
+class Command(BaseCommand):
+    help = "Generate rich synthetic APILens request, log, and trace telemetry for demos, QA, and load data."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--list-scenarios", action="store_true", help="Print available scenario keys and exit")
+        parser.add_argument(
+            "--scenario",
+            action="append",
+            default=[],
+            help="Scenario key to generate. Repeat or pass comma-separated values. Defaults to all.",
+        )
+        parser.add_argument("--project-slug", default="", help="Target project slug for direct/http modes")
+        parser.add_argument("--owner-email", default="", help="Owner email used with --ensure-demo-project")
+        parser.add_argument(
+            "--ensure-demo-project",
+            action="store_true",
+            help="Create/update a synthetic project, apps, and environments before generation.",
+        )
+        parser.add_argument("--app-slugs", default="", help="Comma-separated real app slugs to target")
+        parser.add_argument("--count", type=int, default=5000, help="Number of request events to generate")
+        parser.add_argument("--days", type=int, default=14, help="Past time window to cover")
+        parser.add_argument("--seed", type=int, default=None, help="Fixed seed for repeatable output. Omit for hourly rotation.")
+        parser.add_argument(
+            "--accelerator",
+            choices=("auto", "cpu", "gpu"),
+            default="auto",
+            help="Random planner accelerator. auto uses CUDA through CuPy/Torch when available, otherwise CPU.",
+        )
+        parser.add_argument(
+            "--mode",
+            choices=("jsonl", "http", "direct"),
+            default="jsonl",
+            help="Output mode. jsonl is safe; http posts to ingest; direct writes local ClickHouse.",
+        )
+        parser.add_argument("--output-dir", default="", help="JSONL output directory")
+        parser.add_argument("--ingest-url", default="", help="Base ingest URL for --mode http, e.g. http://127.0.0.1:8001")
+        parser.add_argument("--api-key", default="", help="Project API key for --mode http")
+        parser.add_argument("--batch-size", type=int, default=1000, help="Write batch size, capped at 1000")
+        parser.add_argument("--no-logs", action="store_true", help="Do not generate correlated log events")
+        parser.add_argument("--no-spans", action="store_true", help="Do not generate correlated trace spans")
+        parser.add_argument("--dry-run", action="store_true", help="Generate and summarize without writing")
+
+    def handle(self, *args, **options):
+        if options["list_scenarios"]:
+            self._print_scenarios()
+            return
+
+        scenario_keys = self._scenario_keys(options["scenario"])
+        mode = options["mode"]
+        project = None
+        project_slug = (options["project_slug"] or "").strip()
+
+        if options["ensure_demo_project"]:
+            project = self._ensure_demo_project(
+                project_slug=project_slug or "synthetic-apilens-demo",
+                owner_email=(options["owner_email"] or "").strip(),
+                scenario_keys=scenario_keys,
+            )
+            project_slug = project.slug
+        elif project_slug:
+            try:
+                project = Project.objects.get(slug=project_slug, is_active=True)
+            except Project.DoesNotExist as exc:
+                raise CommandError(f"Active project '{project_slug}' was not found") from exc
+
+        if mode in {"http", "direct"} and project is None:
+            raise CommandError("--project-slug or --ensure-demo-project is required for http/direct modes")
+        if mode == "http" and (not options["ingest_url"] or not options["api_key"]):
+            raise CommandError("--ingest-url and --api-key are required for --mode http")
+
+        try:
+            count, days = validate_count_and_days(
+                count=int(options["count"]),
+                days=int(options["days"]),
+            )
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        app_targets = self._resolve_app_targets(
+            project=project,
+            app_slugs=(options["app_slugs"] or "").strip(),
+            scenario_keys=scenario_keys,
+        )
+        if mode in {"http", "direct"} and not app_targets:
+            raise CommandError("No target apps found. Pass --app-slugs or use --ensure-demo-project.")
+
+        config = SyntheticRunConfig(
+            scenario_keys=scenario_keys,
+            count=count,
+            days=days,
+            seed=options["seed"],
+            accelerator=options["accelerator"],
+            include_logs=not options["no_logs"],
+            include_spans=not options["no_spans"],
+            project_slug=project_slug,
+            app_targets=app_targets,
+        )
+        result = SyntheticTelemetryEngine(config).generate()
+        self._print_generation_summary(result.summary())
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run complete. No data was written."))
+            return
+
+        if mode == "jsonl":
+            output_dir = options["output_dir"] or self._default_output_dir()
+            summary = JsonlWriter(output_dir).write(result)
+        elif mode == "http":
+            summary = HttpIngestWriter(
+                options["ingest_url"],
+                options["api_key"],
+                batch_size=options["batch_size"],
+            ).write(result)
+        else:
+            summary = DirectClickHouseWriter(batch_size=options["batch_size"]).write(result)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Synthetic telemetry written: "
+                f"mode={summary.mode}, requests={summary.requests}, logs={summary.logs}, spans={summary.spans}"
+            )
+        )
+        if summary.output_dir:
+            self.stdout.write(f"Output directory: {summary.output_dir}")
+        if summary.details:
+            for key, value in summary.details.items():
+                self.stdout.write(f"{key}: {value}")
+
+    def _print_scenarios(self) -> None:
+        self.stdout.write("Available synthetic telemetry scenarios:")
+        for scenario in list_scenarios():
+            self.stdout.write(
+                f"- {scenario.key}: {scenario.name} [{scenario.industry}] "
+                f"apps={len(scenario.apps)} endpoints={len(scenario.endpoints)} consumers={len(scenario.consumers)}"
+            )
+
+    def _scenario_keys(self, values: list[str]) -> tuple[str, ...]:
+        tokens: list[str] = []
+        for raw in values:
+            tokens.extend(part.strip() for part in raw.split(",") if part.strip())
+        try:
+            return expand_scenario_keys(tokens or ("all",))
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+    def _ensure_demo_project(self, *, project_slug: str, owner_email: str, scenario_keys: tuple[str, ...]) -> Project:
+        if not owner_email:
+            raise CommandError("--owner-email is required with --ensure-demo-project")
+        User = get_user_model()
+        user, _created = User.objects.get_or_create(
+            email=owner_email.lower(),
+            defaults={
+                "email_verified": True,
+                "auth_provider": "synthetic",
+                "is_active": True,
+            },
+        )
+        if not user.email_verified:
+            user.email_verified = True
+            user.save(update_fields=["email_verified", "updated_at"])
+
+        slug = slugify(project_slug) or "synthetic-apilens-demo"
+        project, _created = Project.objects.get_or_create(
+            slug=slug,
+            defaults={
+                "owner": user,
+                "name": "Synthetic APILens Demo",
+                "description": "Synthetic telemetry project for APILens demos, QA, and regression data.",
+            },
+        )
+        if not project.is_active:
+            project.is_active = True
+            project.save(update_fields=["is_active", "updated_at"])
+
+        for scenario_key in scenario_keys:
+            scenario = get_scenario(scenario_key)
+            for profile in scenario.apps:
+                app, _created = App.objects.get_or_create(
+                    project=project,
+                    slug=profile.slug,
+                    defaults={
+                        "name": profile.name,
+                        "description": profile.description,
+                        "framework": profile.framework,
+                        "icon": profile.icon[:8],
+                    },
+                )
+                updates = []
+                if app.name != profile.name:
+                    app.name = profile.name
+                    updates.append("name")
+                if app.description != profile.description:
+                    app.description = profile.description
+                    updates.append("description")
+                if app.framework != profile.framework:
+                    app.framework = profile.framework
+                    updates.append("framework")
+                if app.icon != profile.icon[:8]:
+                    app.icon = profile.icon[:8]
+                    updates.append("icon")
+                if not app.is_active:
+                    app.is_active = True
+                    updates.append("is_active")
+                if updates:
+                    app.save(update_fields=updates + ["updated_at"])
+                self._ensure_environments(app, scenario.environments)
+
+        self.stdout.write(self.style.SUCCESS(f"Demo project ready: {project.slug}"))
+        return project
+
+    def _ensure_environments(self, app: App, environments) -> None:
+        colors = {
+            "production": "#16a34a",
+            "staging": "#2563eb",
+            "development": "#9333ea",
+        }
+        for order, env in enumerate(environments):
+            slug = slugify(env.value)
+            Environment.objects.get_or_create(
+                app=app,
+                slug=slug,
+                defaults={
+                    "name": env.value.title(),
+                    "color": colors.get(slug, "#6b7280"),
+                    "order": order,
+                },
+            )
+
+    def _resolve_app_targets(self, *, project: Project | None, app_slugs: str, scenario_keys: tuple[str, ...]) -> tuple[AppTarget, ...]:
+        if project is None:
+            return ()
+        requested = [slug.strip() for slug in app_slugs.split(",") if slug.strip()]
+        queryset = App.objects.filter(project=project, is_active=True)
+        if requested:
+            queryset = queryset.filter(slug__in=requested)
+        else:
+            scenario_app_slugs = {profile.slug for key in scenario_keys for profile in get_scenario(key).apps}
+            queryset = queryset.filter(slug__in=scenario_app_slugs)
+        apps = list(queryset.order_by("slug"))
+        found = {app.slug for app in apps}
+        missing = sorted(set(requested) - found)
+        if missing:
+            raise CommandError(f"Target app slug(s) not found in project '{project.slug}': {', '.join(missing)}")
+        return tuple(
+            AppTarget(
+                slug=app.slug,
+                name=app.name,
+                app_id=str(app.id),
+                project_id=str(project.id),
+                project_slug=project.slug,
+                framework=app.framework,
+            )
+            for app in apps
+        )
+
+    def _default_output_dir(self) -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return str(Path("synthetic-output") / stamp)
+
+    def _print_generation_summary(self, summary: dict) -> None:
+        self.stdout.write(
+            "Generated synthetic telemetry: "
+            f"requests={summary['requests']}, logs={summary['logs']}, spans={summary['spans']}, "
+            f"scenarios={','.join(summary['scenarios'])}, accelerator={summary['accelerator_backend']}, "
+            f"used_gpu={summary['used_gpu']}, seed={summary['seed']}"
+        )

--- a/apps/api/apps/projects/membership.py
+++ b/apps/api/apps/projects/membership.py
@@ -11,6 +11,8 @@ import hashlib
 import secrets
 from datetime import timedelta
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.db import transaction
 from django.utils import timezone
 
@@ -92,6 +94,10 @@ class MembershipService:
         email = (email or "").lower().strip()
         if not email:
             raise ValidationError("Email is required")
+        try:
+            validate_email(email)
+        except DjangoValidationError as exc:
+            raise ValidationError("Enter a valid email address") from exc
         if role not in _ASSIGNABLE:
             raise ValidationError("Invalid role")
         if email == project.owner.email.lower():

--- a/apps/api/apps/projects/services.py
+++ b/apps/api/apps/projects/services.py
@@ -36,10 +36,20 @@ MAX_APPS_PER_PROJECT = 50
 RESERVED_SLUGS = RESERVED_PROJECT_SLUGS
 
 
+def _parse_time_param(value: str, name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(f"Invalid {name} timestamp. Use ISO 8601 format.") from exc
+    return _as_utc(parsed)
+
+
 def _resolve_time_range(since: str | None, until: str | None) -> tuple[datetime, datetime]:
     now = datetime.now(tz.utc)
-    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else now - timedelta(hours=24)
-    until_dt = datetime.fromisoformat(until.replace("Z", "+00:00")) if until else now
+    since_dt = _parse_time_param(since, "since") if since else now - timedelta(hours=24)
+    until_dt = _parse_time_param(until, "until") if until else now
+    if since_dt >= until_dt:
+        raise ValidationError("'since' must be before 'until'.")
     return since_dt, until_dt
 
 
@@ -257,8 +267,6 @@ class ProjectService:
                     f"A project named '{name}' is already taken. Please choose a different name."
                 )
             project.name = name
-            # Slug is globally unique across all users.
-            project.slug = _unique_project_slug(name, exclude_id=project.id)
 
         if description is not None:
             project.description = description.strip()
@@ -395,7 +403,6 @@ class AppService:
             if not name:
                 raise ValidationError("App name is required")
             app.name = name
-            app.slug = _unique_slug(project, name, exclude_id=app.id)
 
         if description is not None:
             app.description = description.strip()
@@ -644,28 +651,6 @@ class IngestService:
             IngestService._base_url_column_ready = True
 
     @staticmethod
-    def ensure_consumer_columns(client) -> None:
-        if IngestService._consumer_columns_ready:
-            return
-        with IngestService._consumer_columns_lock:
-            if IngestService._consumer_columns_ready:
-                return
-            try:
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(3))"
-                )
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(3))"
-                )
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(3))"
-                )
-            except Exception as exc:
-                logger.warning("Unable to ensure consumer columns on api_requests: %s", exc)
-                return
-            IngestService._consumer_columns_ready = True
-
-    @staticmethod
     def ensure_trace_columns(client) -> None:
         if IngestService._trace_columns_ready:
             return
@@ -686,6 +671,28 @@ class IngestService:
                 logger.warning("Unable to ensure trace columns on api_requests: %s", exc)
                 return
             IngestService._trace_columns_ready = True
+
+    @staticmethod
+    def ensure_consumer_columns(client) -> None:
+        if IngestService._consumer_columns_ready:
+            return
+        with IngestService._consumer_columns_lock:
+            if IngestService._consumer_columns_ready:
+                return
+            try:
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(3))"
+                )
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(3))"
+                )
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(3))"
+                )
+            except Exception as exc:
+                logger.warning("Unable to ensure consumer columns on api_requests: %s", exc)
+                return
+            IngestService._consumer_columns_ready = True
 
     @staticmethod
     def _safe_payload(value: str) -> str:
@@ -722,21 +729,9 @@ class IngestService:
                     SETTINGS index_granularity = 8192
                     """
                 )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))"
-                )
-                # Correlation columns from migration 004; the legacy runtime
-                # CREATE above lacks them, so ensure before selecting them.
                 for stmt in (
+                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_method LowCardinality(String) CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_path String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
@@ -745,6 +740,10 @@ class IngestService:
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
                     "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
                 ):
                     client.execute(stmt)
@@ -786,17 +785,30 @@ class IngestService:
                     SETTINGS index_granularity = 8192
                     """
                 )
-                client.execute(
-                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
+                for statement in (
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS app_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS environment LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS parent_span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS name String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS kind LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS service_name LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS duration_ms Float64 CODEC(Gorilla, ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS status LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+                ):
+                    client.execute(statement)
             except Exception as exc:
                 logger.warning("Unable to ensure api_spans table: %s", exc)
                 return
             IngestService._api_spans_table_ready = True
-
     @staticmethod
     def _safe_log_text(value: str, *, limit: int) -> str:
         if not value:
@@ -1492,6 +1504,8 @@ class LogsService:
         search: str | None = None,
         attribute_filters: list[tuple[str, str]] | None = None,
         logger_filters: list[str] | None = None,
+        trace_id: str | None = None,
+        span_id: str | None = None,
         page: int = 1,
         page_size: int = 50,
     ) -> dict:
@@ -1548,6 +1562,14 @@ class LogsService:
                 level,
                 message,
                 logger_name,
+                endpoint_method,
+                endpoint_path,
+                status_code,
+                consumer_id,
+                consumer_name,
+                consumer_group,
+                trace_id,
+                span_id,
                 payload,
                 attributes_json
             FROM api_logs
@@ -1924,6 +1946,7 @@ class DataQueryService:
         attribute_filters: list[tuple[str, str]] | None = None,
         logger_filters: list[str] | None = None,
         trace_id: str | None = None,
+        span_id: str | None = None,
         page: int = 1,
         page_size: int = 50,
     ) -> dict:
@@ -1941,12 +1964,7 @@ class DataQueryService:
             client = get_clickhouse_client()
         except Exception as exc:
             logger.warning("ClickHouse client initialization failed; returning empty logs: %s", exc)
-            return {
-                "items": [],
-                "total_count": 0,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
+            return {"items": [], "total_count": 0, "page": safe_page, "page_size": safe_size}
 
         IngestService.ensure_api_logs_table(client)
 
@@ -1959,7 +1977,6 @@ class DataQueryService:
             "offset": offset,
         }
 
-        # Build app_ids filter
         app_filter = ""
         if app_ids:
             app_placeholders = []
@@ -1978,9 +1995,13 @@ class DataQueryService:
             logger_filters=logger_filters,
         )
 
-        if trace_id:
-            where_filters += " AND trace_id = %(trace_id)s"
+        correlation_filters = ""
+        if trace_id and trace_id.strip():
             params["trace_id"] = trace_id.strip().lower()
+            correlation_filters += " AND trace_id = %(trace_id)s"
+        if span_id and span_id.strip():
+            params["span_id"] = span_id.strip().lower()
+            correlation_filters += " AND span_id = %(span_id)s"
 
         count_query = f"""
             SELECT count() AS total_count
@@ -1989,6 +2010,7 @@ class DataQueryService:
               {app_filter}
               AND timestamp >= %(since)s
               AND timestamp <= %(until)s
+              {correlation_filters}
               {where_filters}
         """
 
@@ -2000,6 +2022,12 @@ class DataQueryService:
                 level,
                 message,
                 logger_name,
+                endpoint_method,
+                endpoint_path,
+                status_code,
+                consumer_id,
+                consumer_name,
+                consumer_group,
                 trace_id,
                 span_id,
                 payload,
@@ -2009,6 +2037,7 @@ class DataQueryService:
               {app_filter}
               AND timestamp >= %(since)s
               AND timestamp <= %(until)s
+              {correlation_filters}
               {where_filters}
             ORDER BY timestamp DESC
             LIMIT %(limit)s
@@ -2030,21 +2059,10 @@ class DataQueryService:
                     parsed = {}
                 item["attributes"] = {str(k): str(v) for k, v in parsed.items()}
                 item.pop("attributes_json", None)
-            return {
-                "items": items,
-                "total_count": total_count,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
+            return {"items": items, "total_count": total_count, "page": safe_page, "page_size": safe_size}
         except Exception as exc:
             logger.warning("ClickHouse query failed for project logs: %s", exc)
-            return {
-                "items": [],
-                "total_count": 0,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
-
+            return {"items": [], "total_count": 0, "page": safe_page, "page_size": safe_size}
     @staticmethod
     def get_project_requests(
         project_id: str,
@@ -2212,6 +2230,135 @@ class DataQueryService:
             }
         except Exception as exc:
             logger.warning("ClickHouse query failed for project requests: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+    @staticmethod
+    def get_project_spans(
+        project_id: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        trace_id: str | None = None,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        Query trace spans across all apps in a project or specific apps.
+        Returns paginated span records with optional trace filtering.
+        """
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        safe_page = max(1, int(page))
+        safe_size = max(1, min(int(page_size), 200))
+        offset = (safe_page - 1) * safe_size
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty spans: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+        IngestService.ensure_api_spans_table(client)
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        params: dict[str, Any] = {
+            "project_id": project_id,
+            "since": since_dt,
+            "until": until_dt,
+            "limit": safe_size,
+            "offset": offset,
+        }
+
+        filters: list[str] = []
+
+        if app_ids:
+            app_placeholders = []
+            for idx, app_id in enumerate(app_ids):
+                key = f"app_id_{idx}"
+                params[key] = app_id
+                app_placeholders.append(f"%({key})s")
+            filters.append(f"app_id IN ({', '.join(app_placeholders)})")
+
+        if environment:
+            filters.append("environment = %(environment)s")
+            params["environment"] = environment
+
+        if trace_id and trace_id.strip():
+            filters.append("trace_id = %(trace_id)s")
+            params["trace_id"] = trace_id.strip()
+
+        where_clause = ""
+        if filters:
+            where_clause = "AND " + " AND ".join(filters)
+
+        count_query = f"""
+            SELECT count() AS total_count
+            FROM api_spans
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+        """
+
+        rows_query = f"""
+            SELECT
+                timestamp,
+                app_id,
+                environment,
+                trace_id,
+                span_id,
+                parent_span_id,
+                name,
+                kind,
+                service_name,
+                duration_ms,
+                status,
+                status_code,
+                attributes_json
+            FROM api_spans
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+            ORDER BY timestamp ASC, span_id ASC
+            LIMIT %(limit)s
+            OFFSET %(offset)s
+        """
+
+        try:
+            count_rows = client.execute(count_query, params)
+            total_count = int(count_rows[0]["total_count"]) if count_rows else 0
+            items = client.execute(rows_query, params)
+            for item in items:
+                item["timestamp"] = _as_utc(item.get("timestamp"))
+                raw_attributes = item.get("attributes_json", "") or "{}"
+                try:
+                    parsed = json.loads(raw_attributes)
+                    if not isinstance(parsed, dict):
+                        parsed = {}
+                except Exception:
+                    parsed = {}
+                item["attributes"] = {str(k): str(v) for k, v in parsed.items()}
+                item.pop("attributes_json", None)
+            return {
+                "items": items,
+                "total_count": total_count,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project spans: %s", exc)
             return {
                 "items": [],
                 "total_count": 0,

--- a/apps/api/apps/projects/synthetic/__init__.py
+++ b/apps/api/apps/projects/synthetic/__init__.py
@@ -1,0 +1,26 @@
+"""Synthetic telemetry generation for APILens demo, QA, and load data."""
+
+from .accelerators import RandomPlanner
+from .catalog import SCENARIOS, expand_scenario_keys, get_scenario, list_scenarios
+from .generator import (
+    AppTarget,
+    GenerationResult,
+    SyntheticTelemetryEngine,
+    SyntheticRunConfig,
+)
+from .writers import DirectClickHouseWriter, HttpIngestWriter, JsonlWriter
+
+__all__ = [
+    "AppTarget",
+    "DirectClickHouseWriter",
+    "GenerationResult",
+    "HttpIngestWriter",
+    "JsonlWriter",
+    "RandomPlanner",
+    "SCENARIOS",
+    "SyntheticRunConfig",
+    "SyntheticTelemetryEngine",
+    "expand_scenario_keys",
+    "get_scenario",
+    "list_scenarios",
+]

--- a/apps/api/apps/projects/synthetic/accelerators.py
+++ b/apps/api/apps/projects/synthetic/accelerators.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Literal
+
+AcceleratorMode = Literal["auto", "cpu", "gpu"]
+
+
+@dataclass(frozen=True)
+class RandomStreams:
+    backend: str
+    used_gpu: bool
+    seed: int
+    time_roll: list[float]
+    scenario_roll: list[float]
+    app_roll: list[float]
+    endpoint_roll: list[float]
+    consumer_roll: list[float]
+    environment_roll: list[float]
+    status_roll: list[float]
+    latency_roll: list[float]
+    tail_roll: list[float]
+    payload_roll: list[float]
+    log_roll: list[float]
+    span_roll: list[float]
+
+
+class RandomPlanner:
+    """Generate numeric random streams, preferring GPU batch generation when available.
+
+    The telemetry engine is mostly text and JSON synthesis, but high-volume runs
+    still need millions of random numbers for timestamps, weighted choices,
+    statuses, latency, log sampling, and span fan-out. This planner centralizes
+    that work and can move it to CUDA through optional CuPy or Torch installs.
+    """
+
+    STREAM_COUNT = 12
+
+    def __init__(self, mode: AcceleratorMode = "auto") -> None:
+        if mode not in {"auto", "cpu", "gpu"}:
+            raise ValueError("accelerator mode must be one of: auto, cpu, gpu")
+        self.mode = mode
+
+    def plan(self, *, count: int, seed: int) -> RandomStreams:
+        safe_count = max(0, int(count))
+        if safe_count == 0:
+            return self._empty(seed, "cpu-random", used_gpu=False)
+
+        if self.mode in {"auto", "gpu"}:
+            for maker in (self._cupy_plan, self._torch_plan):
+                try:
+                    streams = maker(safe_count, seed)
+                except Exception:
+                    streams = None
+                if streams is not None:
+                    return streams
+            if self.mode == "gpu":
+                raise RuntimeError("GPU accelerator requested, but neither CuPy nor Torch CUDA is available")
+
+        return self._cpu_plan(safe_count, seed)
+
+    def _empty(self, seed: int, backend: str, *, used_gpu: bool) -> RandomStreams:
+        return RandomStreams(
+            backend=backend,
+            used_gpu=used_gpu,
+            seed=seed,
+            time_roll=[],
+            scenario_roll=[],
+            app_roll=[],
+            endpoint_roll=[],
+            consumer_roll=[],
+            environment_roll=[],
+            status_roll=[],
+            latency_roll=[],
+            tail_roll=[],
+            payload_roll=[],
+            log_roll=[],
+            span_roll=[],
+        )
+
+    def _from_matrix(self, *, matrix: list[list[float]], seed: int, backend: str, used_gpu: bool) -> RandomStreams:
+        return RandomStreams(
+            backend=backend,
+            used_gpu=used_gpu,
+            seed=seed,
+            time_roll=matrix[0],
+            scenario_roll=matrix[1],
+            app_roll=matrix[2],
+            endpoint_roll=matrix[3],
+            consumer_roll=matrix[4],
+            environment_roll=matrix[5],
+            status_roll=matrix[6],
+            latency_roll=matrix[7],
+            tail_roll=matrix[8],
+            payload_roll=matrix[9],
+            log_roll=matrix[10],
+            span_roll=matrix[11],
+        )
+
+    def _cpu_plan(self, count: int, seed: int) -> RandomStreams:
+        rng = random.Random(seed)
+        matrix = [[rng.random() for _ in range(count)] for _ in range(self.STREAM_COUNT)]
+        return self._from_matrix(matrix=matrix, seed=seed, backend="cpu-random", used_gpu=False)
+
+    def _cupy_plan(self, count: int, seed: int) -> RandomStreams | None:
+        import cupy  # type: ignore[import-not-found]
+
+        device_count = int(cupy.cuda.runtime.getDeviceCount())
+        if device_count <= 0:
+            return None
+        rng = cupy.random.default_rng(seed)
+        values = rng.random((self.STREAM_COUNT, count), dtype=cupy.float32)
+        matrix = values.get().tolist()
+        return self._from_matrix(matrix=matrix, seed=seed, backend="cupy-cuda", used_gpu=True)
+
+    def _torch_plan(self, count: int, seed: int) -> RandomStreams | None:
+        import torch  # type: ignore[import-not-found]
+
+        if not torch.cuda.is_available():
+            return None
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(seed)
+        values = torch.rand((self.STREAM_COUNT, count), generator=generator, device="cuda")
+        matrix = values.cpu().tolist()
+        return self._from_matrix(matrix=matrix, seed=seed, backend="torch-cuda", used_gpu=True)

--- a/apps/api/apps/projects/synthetic/catalog.py
+++ b/apps/api/apps/projects/synthetic/catalog.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class WeightedValue:
+    value: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class LatencyProfile:
+    base_ms: float
+    jitter_ms: float
+    tail_ms: float
+    error_multiplier: float = 1.8
+
+
+@dataclass(frozen=True)
+class EndpointTemplate:
+    method: str
+    path: str
+    description: str
+    weight: float
+    status_weights: tuple[tuple[int, float], ...]
+    latency: LatencyProfile
+    payload_kind: str
+    service_name: str
+
+
+@dataclass(frozen=True)
+class ConsumerSegment:
+    key: str
+    name: str
+    group: str
+    weight: float
+    user_agents: tuple[str, ...]
+    base_error_rate: float = 0.0
+    latency_multiplier: float = 1.0
+
+
+@dataclass(frozen=True)
+class AppProfile:
+    slug: str
+    name: str
+    framework: str
+    description: str
+    icon: str
+    weight: float
+    base_urls: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IncidentProfile:
+    key: str
+    description: str
+    path_contains: tuple[str, ...]
+    status_code: int
+    start_ratio: float
+    end_ratio: float
+    extra_error_rate: float
+    latency_multiplier: float
+    environments: tuple[str, ...] = ("production",)
+
+
+@dataclass(frozen=True)
+class ScenarioProfile:
+    key: str
+    name: str
+    industry: str
+    description: str
+    product_signal: str
+    traffic_weight: float
+    apps: tuple[AppProfile, ...]
+    endpoints: tuple[EndpointTemplate, ...]
+    consumers: tuple[ConsumerSegment, ...]
+    environments: tuple[WeightedValue, ...]
+    regions: tuple[WeightedValue, ...]
+    incidents: tuple[IncidentProfile, ...] = ()
+
+
+COMMON_CONSUMERS: tuple[ConsumerSegment, ...] = (
+    ConsumerSegment(
+        key="free_developer",
+        name="Free Developer",
+        group="free",
+        weight=18,
+        user_agents=("curl/8.6", "postman-runtime/7.39", "apilens-js-demo/1.0"),
+        base_error_rate=0.015,
+        latency_multiplier=1.0,
+    ),
+    ConsumerSegment(
+        key="pro_team",
+        name="Pro Team",
+        group="pro",
+        weight=24,
+        user_agents=("api-client-node/3.4", "python-requests/2.32", "go-http-client/1.1"),
+        base_error_rate=0.008,
+        latency_multiplier=0.96,
+    ),
+    ConsumerSegment(
+        key="enterprise",
+        name="Enterprise Account",
+        group="enterprise",
+        weight=20,
+        user_agents=("enterprise-gateway/5.8", "java-sdk/4.2", "apilens-enterprise-proxy/2.1"),
+        base_error_rate=0.004,
+        latency_multiplier=0.9,
+    ),
+    ConsumerSegment(
+        key="partner_integration",
+        name="Partner Integration",
+        group="partner",
+        weight=14,
+        user_agents=("partner-sync/6.2", "zapier-hook/1.0", "workato-connector/3.7"),
+        base_error_rate=0.012,
+        latency_multiplier=1.08,
+    ),
+    ConsumerSegment(
+        key="internal_service",
+        name="Internal Service",
+        group="internal",
+        weight=12,
+        user_agents=("billing-worker/2.3", "backoffice-job/1.9", "internal-dashboard/0.12"),
+        base_error_rate=0.006,
+        latency_multiplier=0.86,
+    ),
+    ConsumerSegment(
+        key="trial_tenant",
+        name="Trial Tenant",
+        group="trial",
+        weight=8,
+        user_agents=("sandbox-client/0.9", "api-explorer/1.4", "insomnia/9.2"),
+        base_error_rate=0.024,
+        latency_multiplier=1.14,
+    ),
+    ConsumerSegment(
+        key="automation_bot",
+        name="Automation Bot",
+        group="automation",
+        weight=4,
+        user_agents=("uptime-checker/1.7", "load-verifier/0.8", "synthetic-monitor/2.5"),
+        base_error_rate=0.01,
+        latency_multiplier=0.8,
+    ),
+)
+
+
+COMMON_ENVIRONMENTS: tuple[WeightedValue, ...] = (
+    WeightedValue("production", 72),
+    WeightedValue("staging", 18),
+    WeightedValue("development", 10),
+)
+
+
+COMMON_REGIONS: tuple[WeightedValue, ...] = (
+    WeightedValue("us-east-1", 30),
+    WeightedValue("us-west-2", 18),
+    WeightedValue("eu-west-1", 20),
+    WeightedValue("ap-south-1", 18),
+    WeightedValue("ap-southeast-1", 14),
+)
+
+
+def _statuses(*items: tuple[int, float]) -> tuple[tuple[int, float], ...]:
+    return tuple(items)
+
+
+def _endpoint(
+    method: str,
+    path: str,
+    description: str,
+    weight: float,
+    statuses: tuple[tuple[int, float], ...],
+    base: float,
+    jitter: float,
+    tail: float,
+    payload: str,
+    service: str,
+) -> EndpointTemplate:
+    return EndpointTemplate(
+        method=method,
+        path=path,
+        description=description,
+        weight=weight,
+        status_weights=statuses,
+        latency=LatencyProfile(base, jitter, tail),
+        payload_kind=payload,
+        service_name=service,
+    )
+
+
+SCENARIOS: dict[str, ScenarioProfile] = {
+    "api_product_growth": ScenarioProfile(
+        key="api_product_growth",
+        name="API Product Growth",
+        industry="API product / developer platform",
+        description="Developer-facing API usage with plans, quotas, SDKs, onboarding, and customer adoption analysis.",
+        product_signal=(
+            "Inspired by competitor-visible product analytics patterns such as API usage, customer segments, "
+            "quotas, billing, and developer experience."
+        ),
+        traffic_weight=12,
+        apps=(
+            AppProfile(
+                slug="developer-platform",
+                name="Developer Platform API",
+                framework="fastapi",
+                description="Public API for developers, API keys, plans, and usage dashboards.",
+                icon="API",
+                weight=70,
+                base_urls=("https://api.dev-platform.example", "https://sandbox.dev-platform.example"),
+            ),
+            AppProfile(
+                slug="billing-metering",
+                name="Billing Metering API",
+                framework="django",
+                description="Usage metering, quota checks, invoices, and prepaid credit ledgers.",
+                icon="$",
+                weight=30,
+                base_urls=("https://billing.dev-platform.example",),
+            ),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/apps", "List registered applications.", 9, _statuses((200, 95), (401, 2), (500, 3)), 42, 58, 260, "app", "platform-api"),
+            _endpoint("POST", "/v1/api-keys", "Create scoped API keys.", 4, _statuses((201, 82), (400, 6), (409, 5), (429, 3), (500, 4)), 84, 92, 420, "api_key", "platform-api"),
+            _endpoint("GET", "/v1/usage", "Fetch usage metrics by consumer.", 13, _statuses((200, 92), (400, 4), (429, 2), (503, 2)), 118, 160, 780, "usage", "analytics-api"),
+            _endpoint("POST", "/v1/events", "Ingest product events.", 18, _statuses((202, 94), (400, 3), (413, 1), (503, 2)), 48, 82, 360, "event", "events-api"),
+            _endpoint("GET", "/v1/plans/{plan_id}", "Read a pricing plan.", 5, _statuses((200, 91), (404, 6), (500, 3)), 34, 38, 180, "plan", "billing-api"),
+            _endpoint("POST", "/v1/quotas/check", "Check quota and entitlement.", 16, _statuses((200, 90), (402, 2), (403, 2), (429, 4), (503, 2)), 52, 70, 330, "quota", "billing-api"),
+            _endpoint("POST", "/v1/webhooks/test", "Send a webhook test event.", 4, _statuses((202, 84), (400, 5), (422, 5), (502, 4), (504, 2)), 180, 260, 1400, "webhook", "webhook-worker"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("quota-cache-miss", "Quota cache miss increases latency near the middle of the range.", ("quotas",), 503, 0.42, 0.50, 0.08, 2.6),
+        ),
+    ),
+    "ecommerce_checkout": ScenarioProfile(
+        key="ecommerce_checkout",
+        name="Commerce Checkout",
+        industry="E-commerce / retail",
+        description="Cart, checkout, promotions, fulfillment, and payment API behavior for a retail platform.",
+        product_signal="Captures high-cardinality consumer traffic, conversion-critical latency, and payment failures.",
+        traffic_weight=14,
+        apps=(
+            AppProfile("storefront-api", "Storefront API", "express", "Customer-facing catalog, cart, and checkout API.", "CRT", 60, ("https://api.shop.example",)),
+            AppProfile("fulfillment-api", "Fulfillment API", "django", "Inventory, shipment, and order lifecycle service.", "BOX", 25, ("https://fulfillment.shop.example",)),
+            AppProfile("payment-edge", "Payment Edge API", "fastapi", "Payment orchestration and fraud checks.", "PAY", 15, ("https://payments.shop.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/products", "Browse catalog products.", 18, _statuses((200, 96), (400, 1), (404, 1), (500, 2)), 46, 70, 300, "catalog", "storefront"),
+            _endpoint("GET", "/v1/products/{product_id}", "Read product detail.", 14, _statuses((200, 92), (404, 6), (500, 2)), 38, 54, 220, "catalog", "storefront"),
+            _endpoint("POST", "/v1/carts", "Create cart.", 7, _statuses((201, 92), (400, 4), (409, 2), (500, 2)), 64, 80, 360, "cart", "cart"),
+            _endpoint("PATCH", "/v1/carts/{cart_id}", "Update cart lines.", 11, _statuses((200, 86), (400, 5), (409, 5), (422, 2), (503, 2)), 78, 110, 520, "cart", "cart"),
+            _endpoint("POST", "/v1/checkout", "Submit checkout.", 10, _statuses((201, 82), (400, 6), (402, 4), (409, 4), (503, 4)), 210, 280, 1650, "checkout", "checkout"),
+            _endpoint("POST", "/v1/payments/authorize", "Authorize a card payment.", 8, _statuses((200, 84), (400, 4), (402, 6), (429, 2), (502, 2), (504, 2)), 260, 340, 2200, "payment", "payments"),
+            _endpoint("GET", "/v1/orders/{order_id}", "Read order status.", 9, _statuses((200, 92), (404, 5), (500, 3)), 58, 90, 380, "order", "orders"),
+            _endpoint("POST", "/v1/webhooks/carrier", "Receive carrier webhook.", 4, _statuses((202, 90), (400, 5), (409, 3), (500, 2)), 82, 100, 460, "shipment", "fulfillment"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("payment-provider-timeout", "External payment provider intermittently times out.", ("payments", "checkout"), 504, 0.64, 0.72, 0.14, 3.2),
+            IncidentProfile("inventory-contention", "Inventory writes return conflicts during a launch window.", ("carts", "checkout"), 409, 0.30, 0.36, 0.10, 1.8),
+        ),
+    ),
+    "fintech_payments": ScenarioProfile(
+        key="fintech_payments",
+        name="Fintech Payments",
+        industry="Financial technology",
+        description="Payment initiation, ledger, KYC, payouts, risk scoring, and webhook workloads.",
+        product_signal="Covers regulated customer segments, high-value endpoints, retries, auth failures, and audit-style traces.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("payment-core", "Payment Core API", "fastapi", "Payment lifecycle and authorization service.", "FIN", 55, ("https://api.payments.example",)),
+            AppProfile("risk-screening", "Risk Screening API", "django", "Fraud, sanctions, and transaction risk scoring.", "RSK", 25, ("https://risk.payments.example",)),
+            AppProfile("ledger-api", "Ledger API", "django", "Immutable ledger and reconciliation API.", "LED", 20, ("https://ledger.payments.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/payments", "Create payment instruction.", 16, _statuses((201, 82), (400, 5), (401, 2), (402, 3), (409, 3), (422, 2), (503, 3)), 180, 240, 1400, "payment", "payments"),
+            _endpoint("GET", "/v1/payments/{payment_id}", "Fetch payment status.", 14, _statuses((200, 91), (404, 5), (429, 2), (500, 2)), 70, 110, 460, "payment", "payments"),
+            _endpoint("POST", "/v1/kyc/verifications", "Start KYC verification.", 5, _statuses((202, 80), (400, 6), (409, 5), (422, 5), (503, 4)), 260, 320, 1800, "kyc", "kyc"),
+            _endpoint("POST", "/v1/risk/score", "Score transaction risk.", 12, _statuses((200, 88), (400, 4), (429, 3), (502, 3), (504, 2)), 190, 260, 1700, "risk", "risk"),
+            _endpoint("GET", "/v1/ledger/entries", "List ledger entries.", 8, _statuses((200, 94), (400, 2), (500, 4)), 132, 180, 900, "ledger", "ledger"),
+            _endpoint("POST", "/v1/payouts", "Create payout.", 6, _statuses((201, 82), (400, 5), (403, 3), (409, 5), (503, 5)), 220, 300, 1600, "payout", "payouts"),
+            _endpoint("POST", "/v1/webhooks/bank-events", "Receive bank event webhook.", 9, _statuses((202, 90), (400, 5), (409, 3), (500, 2)), 86, 130, 520, "webhook", "webhooks"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("risk-provider-degradation", "Risk provider degradation increases 502s and tail latency.", ("risk",), 502, 0.54, 0.62, 0.16, 3.8),
+        ),
+    ),
+    "healthtech_patient": ScenarioProfile(
+        key="healthtech_patient",
+        name="Healthtech Patient Platform",
+        industry="Healthcare technology",
+        description="Patient, appointment, claims, eligibility, and consent APIs using synthetic identifiers only.",
+        product_signal="Models regulated traffic without real personal data by using tokenized test identifiers.",
+        traffic_weight=10,
+        apps=(
+            AppProfile("patient-access", "Patient Access API", "django", "Patient portal and appointment APIs.", "HLT", 55, ("https://patient-api.health.example",)),
+            AppProfile("claims-gateway", "Claims Gateway API", "fastapi", "Eligibility and claims integration layer.", "CLM", 45, ("https://claims.health.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/patients/{patient_token}", "Read synthetic patient summary.", 9, _statuses((200, 90), (401, 2), (403, 2), (404, 4), (500, 2)), 82, 120, 560, "patient", "patient-access"),
+            _endpoint("GET", "/v1/appointments", "List appointments.", 11, _statuses((200, 94), (400, 2), (500, 4)), 76, 100, 420, "appointment", "patient-access"),
+            _endpoint("POST", "/v1/appointments", "Create appointment request.", 6, _statuses((201, 84), (400, 5), (409, 5), (422, 3), (503, 3)), 154, 210, 960, "appointment", "scheduling"),
+            _endpoint("POST", "/v1/eligibility/checks", "Run insurance eligibility check.", 10, _statuses((200, 86), (400, 5), (409, 2), (502, 4), (504, 3)), 310, 380, 2300, "eligibility", "claims"),
+            _endpoint("POST", "/v1/claims", "Submit claim.", 5, _statuses((202, 82), (400, 6), (409, 4), (422, 4), (503, 4)), 260, 340, 1800, "claim", "claims"),
+            _endpoint("PATCH", "/v1/consents/{consent_id}", "Update consent.", 4, _statuses((200, 88), (400, 5), (403, 3), (404, 2), (500, 2)), 92, 130, 540, "consent", "consent"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("eligibility-clearinghouse-lag", "Eligibility clearinghouse lag causes timeouts.", ("eligibility",), 504, 0.18, 0.24, 0.18, 4.0),
+        ),
+    ),
+    "logistics_fleet": ScenarioProfile(
+        key="logistics_fleet",
+        name="Logistics Fleet",
+        industry="Logistics / supply chain",
+        description="Shipment tracking, fleet telemetry, warehouse scans, and customer delivery APIs.",
+        product_signal="Models high-volume device and partner integrations with bursty geographic activity.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("tracking-api", "Tracking API", "fastapi", "Customer and partner shipment tracking API.", "TRK", 50, ("https://tracking.logistics.example",)),
+            AppProfile("fleet-ingest", "Fleet Ingest API", "starlette", "Vehicle and scanner event ingestion API.", "FLT", 35, ("https://fleet.logistics.example",)),
+            AppProfile("warehouse-api", "Warehouse API", "django", "Inventory, picking, and scan operations.", "WH", 15, ("https://warehouse.logistics.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/shipments/{shipment_id}", "Read shipment detail.", 15, _statuses((200, 92), (404, 5), (429, 1), (500, 2)), 68, 96, 420, "shipment", "tracking"),
+            _endpoint("GET", "/v1/shipments/{shipment_id}/events", "Read tracking events.", 12, _statuses((200, 93), (404, 4), (500, 3)), 92, 130, 620, "shipment", "tracking"),
+            _endpoint("POST", "/v1/fleet/positions", "Ingest vehicle positions.", 19, _statuses((202, 95), (400, 2), (413, 1), (503, 2)), 42, 74, 280, "position", "fleet-ingest"),
+            _endpoint("POST", "/v1/scans", "Ingest warehouse scan.", 14, _statuses((202, 92), (400, 3), (409, 3), (503, 2)), 54, 82, 330, "scan", "warehouse"),
+            _endpoint("PATCH", "/v1/routes/{route_id}", "Update delivery route.", 6, _statuses((200, 84), (400, 5), (409, 7), (500, 4)), 150, 230, 1000, "route", "routing"),
+            _endpoint("POST", "/v1/webhooks/customer-events", "Send customer delivery webhooks.", 5, _statuses((202, 88), (400, 4), (502, 4), (504, 4)), 180, 260, 1400, "webhook", "webhooks"),
+        ),
+        consumers=COMMON_CONSUMERS
+        + (
+            ConsumerSegment("iot_device", "Fleet Device", "iot", 28, ("vehicle-agent/3.2", "handheld-scanner/4.7", "edge-gateway/2.0"), 0.018, 1.18),
+        ),
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("warehouse-scan-duplicates", "Scan duplicates increase conflicts.", ("scans",), 409, 0.76, 0.84, 0.12, 1.5),
+        ),
+    ),
+    "ai_platform": ScenarioProfile(
+        key="ai_platform",
+        name="AI Platform",
+        industry="AI / machine learning infrastructure",
+        description="Model inference, embeddings, vector search, token metering, and prompt safety APIs.",
+        product_signal="Reflects API and AI product monetization patterns such as token counts, traces, quota checks, and heavy payloads.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("inference-api", "Inference API", "fastapi", "LLM and model inference API.", "AI", 55, ("https://inference.ai.example",)),
+            AppProfile("vector-api", "Vector API", "starlette", "Embeddings and vector search API.", "VEC", 25, ("https://vectors.ai.example",)),
+            AppProfile("ai-metering", "AI Metering API", "django", "Token and credit metering service.", "TOK", 20, ("https://metering.ai.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/chat/completions", "Generate chat completion.", 15, _statuses((200, 86), (400, 4), (401, 1), (429, 5), (500, 2), (503, 2)), 620, 900, 5200, "completion", "inference"),
+            _endpoint("POST", "/v1/embeddings", "Generate embedding vectors.", 13, _statuses((200, 90), (400, 4), (413, 2), (429, 2), (503, 2)), 220, 360, 2100, "embedding", "embedding"),
+            _endpoint("POST", "/v1/vector/search", "Search vector index.", 11, _statuses((200, 90), (400, 3), (404, 2), (500, 3), (503, 2)), 150, 240, 1300, "vector_search", "vector"),
+            _endpoint("POST", "/v1/safety/moderations", "Run prompt moderation.", 6, _statuses((200, 91), (400, 3), (429, 3), (503, 3)), 110, 170, 900, "moderation", "safety"),
+            _endpoint("POST", "/v1/tokens/meter", "Record token usage.", 16, _statuses((202, 95), (400, 2), (409, 1), (503, 2)), 45, 64, 240, "token_meter", "metering"),
+            _endpoint("GET", "/v1/models", "List available models.", 7, _statuses((200, 96), (401, 1), (500, 3)), 42, 56, 210, "model", "inference"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("model-capacity-429", "Model capacity pushes quota and rate-limit responses.", ("chat", "embeddings"), 429, 0.58, 0.68, 0.18, 2.4),
+        ),
+    ),
+    "telco_iot": ScenarioProfile(
+        key="telco_iot",
+        name="Telco IoT",
+        industry="Telecommunications / IoT",
+        description="SIM lifecycle, device telemetry, usage counters, and network policy APIs.",
+        product_signal="Models large-scale device traffic and operational dashboards for billions-style API estates.",
+        traffic_weight=10,
+        apps=(
+            AppProfile("device-api", "Device API", "fastapi", "Device registration and lifecycle API.", "SIM", 45, ("https://devices.telco.example",)),
+            AppProfile("usage-api", "Usage API", "django", "Data usage and billing counter API.", "GB", 35, ("https://usage.telco.example",)),
+            AppProfile("network-policy", "Network Policy API", "starlette", "Policy and provisioning API.", "NET", 20, ("https://network.telco.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/devices/register", "Register device.", 8, _statuses((201, 88), (400, 5), (409, 4), (503, 3)), 96, 130, 620, "device", "device"),
+            _endpoint("GET", "/v1/devices/{device_id}", "Read device.", 13, _statuses((200, 92), (404, 5), (500, 3)), 50, 72, 300, "device", "device"),
+            _endpoint("POST", "/v1/telemetry", "Ingest device telemetry.", 22, _statuses((202, 96), (400, 2), (413, 1), (503, 1)), 34, 56, 210, "telemetry", "telemetry"),
+            _endpoint("GET", "/v1/usage/{device_id}", "Read usage counters.", 14, _statuses((200, 92), (404, 4), (429, 2), (500, 2)), 72, 100, 440, "usage", "usage"),
+            _endpoint("PATCH", "/v1/policies/{policy_id}", "Update network policy.", 5, _statuses((200, 85), (400, 5), (403, 3), (409, 4), (503, 3)), 130, 180, 900, "policy", "network-policy"),
+        ),
+        consumers=COMMON_CONSUMERS
+        + (
+            ConsumerSegment("iot_device", "IoT Device", "iot", 42, ("iot-modem/7.2", "edge-router/5.0", "sim-agent/2.4"), 0.02, 1.1),
+        ),
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("telemetry-burst", "Regional device reconnect burst creates ingestion pressure.", ("telemetry",), 503, 0.10, 0.16, 0.10, 2.2),
+        ),
+    ),
+    "internal_saas": ScenarioProfile(
+        key="internal_saas",
+        name="Internal SaaS Operations",
+        industry="B2B SaaS / internal operations",
+        description="Admin, CRM, billing, notifications, support, and audit APIs for internal teams.",
+        product_signal="Creates data for RBAC, support debugging, audit-oriented logs, and operational workflows.",
+        traffic_weight=9,
+        apps=(
+            AppProfile("admin-api", "Admin API", "django", "Tenant administration and settings API.", "ADM", 45, ("https://admin.saas.example",)),
+            AppProfile("notification-api", "Notification API", "fastapi", "Email, SMS, webhook, and in-app notification API.", "NTF", 30, ("https://notify.saas.example",)),
+            AppProfile("support-api", "Support API", "express", "Support workflow and ticket API.", "SUP", 25, ("https://support.saas.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/tenants", "List tenants.", 7, _statuses((200, 95), (401, 2), (500, 3)), 58, 82, 330, "tenant", "admin"),
+            _endpoint("PATCH", "/v1/tenants/{tenant_id}/settings", "Update tenant settings.", 5, _statuses((200, 84), (400, 6), (403, 4), (409, 3), (500, 3)), 110, 160, 760, "settings", "admin"),
+            _endpoint("POST", "/v1/notifications/email", "Send email notification.", 12, _statuses((202, 90), (400, 4), (429, 2), (502, 2), (504, 2)), 150, 230, 1300, "notification", "notifications"),
+            _endpoint("POST", "/v1/notifications/webhook", "Send webhook notification.", 10, _statuses((202, 86), (400, 4), (429, 2), (502, 5), (504, 3)), 180, 260, 1600, "webhook", "notifications"),
+            _endpoint("GET", "/v1/audit/events", "Read audit events.", 9, _statuses((200, 94), (400, 2), (500, 4)), 130, 190, 900, "audit", "audit"),
+            _endpoint("POST", "/v1/support/tickets", "Create support ticket.", 5, _statuses((201, 90), (400, 4), (409, 2), (500, 4)), 96, 120, 520, "ticket", "support"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("webhook-destination-errors", "Webhook destinations return transient 502/504 responses.", ("webhook",), 502, 0.70, 0.80, 0.14, 2.8),
+        ),
+    ),
+    "enterprise_governance": ScenarioProfile(
+        key="enterprise_governance",
+        name="Enterprise Governance",
+        industry="Enterprise API platform",
+        description="API catalog, OpenAPI linting, policy checks, runtime drift, and security review workflows.",
+        product_signal="Aligned to enterprise API governance and runtime security patterns observed in competitor positioning.",
+        traffic_weight=9,
+        apps=(
+            AppProfile("catalog-api", "API Catalog API", "django", "API catalog and spec inventory API.", "CAT", 40, ("https://catalog.enterprise.example",)),
+            AppProfile("governance-api", "Governance API", "fastapi", "Design-time and runtime policy API.", "GOV", 35, ("https://governance.enterprise.example",)),
+            AppProfile("security-api", "Security Review API", "fastapi", "Runtime security findings and audit API.", "SEC", 25, ("https://security.enterprise.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/specs/lint", "Lint OpenAPI spec.", 9, _statuses((200, 86), (400, 5), (422, 6), (500, 3)), 190, 260, 1600, "spec", "governance"),
+            _endpoint("GET", "/v1/apis", "List APIs.", 11, _statuses((200, 95), (401, 2), (500, 3)), 74, 96, 400, "api_catalog", "catalog"),
+            _endpoint("POST", "/v1/apis/{api_id}/reviews", "Start API review.", 5, _statuses((202, 84), (400, 4), (403, 4), (409, 4), (500, 4)), 170, 230, 1100, "review", "governance"),
+            _endpoint("GET", "/v1/security/findings", "List security findings.", 8, _statuses((200, 93), (400, 3), (500, 4)), 140, 190, 900, "finding", "security"),
+            _endpoint("POST", "/v1/runtime/drift", "Record runtime drift.", 12, _statuses((202, 92), (400, 4), (409, 2), (503, 2)), 66, 98, 420, "drift", "runtime"),
+            _endpoint("PATCH", "/v1/policies/{policy_id}", "Update policy.", 4, _statuses((200, 84), (400, 5), (403, 5), (409, 3), (500, 3)), 118, 160, 780, "policy", "governance"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("spec-linter-overload", "Large spec lint jobs overload linter workers.", ("specs",), 503, 0.34, 0.40, 0.12, 3.1),
+        ),
+    ),
+}
+
+
+def list_scenarios() -> tuple[ScenarioProfile, ...]:
+    return tuple(SCENARIOS.values())
+
+
+def get_scenario(key: str) -> ScenarioProfile:
+    normalized = (key or "").strip().lower()
+    try:
+        return SCENARIOS[normalized]
+    except KeyError as exc:
+        choices = ", ".join(sorted(SCENARIOS))
+        raise ValueError(f"Unknown synthetic scenario '{key}'. Available scenarios: {choices}") from exc
+
+
+def expand_scenario_keys(keys: Iterable[str] | None) -> tuple[str, ...]:
+    requested = [k.strip().lower() for k in (keys or ()) if k and k.strip()]
+    if not requested or "all" in requested:
+        return tuple(SCENARIOS)
+    unknown = [k for k in requested if k not in SCENARIOS]
+    if unknown:
+        choices = ", ".join(sorted(SCENARIOS))
+        raise ValueError(f"Unknown synthetic scenario(s): {', '.join(unknown)}. Available scenarios: {choices}")
+    return tuple(dict.fromkeys(requested))

--- a/apps/api/apps/projects/synthetic/generator.py
+++ b/apps/api/apps/projects/synthetic/generator.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from .accelerators import AcceleratorMode, RandomPlanner, RandomStreams
+from .catalog import (
+    AppProfile,
+    ConsumerSegment,
+    EndpointTemplate,
+    IncidentProfile,
+    ScenarioProfile,
+    WeightedValue,
+    expand_scenario_keys,
+    get_scenario,
+)
+
+
+@dataclass(frozen=True)
+class AppTarget:
+    slug: str
+    name: str = ""
+    app_id: str = ""
+    project_id: str = ""
+    project_slug: str = ""
+    framework: str = ""
+    base_urls: tuple[str, ...] = ()
+
+    @property
+    def ingest_identifier(self) -> str:
+        return self.app_id or self.slug
+
+
+@dataclass(frozen=True)
+class SyntheticRunConfig:
+    scenario_keys: tuple[str, ...] = ("all",)
+    count: int = 5000
+    days: int = 14
+    now: datetime | None = None
+    seed: int | None = None
+    accelerator: AcceleratorMode = "auto"
+    include_logs: bool = True
+    include_spans: bool = True
+    project_slug: str = ""
+    app_targets: tuple[AppTarget, ...] = ()
+
+
+@dataclass(frozen=True)
+class RequestEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    method: str
+    path: str
+    status_code: int
+    response_time_ms: float
+    request_size: int
+    response_size: int
+    ip_address: str
+    user_agent: str
+    consumer_id: str
+    consumer_name: str
+    consumer_group: str
+    request_payload: str
+    response_payload: str
+    request_headers: str
+    response_headers: str
+    base_url: str
+    trace_id: str
+    span_id: str
+    endpoint_service: str = ""
+    endpoint_description: str = ""
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "method": self.method,
+            "path": self.path,
+            "status_code": self.status_code,
+            "response_time_ms": self.response_time_ms,
+            "request_size": self.request_size,
+            "response_size": self.response_size,
+            "ip_address": self.ip_address,
+            "user_agent": self.user_agent,
+            "consumer_id": self.consumer_id,
+            "consumer_name": self.consumer_name,
+            "consumer_group": self.consumer_group,
+            "request_payload": self.request_payload,
+            "response_payload": self.response_payload,
+            "request_headers": self.request_headers,
+            "response_headers": self.response_headers,
+            "base_url": self.base_url,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+        }
+
+
+@dataclass(frozen=True)
+class LogEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    level: str
+    message: str
+    logger_name: str
+    endpoint_method: str
+    endpoint_path: str
+    status_code: int
+    consumer_id: str
+    consumer_name: str
+    consumer_group: str
+    trace_id: str
+    span_id: str
+    payload: str
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "level": self.level,
+            "message": self.message,
+            "logger_name": self.logger_name,
+            "endpoint_method": self.endpoint_method,
+            "endpoint_path": self.endpoint_path,
+            "status_code": self.status_code,
+            "consumer_id": self.consumer_id,
+            "consumer_name": self.consumer_name,
+            "consumer_group": self.consumer_group,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "payload": self.payload,
+            "attributes": dict(self.attributes),
+        }
+
+
+@dataclass(frozen=True)
+class SpanEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str
+    name: str
+    kind: str
+    service_name: str
+    duration_ms: float
+    status: str
+    status_code: int
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "name": self.name,
+            "kind": self.kind,
+            "service_name": self.service_name,
+            "duration_ms": self.duration_ms,
+            "status": self.status,
+            "status_code": self.status_code,
+            "attributes": dict(self.attributes),
+        }
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    requests: list[RequestEvent]
+    logs: list[LogEvent]
+    spans: list[SpanEvent]
+    scenarios: tuple[str, ...]
+    accelerator_backend: str
+    used_gpu: bool
+    seed: int
+    generated_at: datetime
+    app_targets: tuple[AppTarget, ...]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "requests": len(self.requests),
+            "logs": len(self.logs),
+            "spans": len(self.spans),
+            "scenarios": list(self.scenarios),
+            "accelerator_backend": self.accelerator_backend,
+            "used_gpu": self.used_gpu,
+            "seed": self.seed,
+            "generated_at": self.generated_at.isoformat(),
+            "apps": [target.slug for target in self.app_targets],
+        }
+
+
+class SyntheticTelemetryEngine:
+    def __init__(self, config: SyntheticRunConfig) -> None:
+        if config.count < 0:
+            raise ValueError("count must be greater than or equal to 0")
+        if config.days <= 0:
+            raise ValueError("days must be greater than 0")
+        self.config = config
+        self.now = _normalize_now(config.now)
+        self.scenario_keys = expand_scenario_keys(config.scenario_keys)
+        self.scenarios = tuple(get_scenario(key) for key in self.scenario_keys)
+        self.seed = config.seed if config.seed is not None else self._rotating_seed()
+        self.rng = random.Random(self.seed)
+
+    def generate(self) -> GenerationResult:
+        planner = RandomPlanner(self.config.accelerator)
+        streams = planner.plan(count=self.config.count, seed=self.seed)
+        requests: list[RequestEvent] = []
+        logs: list[LogEvent] = []
+        spans: list[SpanEvent] = []
+        app_targets_seen: dict[str, AppTarget] = {}
+
+        for idx in range(self.config.count):
+            scenario = _weighted_choice(self.scenarios, streams.scenario_roll[idx], "traffic_weight")
+            endpoint = _weighted_choice(scenario.endpoints, streams.endpoint_roll[idx], "weight")
+            app_profile = _app_profile_for_endpoint(scenario, endpoint, streams.app_roll[idx])
+            app_target = self._resolve_app_target(app_profile, scenario)
+            app_targets_seen[app_target.slug] = app_target
+            consumer = _weighted_choice(scenario.consumers, streams.consumer_roll[idx], "weight")
+            environment = _weighted_choice(scenario.environments, streams.environment_roll[idx], "weight").value
+            timestamp = self._timestamp_for_roll(streams.time_roll[idx], consumer)
+            path = _materialize_path(endpoint.path, self.rng)
+            active_incident = _active_incident(scenario.incidents, endpoint, environment, streams.time_roll[idx])
+            status_code = self._status_for(endpoint, consumer, active_incident, streams.status_roll[idx])
+            latency_ms = self._latency_for(endpoint, consumer, active_incident, status_code, streams.latency_roll[idx], streams.tail_roll[idx])
+            trace_id = _hex_id(self.rng, 32)
+            span_id = _hex_id(self.rng, 16)
+            consumer_id = _consumer_id(scenario.key, consumer, self.rng)
+            base_url = self._base_url(app_target, app_profile)
+            request_payload, response_payload = _payloads(
+                endpoint=endpoint,
+                scenario=scenario,
+                path=path,
+                status_code=status_code,
+                consumer_id=consumer_id,
+                rng=self.rng,
+            )
+            request_size = _request_size(endpoint, request_payload, streams.payload_roll[idx])
+            response_size = _response_size(endpoint, response_payload, status_code, streams.tail_roll[idx])
+            event = RequestEvent(
+                timestamp=timestamp,
+                app_id=app_target.app_id,
+                app_slug=app_target.slug,
+                project_id=app_target.project_id,
+                project_slug=app_target.project_slug or self.config.project_slug,
+                scenario_key=scenario.key,
+                environment=environment,
+                method=endpoint.method,
+                path=path,
+                status_code=status_code,
+                response_time_ms=latency_ms,
+                request_size=request_size,
+                response_size=response_size,
+                ip_address=_ip_address(self.rng),
+                user_agent=self.rng.choice(consumer.user_agents),
+                consumer_id=consumer_id,
+                consumer_name=f"{consumer.name} {consumer_id.rsplit('-', 1)[-1]}",
+                consumer_group=consumer.group,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                request_headers=_headers(trace_id, consumer, scenario, request=True),
+                response_headers=_headers(trace_id, consumer, scenario, request=False),
+                base_url=base_url,
+                trace_id=trace_id,
+                span_id=span_id,
+                endpoint_service=endpoint.service_name,
+                endpoint_description=endpoint.description,
+            )
+            requests.append(event)
+
+            if self.config.include_logs:
+                logs.extend(self._logs_for(event, endpoint, scenario, active_incident, streams.log_roll[idx]))
+
+            if self.config.include_spans:
+                spans.extend(self._spans_for(event, endpoint, scenario, active_incident, streams.span_roll[idx]))
+
+        return GenerationResult(
+            requests=requests,
+            logs=logs,
+            spans=spans,
+            scenarios=self.scenario_keys,
+            accelerator_backend=streams.backend,
+            used_gpu=streams.used_gpu,
+            seed=streams.seed,
+            generated_at=self.now,
+            app_targets=tuple(app_targets_seen.values()),
+        )
+
+    def _rotating_seed(self) -> int:
+        hour_bucket = self.now.strftime("%Y%m%d%H")
+        material = "|".join(
+            [
+                "apilens-synthetic",
+                hour_bucket,
+                ",".join(self.scenario_keys),
+                str(self.config.count),
+                str(self.config.days),
+                self.config.project_slug,
+                ",".join(target.slug for target in self.config.app_targets),
+            ]
+        )
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+        return int(digest[:16], 16)
+
+    def _resolve_app_target(self, app_profile: AppProfile, scenario: ScenarioProfile) -> AppTarget:
+        if self.config.app_targets:
+            by_slug = {target.slug: target for target in self.config.app_targets}
+            if app_profile.slug in by_slug:
+                return by_slug[app_profile.slug]
+            # Allow a caller to provide fewer real apps than the scenario has
+            # app profiles; weighted choice still spreads traffic over supplied
+            # apps deterministically.
+            index = int(self.rng.random() * len(self.config.app_targets))
+            return self.config.app_targets[index]
+        return AppTarget(
+            slug=app_profile.slug,
+            name=app_profile.name,
+            project_slug=self.config.project_slug,
+            framework=app_profile.framework,
+            base_urls=app_profile.base_urls,
+        )
+
+    def _timestamp_for_roll(self, roll: float, consumer: ConsumerSegment) -> datetime:
+        start = self.now - timedelta(days=self.config.days)
+        day = int(min(0.999999, max(0.0, roll)) * self.config.days)
+        if consumer.group in {"iot", "automation"}:
+            seconds = self.rng.randint(0, 86_399)
+        elif consumer.group in {"enterprise", "internal"}:
+            seconds = int(self.rng.triangular(7 * 3600, 20 * 3600, 11 * 3600))
+        else:
+            seconds = int(self.rng.triangular(0, 86_399, 15 * 3600))
+        return start + timedelta(days=day, seconds=max(0, min(seconds, 86_399)))
+
+    def _status_for(
+        self,
+        endpoint: EndpointTemplate,
+        consumer: ConsumerSegment,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> int:
+        if incident and roll < incident.extra_error_rate:
+            return incident.status_code
+        if roll < consumer.base_error_rate:
+            return 429 if consumer.group in {"free", "trial", "iot"} else 400
+        adjusted_roll = min(0.999999, max(0.0, roll - consumer.base_error_rate))
+        return _weighted_status(endpoint.status_weights, adjusted_roll)
+
+    def _latency_for(
+        self,
+        endpoint: EndpointTemplate,
+        consumer: ConsumerSegment,
+        incident: IncidentProfile | None,
+        status_code: int,
+        latency_roll: float,
+        tail_roll: float,
+    ) -> float:
+        profile = endpoint.latency
+        value = profile.base_ms + (profile.jitter_ms * latency_roll)
+        if tail_roll > 0.965:
+            value += profile.tail_ms * ((tail_roll - 0.965) / 0.035)
+        if status_code >= 500:
+            value *= profile.error_multiplier
+        elif status_code >= 400:
+            value *= 1.18
+        value *= consumer.latency_multiplier
+        if incident:
+            value *= incident.latency_multiplier
+        return round(max(1.0, value), 2)
+
+    def _base_url(self, app_target: AppTarget, app_profile: AppProfile) -> str:
+        urls = app_target.base_urls or app_profile.base_urls
+        return self.rng.choice(urls) if urls else ""
+
+    def _logs_for(
+        self,
+        event: RequestEvent,
+        endpoint: EndpointTemplate,
+        scenario: ScenarioProfile,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> list[LogEvent]:
+        should_log = event.status_code >= 500 or (event.status_code >= 400 and roll < 0.72) or roll < 0.10
+        if not should_log:
+            return []
+        if event.status_code >= 500:
+            level = "ERROR"
+            message = f"{endpoint.service_name} returned {event.status_code} for {event.method} {endpoint.path}"
+        elif event.status_code >= 400:
+            level = "WARNING"
+            message = f"{endpoint.service_name} rejected {event.method} {endpoint.path} with {event.status_code}"
+        else:
+            level = "INFO"
+            message = f"{endpoint.service_name} completed {event.method} {endpoint.path}"
+        attrs = {
+            "scenario": scenario.key,
+            "consumer_group": event.consumer_group,
+            "endpoint_template": endpoint.path,
+            "latency_ms": str(event.response_time_ms),
+        }
+        if incident:
+            attrs["incident"] = incident.key
+        return [
+            LogEvent(
+                timestamp=event.timestamp + timedelta(milliseconds=min(event.response_time_ms, 250)),
+                app_id=event.app_id,
+                app_slug=event.app_slug,
+                project_id=event.project_id,
+                project_slug=event.project_slug,
+                scenario_key=event.scenario_key,
+                environment=event.environment,
+                level=level,
+                message=message,
+                logger_name=f"{endpoint.service_name}.request",
+                endpoint_method=event.method,
+                endpoint_path=event.path,
+                status_code=event.status_code,
+                consumer_id=event.consumer_id,
+                consumer_name=event.consumer_name,
+                consumer_group=event.consumer_group,
+                trace_id=event.trace_id,
+                span_id=event.span_id,
+                payload=_json({"path": event.path, "status_code": event.status_code, "base_url": event.base_url}),
+                attributes=attrs,
+            )
+        ]
+
+    def _spans_for(
+        self,
+        event: RequestEvent,
+        endpoint: EndpointTemplate,
+        scenario: ScenarioProfile,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> list[SpanEvent]:
+        status = "error" if event.status_code >= 500 else "ok"
+        spans = [
+            SpanEvent(
+                timestamp=event.timestamp,
+                app_id=event.app_id,
+                app_slug=event.app_slug,
+                project_id=event.project_id,
+                project_slug=event.project_slug,
+                scenario_key=event.scenario_key,
+                environment=event.environment,
+                trace_id=event.trace_id,
+                span_id=event.span_id,
+                parent_span_id="",
+                name=f"{event.method} {endpoint.path}",
+                kind="server",
+                service_name=endpoint.service_name,
+                duration_ms=event.response_time_ms,
+                status=status,
+                status_code=event.status_code,
+                attributes={
+                    "http.method": event.method,
+                    "http.route": endpoint.path,
+                    "consumer.group": event.consumer_group,
+                    "scenario": scenario.key,
+                },
+            )
+        ]
+        child_count = 1 + int(roll * 3)
+        remaining = max(event.response_time_ms * 0.74, 1.0)
+        child_names = _child_span_names(endpoint, incident)
+        parent_start_offset = 4.0
+        for child_index in range(child_count):
+            duration = max(1.0, remaining * self.rng.uniform(0.18, 0.42))
+            remaining -= duration * 0.35
+            name, kind = child_names[child_index % len(child_names)]
+            spans.append(
+                SpanEvent(
+                    timestamp=event.timestamp + timedelta(milliseconds=parent_start_offset + child_index * 3),
+                    app_id=event.app_id,
+                    app_slug=event.app_slug,
+                    project_id=event.project_id,
+                    project_slug=event.project_slug,
+                    scenario_key=event.scenario_key,
+                    environment=event.environment,
+                    trace_id=event.trace_id,
+                    span_id=_hex_id(self.rng, 16),
+                    parent_span_id=event.span_id,
+                    name=name,
+                    kind=kind,
+                    service_name=endpoint.service_name,
+                    duration_ms=round(duration, 2),
+                    status=status if child_index == child_count - 1 and event.status_code >= 500 else "ok",
+                    status_code=event.status_code if child_index == child_count - 1 else 0,
+                    attributes={
+                        "endpoint.template": endpoint.path,
+                        "payload.kind": endpoint.payload_kind,
+                        "scenario": scenario.key,
+                    },
+                )
+            )
+        return spans
+
+
+def _normalize_now(now: datetime | None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _weighted_choice(items: Iterable[Any], roll: float, weight_attr: str) -> Any:
+    values = tuple(items)
+    if not values:
+        raise ValueError("weighted choice requires at least one item")
+    total = sum(max(0.0, float(getattr(item, weight_attr))) for item in values)
+    if total <= 0:
+        return values[0]
+    cursor = min(0.999999, max(0.0, roll)) * total
+    running = 0.0
+    for item in values:
+        running += max(0.0, float(getattr(item, weight_attr)))
+        if cursor <= running:
+            return item
+    return values[-1]
+
+
+def _weighted_status(items: tuple[tuple[int, float], ...], roll: float) -> int:
+    total = sum(max(0.0, weight) for _, weight in items)
+    if total <= 0:
+        return 200
+    cursor = min(0.999999, max(0.0, roll)) * total
+    running = 0.0
+    for status, weight in items:
+        running += max(0.0, weight)
+        if cursor <= running:
+            return int(status)
+    return int(items[-1][0])
+
+
+def _app_profile_for_endpoint(scenario: ScenarioProfile, endpoint: EndpointTemplate, roll: float) -> AppProfile:
+    service_tokens = [token for token in endpoint.service_name.lower().replace("_", "-").split("-") if token]
+    candidates: list[AppProfile] = []
+    for profile in scenario.apps:
+        searchable = " ".join([profile.slug, profile.name, profile.description]).lower()
+        if any(token in searchable for token in service_tokens):
+            candidates.append(profile)
+    if candidates:
+        return _weighted_choice(candidates, roll, "weight")
+    return _weighted_choice(scenario.apps, roll, "weight")
+
+
+def _active_incident(
+    incidents: tuple[IncidentProfile, ...],
+    endpoint: EndpointTemplate,
+    environment: str,
+    time_roll: float,
+) -> IncidentProfile | None:
+    for incident in incidents:
+        if environment not in incident.environments:
+            continue
+        if not (incident.start_ratio <= time_roll <= incident.end_ratio):
+            continue
+        if any(fragment in endpoint.path for fragment in incident.path_contains):
+            return incident
+    return None
+
+
+def _materialize_path(path: str, rng: random.Random) -> str:
+    replacements = {
+        "{api_id}": f"api_{rng.randint(1000, 9999)}",
+        "{cart_id}": f"cart_{rng.randint(10000, 99999)}",
+        "{consent_id}": f"consent_{rng.randint(1000, 9999)}",
+        "{device_id}": f"dev_{rng.randint(100000, 999999)}",
+        "{order_id}": f"ord_{rng.randint(100000, 999999)}",
+        "{patient_token}": f"pt_{rng.randint(100000, 999999)}",
+        "{payment_id}": f"pay_{rng.randint(100000, 999999)}",
+        "{plan_id}": f"plan_{rng.choice(['free', 'pro', 'business', 'enterprise'])}",
+        "{policy_id}": f"pol_{rng.randint(1000, 9999)}",
+        "{product_id}": f"sku_{rng.randint(10000, 99999)}",
+        "{route_id}": f"route_{rng.randint(1000, 9999)}",
+        "{shipment_id}": f"ship_{rng.randint(100000, 999999)}",
+        "{tenant_id}": f"tenant_{rng.randint(1000, 9999)}",
+    }
+    output = path
+    for token, value in replacements.items():
+        output = output.replace(token, value)
+    return output
+
+
+def _payloads(
+    *,
+    endpoint: EndpointTemplate,
+    scenario: ScenarioProfile,
+    path: str,
+    status_code: int,
+    consumer_id: str,
+    rng: random.Random,
+) -> tuple[str, str]:
+    request: dict[str, Any] = {
+        "scenario": scenario.key,
+        "consumer_id": consumer_id,
+        "request_id": f"req_{rng.randint(1000000, 9999999)}",
+    }
+    kind = endpoint.payload_kind
+    if endpoint.method == "GET":
+        request = {}
+    elif kind in {"payment", "checkout", "payout"}:
+        request.update({"amount": rng.randint(900, 250000) / 100, "currency": rng.choice(["USD", "EUR", "INR", "GBP"]), "idempotency_key": f"idem_{rng.randint(100000, 999999)}"})
+    elif kind in {"completion", "embedding", "moderation"}:
+        request.update({"model": rng.choice(["apex-mini", "apex-pro", "embed-small"]), "input_tokens": rng.randint(24, 4096), "prompt_ref": f"prompt_{rng.randint(1000, 9999)}"})
+    elif kind in {"telemetry", "position"}:
+        request.update({"device_ref": f"dev_{rng.randint(100000, 999999)}", "sample_count": rng.randint(1, 200), "battery_pct": rng.randint(4, 100)})
+    elif kind in {"patient", "appointment", "claim", "eligibility"}:
+        request.update({"patient_token": f"pt_{rng.randint(100000, 999999)}", "facility_code": f"fac_{rng.randint(100, 999)}", "test_data": True})
+    elif kind in {"webhook", "notification"}:
+        request.update({"destination_ref": f"dest_{rng.randint(1000, 9999)}", "event_type": rng.choice(["created", "updated", "failed", "delivered"])})
+    else:
+        request.update({"entity_ref": f"{kind}_{rng.randint(100000, 999999)}"})
+
+    if status_code >= 400:
+        response = {
+            "ok": False,
+            "error": {
+                "code": _error_code(status_code),
+                "message": "Synthetic error generated for APILens QA data.",
+            },
+            "path": path,
+        }
+    else:
+        response = {
+            "ok": True,
+            "status": status_code,
+            "result_ref": f"{kind}_{rng.randint(1000000, 9999999)}",
+        }
+        if kind in {"completion", "embedding", "token_meter"}:
+            response["usage"] = {"input_tokens": rng.randint(20, 4096), "output_tokens": rng.randint(8, 2048)}
+        if kind in {"usage", "quota"}:
+            response["quota"] = {"used": rng.randint(1, 95), "limit": 100}
+
+    return (_json(request) if request else "", _json(response))
+
+
+def _error_code(status_code: int) -> str:
+    if status_code == 400:
+        return "bad_request"
+    if status_code == 401:
+        return "authentication_required"
+    if status_code == 402:
+        return "payment_required"
+    if status_code == 403:
+        return "permission_denied"
+    if status_code == 404:
+        return "not_found"
+    if status_code == 409:
+        return "conflict"
+    if status_code == 413:
+        return "payload_too_large"
+    if status_code == 422:
+        return "validation_error"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code in {502, 503, 504}:
+        return "upstream_unavailable"
+    return "internal_error"
+
+
+def _request_size(endpoint: EndpointTemplate, payload: str, roll: float) -> int:
+    baseline = 120 + len(payload.encode("utf-8"))
+    multiplier = 1 + (roll * 2.5)
+    if endpoint.payload_kind in {"completion", "embedding", "spec"}:
+        multiplier *= 2.8
+    return int(baseline * multiplier)
+
+
+def _response_size(endpoint: EndpointTemplate, payload: str, status_code: int, roll: float) -> int:
+    baseline = 220 + len(payload.encode("utf-8"))
+    multiplier = 1 + (roll * 4.5)
+    if endpoint.payload_kind in {"catalog", "api_catalog", "audit", "ledger"}:
+        multiplier *= 3.2
+    if status_code >= 400:
+        multiplier *= 0.65
+    return int(baseline * multiplier)
+
+
+def _headers(trace_id: str, consumer: ConsumerSegment, scenario: ScenarioProfile, *, request: bool) -> str:
+    if request:
+        return _json(
+            {
+                "content-type": "application/json",
+                "x-request-source": consumer.group,
+                "x-scenario": scenario.key,
+                "traceparent": f"00-{trace_id}-{trace_id[:16]}-01",
+            }
+        )
+    return _json({"content-type": "application/json", "x-synthetic-data": "true"})
+
+
+def _consumer_id(scenario_key: str, consumer: ConsumerSegment, rng: random.Random) -> str:
+    return f"{scenario_key[:8]}-{consumer.group}-{rng.randint(1000, 9999)}"
+
+
+def _ip_address(rng: random.Random) -> str:
+    block = rng.choice(("192.0.2", "198.51.100", "203.0.113"))
+    return f"{block}.{rng.randint(1, 254)}"
+
+
+def _hex_id(rng: random.Random, length: int) -> str:
+    bits = length * 4
+    return f"{rng.getrandbits(bits):0{length}x}"[-length:]
+
+
+def _child_span_names(endpoint: EndpointTemplate, incident: IncidentProfile | None) -> tuple[tuple[str, str], ...]:
+    names = [
+        (f"{endpoint.service_name}.validate", "internal"),
+        (f"{endpoint.service_name}.db", "db"),
+        (f"{endpoint.service_name}.cache", "internal"),
+    ]
+    if endpoint.payload_kind in {"payment", "risk", "eligibility", "webhook", "notification", "completion", "embedding"}:
+        names.append((f"{endpoint.service_name}.upstream", "client"))
+    if incident:
+        names.append((f"{endpoint.service_name}.{incident.key}", "client"))
+    return tuple(names)
+
+
+def _json(value: dict[str, Any]) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)

--- a/apps/api/apps/projects/synthetic/runner.py
+++ b/apps/api/apps/projects/synthetic/runner.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.db import transaction
+from django.utils.text import slugify
+
+from apps.projects.models import App, Environment, Project
+
+from .catalog import ScenarioProfile, expand_scenario_keys, get_scenario, list_scenarios
+from .generator import AppTarget, SyntheticRunConfig, SyntheticTelemetryEngine
+from .writers import DirectClickHouseWriter, WriteSummary
+
+MAX_UI_INGEST_COUNT = 50_000
+
+
+@dataclass(frozen=True)
+class SyntheticDirectRun:
+    generation: dict[str, Any]
+    write: WriteSummary
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            **self.generation,
+            "mode": self.write.mode,
+            "written_requests": self.write.requests,
+            "written_logs": self.write.logs,
+            "written_spans": self.write.spans,
+        }
+
+
+def scenario_options() -> list[dict[str, Any]]:
+    return [_scenario_dict(scenario) for scenario in list_scenarios()]
+
+
+def run_project_direct_ingest(
+    *,
+    project: Project,
+    scenario_keys: list[str] | tuple[str, ...],
+    count: int,
+    days: int,
+    seed: int | None = None,
+    accelerator: str = "auto",
+    include_logs: bool = True,
+    include_spans: bool = True,
+    ensure_apps: bool = True,
+    app_slugs: list[str] | tuple[str, ...] | None = None,
+) -> SyntheticDirectRun:
+    safe_count = max(1, min(int(count), MAX_UI_INGEST_COUNT))
+    safe_days = max(1, min(int(days), 365))
+    keys = expand_scenario_keys(scenario_keys)
+
+    if ensure_apps:
+        ensure_project_scenario_apps(project, keys)
+
+    targets = app_targets_for_project(project, keys, app_slugs=app_slugs)
+    if not targets:
+        raise ValueError("No active target apps found for the selected scenarios")
+
+    config = SyntheticRunConfig(
+        scenario_keys=keys,
+        count=safe_count,
+        days=safe_days,
+        seed=seed,
+        accelerator=accelerator,  # type: ignore[arg-type]
+        include_logs=include_logs,
+        include_spans=include_spans,
+        project_slug=project.slug,
+        app_targets=targets,
+    )
+    result = SyntheticTelemetryEngine(config).generate()
+    write = DirectClickHouseWriter().write(result)
+    return SyntheticDirectRun(generation=result.summary(), write=write)
+
+
+@transaction.atomic
+def ensure_project_scenario_apps(project: Project, scenario_keys: tuple[str, ...]) -> None:
+    for scenario_key in scenario_keys:
+        scenario = get_scenario(scenario_key)
+        for profile in scenario.apps:
+            app, _created = App.objects.get_or_create(
+                project=project,
+                slug=profile.slug,
+                defaults={
+                    "name": profile.name,
+                    "description": profile.description,
+                    "framework": profile.framework,
+                    "icon": profile.icon[:8],
+                },
+            )
+            updates: list[str] = []
+            for field, value in (
+                ("name", profile.name),
+                ("description", profile.description),
+                ("framework", profile.framework),
+                ("icon", profile.icon[:8]),
+            ):
+                if getattr(app, field) != value:
+                    setattr(app, field, value)
+                    updates.append(field)
+            if not app.is_active:
+                app.is_active = True
+                updates.append("is_active")
+            if updates:
+                app.save(update_fields=updates + ["updated_at"])
+            _ensure_environments(app, scenario)
+
+
+def app_targets_for_project(
+    project: Project,
+    scenario_keys: tuple[str, ...],
+    *,
+    app_slugs: list[str] | tuple[str, ...] | None = None,
+) -> tuple[AppTarget, ...]:
+    profile_by_slug = {
+        profile.slug: profile
+        for key in scenario_keys
+        for profile in get_scenario(key).apps
+    }
+    requested = [slug.strip() for slug in (app_slugs or []) if slug and slug.strip()]
+    slugs = requested or list(profile_by_slug)
+    apps = App.objects.filter(project=project, slug__in=slugs, is_active=True).order_by("slug")
+    targets: list[AppTarget] = []
+    for app in apps:
+        profile = profile_by_slug.get(app.slug)
+        targets.append(
+            AppTarget(
+                slug=app.slug,
+                name=app.name,
+                app_id=str(app.id),
+                project_id=str(project.id),
+                project_slug=project.slug,
+                framework=app.framework,
+                base_urls=profile.base_urls if profile else (),
+            )
+        )
+    return tuple(targets)
+
+
+def _ensure_environments(app: App, scenario: ScenarioProfile) -> None:
+    colors = {
+        "production": "#16a34a",
+        "staging": "#2563eb",
+        "development": "#9333ea",
+    }
+    for order, env in enumerate(scenario.environments):
+        slug = slugify(env.value)
+        Environment.objects.get_or_create(
+            app=app,
+            slug=slug,
+            defaults={
+                "name": env.value.title(),
+                "color": colors.get(slug, "#6b7280"),
+                "order": order,
+            },
+        )
+
+
+def _scenario_dict(scenario: ScenarioProfile) -> dict[str, Any]:
+    return {
+        "key": scenario.key,
+        "name": scenario.name,
+        "industry": scenario.industry,
+        "description": scenario.description,
+        "product_signal": scenario.product_signal,
+        "apps": len(scenario.apps),
+        "endpoints": len(scenario.endpoints),
+        "consumers": len(scenario.consumers),
+    }

--- a/apps/api/apps/projects/synthetic/validation.py
+++ b/apps/api/apps/projects/synthetic/validation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def normalize_selected_scenarios(keys: Iterable[str] | None) -> tuple[str, ...]:
+    return tuple(k.strip().lower() for k in (keys or ()) if k and k.strip())
+
+
+def validate_selected_scenarios(keys: Iterable[str] | None) -> tuple[str, ...]:
+    normalized = normalize_selected_scenarios(keys)
+    if not normalized:
+        raise ValueError("At least one synthetic scenario must be selected")
+    return normalized
+
+
+def validate_count_and_days(
+    *,
+    count: int,
+    days: int,
+    max_count: int | None = None,
+    max_days: int | None = None,
+) -> tuple[int, int]:
+    if count < 1:
+        raise ValueError("count must be at least 1")
+    if max_count is not None and count > max_count:
+        raise ValueError(f"count must be at most {max_count}")
+    if days < 1:
+        raise ValueError("days must be at least 1")
+    if max_days is not None and days > max_days:
+        raise ValueError(f"days must be at most {max_days}")
+    return count, days

--- a/apps/api/apps/projects/synthetic/writers.py
+++ b/apps/api/apps/projects/synthetic/writers.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .generator import GenerationResult, LogEvent, RequestEvent, SpanEvent
+
+REQUEST_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "endpoint_id",
+    "environment",
+    "method",
+    "path",
+    "status_code",
+    "response_time_ms",
+    "request_size",
+    "response_size",
+    "ip_address",
+    "user_agent",
+    "consumer_id",
+    "consumer_name",
+    "consumer_group",
+    "request_payload",
+    "response_payload",
+    "request_headers",
+    "response_headers",
+    "base_url",
+    "trace_id",
+    "span_id",
+]
+
+LOG_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "environment",
+    "level",
+    "message",
+    "logger_name",
+    "endpoint_method",
+    "endpoint_path",
+    "status_code",
+    "consumer_id",
+    "consumer_name",
+    "consumer_group",
+    "trace_id",
+    "span_id",
+    "payload",
+    "attributes_json",
+]
+
+SPAN_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "environment",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "name",
+    "kind",
+    "service_name",
+    "duration_ms",
+    "status",
+    "status_code",
+    "attributes_json",
+]
+
+
+@dataclass(frozen=True)
+class WriteSummary:
+    mode: str
+    requests: int = 0
+    logs: int = 0
+    spans: int = 0
+    output_dir: str = ""
+    details: dict[str, Any] | None = None
+
+
+class JsonlWriter:
+    def __init__(self, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        request_path = self.output_dir / "requests.jsonl"
+        log_path = self.output_dir / "logs.jsonl"
+        span_path = self.output_dir / "spans.jsonl"
+        manifest_path = self.output_dir / "manifest.json"
+
+        request_count = _write_jsonl(request_path, (event.as_ingest_dict() for event in result.requests))
+        log_count = _write_jsonl(log_path, (event.as_ingest_dict() for event in result.logs))
+        span_count = _write_jsonl(span_path, (event.as_ingest_dict() for event in result.spans))
+        manifest_path.write_text(json.dumps(result.summary(), indent=2, sort_keys=True), encoding="utf-8")
+
+        return WriteSummary(
+            mode="jsonl",
+            requests=request_count,
+            logs=log_count,
+            spans=span_count,
+            output_dir=str(self.output_dir),
+            details={
+                "requests": str(request_path),
+                "logs": str(log_path),
+                "spans": str(span_path),
+                "manifest": str(manifest_path),
+            },
+        )
+
+
+class HttpIngestWriter:
+    def __init__(self, ingest_url: str, api_key: str, *, batch_size: int = 1000, timeout: float = 30.0) -> None:
+        if not ingest_url:
+            raise ValueError("ingest_url is required for HTTP ingest")
+        if not api_key:
+            raise ValueError("api_key is required for HTTP ingest")
+        self.ingest_url = ingest_url.rstrip("/")
+        self.api_key = api_key
+        self.batch_size = max(1, min(int(batch_size), 1000))
+        self.timeout = timeout
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        import httpx
+
+        headers = {"X-API-Key": self.api_key}
+        accepted_requests = accepted_logs = accepted_spans = 0
+        with httpx.Client(timeout=self.timeout, headers=headers) as client:
+            for batch in _chunks([event.as_ingest_dict() for event in result.requests], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/requests", json={"requests": batch})
+                response.raise_for_status()
+                accepted_requests += int(response.json().get("accepted", 0))
+            for batch in _chunks([event.as_ingest_dict() for event in result.logs], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/logs", json={"logs": batch})
+                response.raise_for_status()
+                accepted_logs += int(response.json().get("accepted", 0))
+            for batch in _chunks([event.as_ingest_dict() for event in result.spans], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/traces", json={"spans": batch})
+                response.raise_for_status()
+                accepted_spans += int(response.json().get("accepted", 0))
+
+        return WriteSummary(mode="http", requests=accepted_requests, logs=accepted_logs, spans=accepted_spans)
+
+
+class DirectClickHouseWriter:
+    def __init__(self, *, batch_size: int = 1000) -> None:
+        self.batch_size = max(1, min(int(batch_size), 1000))
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        from apps.projects.models import App, Endpoint
+        from apps.projects.services import IngestService
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        client = get_clickhouse_client()
+        self._ensure_schema(client, IngestService)
+
+        app_by_identifier = self._resolve_apps(App, result.requests)
+        missing = sorted(
+            {
+                event.app_id or event.app_slug
+                for event in result.requests
+                if not self._app_for_event(event, app_by_identifier)
+            }
+        )
+        if missing:
+            raise ValueError(f"Cannot direct-write telemetry because app(s) were not found: {', '.join(missing)}")
+
+        endpoint_map = self._ensure_endpoints(Endpoint, app_by_identifier, result.requests)
+        accepted_requests = accepted_logs = accepted_spans = 0
+
+        for batch in _chunks(result.requests, self.batch_size):
+            rows = [self._request_row(event, app_by_identifier, endpoint_map) for event in batch]
+            client.insert("api_requests", rows, columns=REQUEST_COLUMNS)
+            accepted_requests += len(rows)
+
+        for batch in _chunks(result.logs, self.batch_size):
+            rows = [self._log_row(event, app_by_identifier) for event in batch]
+            if rows:
+                client.insert("api_logs", rows, columns=LOG_COLUMNS)
+                accepted_logs += len(rows)
+
+        for batch in _chunks(result.spans, self.batch_size):
+            rows = [self._span_row(event, app_by_identifier) for event in batch]
+            if rows:
+                client.insert("api_spans", rows, columns=SPAN_COLUMNS)
+                accepted_spans += len(rows)
+
+        return WriteSummary(mode="direct", requests=accepted_requests, logs=accepted_logs, spans=accepted_spans)
+
+    def _ensure_schema(self, client, ingest_service) -> None:
+        for helper in (
+            "ensure_payload_columns",
+            "ensure_header_columns",
+            "ensure_consumer_columns",
+            "ensure_base_url_column",
+            "ensure_api_logs_table",
+            "ensure_api_spans_table",
+        ):
+            fn = getattr(ingest_service, helper, None)
+            if fn:
+                fn(client)
+
+        for statement in (
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_payload String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_payload String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_headers String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_headers String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(3))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS base_url String DEFAULT '' CODEC(ZSTD(1))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS trace_id String DEFAULT '' CODEC(ZSTD(1))",
+            "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS span_id String DEFAULT '' CODEC(ZSTD(1))",
+            "ALTER TABLE api_requests ADD INDEX IF NOT EXISTS idx_api_requests_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_method LowCardinality(String) CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_path String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+        ):
+            client.execute(statement)
+
+        client.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_spans (
+                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+                app_id String CODEC(ZSTD(1)),
+                project_id String CODEC(ZSTD(1)),
+                environment LowCardinality(String) CODEC(ZSTD(1)),
+                trace_id String CODEC(ZSTD(1)),
+                span_id String CODEC(ZSTD(1)),
+                parent_span_id String CODEC(ZSTD(1)),
+                name String CODEC(ZSTD(1)),
+                kind LowCardinality(String) CODEC(ZSTD(1)),
+                service_name LowCardinality(String) CODEC(ZSTD(1)),
+                duration_ms Float64 CODEC(Gorilla, ZSTD(1)),
+                status LowCardinality(String) CODEC(ZSTD(1)),
+                status_code UInt16 CODEC(ZSTD(1)),
+                attributes_json String CODEC(ZSTD(3))
+            ) ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (app_id, trace_id, timestamp)
+            TTL toDateTime(timestamp) + INTERVAL 30 DAY
+            SETTINGS index_granularity = 8192
+            """
+        )
+        client.execute("ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1")
+        client.execute("ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1")
+
+    def _resolve_apps(self, app_model, requests: list[RequestEvent]) -> dict[str, Any]:
+        app_ids = {event.app_id for event in requests if event.app_id}
+        apps = list(app_model.objects.filter(id__in=app_ids, is_active=True).select_related("project")) if app_ids else []
+        if not apps:
+            slugs = {event.app_slug for event in requests if event.app_slug}
+            apps = list(app_model.objects.filter(slug__in=slugs, is_active=True).select_related("project"))
+        mapping: dict[str, Any] = {}
+        for app in apps:
+            mapping[str(app.id)] = app
+            mapping.setdefault(app.slug, app)
+        return mapping
+
+    def _app_for_event(self, event: RequestEvent | LogEvent | SpanEvent, app_by_identifier: dict[str, Any]):
+        return app_by_identifier.get(event.app_id) or app_by_identifier.get(event.app_slug)
+
+    def _endpoint_key(self, event: RequestEvent, app_by_identifier: dict[str, Any]) -> tuple[str, str, str]:
+        app = self._app_for_event(event, app_by_identifier)
+        return (str(app.id), event.method.upper(), event.path)
+
+    def _ensure_endpoints(self, endpoint_model, app_by_identifier: dict[str, Any], requests: list[RequestEvent]) -> dict[tuple[str, str, str], str]:
+        seen: dict[tuple[str, str, str], datetime] = {}
+        for event in requests:
+            key = self._endpoint_key(event, app_by_identifier)
+            previous = seen.get(key)
+            if previous is None or event.timestamp > previous:
+                seen[key] = event.timestamp
+
+        endpoint_ids: dict[tuple[str, str, str], str] = {}
+        for (app_id, method, path), last_seen_at in seen.items():
+            endpoint, _created = endpoint_model.objects.update_or_create(
+                app_id=app_id,
+                method=method,
+                path=path,
+                defaults={
+                    "description": "",
+                    "is_active": True,
+                    "last_seen_at": last_seen_at,
+                },
+            )
+            endpoint_ids[(app_id, method, path)] = str(endpoint.id)
+        return endpoint_ids
+
+    def _request_row(self, event: RequestEvent, app_by_identifier: dict[str, Any], endpoint_map: dict[tuple[str, str, str], str]) -> dict[str, Any]:
+        app = self._app_for_event(event, app_by_identifier)
+        method = event.method.upper()
+        endpoint_key = self._endpoint_key(event, app_by_identifier)
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "endpoint_id": endpoint_map.get(endpoint_key, ""),
+            "environment": event.environment,
+            "method": method,
+            "path": event.path,
+            "status_code": event.status_code,
+            "response_time_ms": event.response_time_ms,
+            "request_size": event.request_size,
+            "response_size": event.response_size,
+            "ip_address": event.ip_address,
+            "user_agent": event.user_agent,
+            "consumer_id": event.consumer_id,
+            "consumer_name": event.consumer_name,
+            "consumer_group": event.consumer_group,
+            "request_payload": event.request_payload,
+            "response_payload": event.response_payload,
+            "request_headers": event.request_headers,
+            "response_headers": event.response_headers,
+            "base_url": event.base_url,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+        }
+
+    def _log_row(self, event: LogEvent, app_by_identifier: dict[str, Any]) -> dict[str, Any]:
+        app = self._app_for_event(event, app_by_identifier)
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "environment": event.environment,
+            "level": event.level,
+            "message": event.message,
+            "logger_name": event.logger_name,
+            "endpoint_method": event.endpoint_method,
+            "endpoint_path": event.endpoint_path,
+            "status_code": event.status_code,
+            "consumer_id": event.consumer_id,
+            "consumer_name": event.consumer_name,
+            "consumer_group": event.consumer_group,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+            "payload": event.payload,
+            "attributes_json": json.dumps(event.attributes, separators=(",", ":"), sort_keys=True),
+        }
+
+    def _span_row(self, event: SpanEvent, app_by_identifier: dict[str, Any]) -> dict[str, Any]:
+        app = self._app_for_event(event, app_by_identifier)
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "environment": event.environment,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+            "parent_span_id": event.parent_span_id,
+            "name": event.name,
+            "kind": event.kind,
+            "service_name": event.service_name,
+            "duration_ms": event.duration_ms,
+            "status": event.status,
+            "status_code": event.status_code,
+            "attributes_json": json.dumps(event.attributes, separators=(",", ":"), sort_keys=True),
+        }
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+            count += 1
+    return count
+
+
+def _chunks(items, size: int):
+    for idx in range(0, len(items), size):
+        yield items[idx : idx + size]

--- a/apps/api/routers/projects/router.py
+++ b/apps/api/routers/projects/router.py
@@ -16,9 +16,12 @@ from apps.auth.services import ApiKeyService
 from apps.projects.models import App
 from apps.projects.services import ProjectService, AppService, AnalyticsService, DataQueryService
 from apps.projects.membership import MembershipService
+from apps.projects.synthetic.runner import MAX_UI_INGEST_COUNT, scenario_options, run_project_direct_ingest
+from apps.projects.synthetic.validation import validate_count_and_days, validate_selected_scenarios
 from apps.users.models import User
 from apps.users.services import UserService
 from apps.auth.authentication import jwt_auth
+from core.exceptions.base import ValidationError
 
 from .schemas import (
     CreateProjectRequest,
@@ -36,6 +39,7 @@ from .schemas import (
     LogsQueryResponse,
     RequestsQueryResponse,
     TraceQueryResponse,
+    SpansQueryResponse,
     AnalyticsTimeseriesPointResponse,
     MembersListResponse,
     InvitationResponse,
@@ -44,6 +48,9 @@ from .schemas import (
     AcceptInvitationRequest,
     PendingInvitationResponse,
     AcceptResultResponse,
+    SyntheticScenarioResponse,
+    SyntheticIngestRequest,
+    SyntheticIngestResponse,
 )
 
 router = Router(auth=[jwt_auth])
@@ -150,6 +157,52 @@ def delete_app(request: HttpRequest, project_slug: str, app_slug: str):
     project = ProjectService.get_project_by_slug(user, project_slug, action="write")
     AppService.delete_app(project, app_slug)
     return MessageResponse(message="App deleted successfully")
+
+
+# ── Synthetic telemetry ─────────────────────────────────────────────────────
+
+
+@router.get("/{project_slug}/synthetic/scenarios", response=list[SyntheticScenarioResponse])
+def list_synthetic_scenarios(request: HttpRequest, project_slug: str):
+    """List local synthetic telemetry scenario packs."""
+    user: User = request.auth
+    ProjectService.get_project_by_slug(user, project_slug, action="read")
+    return [SyntheticScenarioResponse(**item) for item in scenario_options()]
+
+
+@router.post("/{project_slug}/synthetic/ingest", response=SyntheticIngestResponse)
+def ingest_synthetic_telemetry(request: HttpRequest, project_slug: str, data: SyntheticIngestRequest):
+    """Generate and direct-write local synthetic telemetry for a project."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug, action="write")
+    if data.accelerator not in {"auto", "cpu", "gpu"}:
+        raise ValidationError("accelerator must be one of: auto, cpu, gpu")
+    try:
+        scenario_keys = validate_selected_scenarios(data.scenario_keys)
+        count, days = validate_count_and_days(
+            count=data.count,
+            days=data.days,
+            max_count=MAX_UI_INGEST_COUNT,
+            max_days=365,
+        )
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+    try:
+        result = run_project_direct_ingest(
+            project=project,
+            scenario_keys=scenario_keys,
+            count=count,
+            days=days,
+            seed=data.seed,
+            accelerator=data.accelerator,
+            include_logs=data.include_logs,
+            include_spans=data.include_spans,
+            ensure_apps=data.ensure_apps,
+            app_slugs=data.app_slugs,
+        ).as_dict()
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+    return SyntheticIngestResponse(**result)
 
 
 # ── Project-scoped API Keys ──────────────────────────────────────────
@@ -794,6 +847,7 @@ def query_project_logs(
     search: str = None,
     loggers: str = None,
     trace_id: str = None,
+    span_id: str = None,
     page: int = 1,
     page_size: int = 50,
 ):
@@ -807,6 +861,7 @@ def query_project_logs(
     - search: Search in message, logger_name, or attributes
     - loggers: Comma-separated logger names
     - trace_id: Only logs correlated with this W3C trace id
+    - span_id: Only logs correlated with this span id
     - since/until: ISO8601 timestamps for time range
     - page/page_size: Pagination controls
     """
@@ -838,6 +893,7 @@ def query_project_logs(
         search=search,
         logger_filters=logger_list,
         trace_id=trace_id,
+        span_id=span_id,
         page=page,
         page_size=page_size,
     )
@@ -931,3 +987,49 @@ def query_project_requests(
     )
 
     return RequestsQueryResponse(**result)
+
+
+@router.get("/{project_slug}/data/spans", response=SpansQueryResponse)
+def query_project_spans(
+    request: HttpRequest,
+    project_slug: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    trace_id: str = None,
+    page: int = 1,
+    page_size: int = 100,
+):
+    """
+    Query raw trace span data across all apps in a project.
+
+    Filters:
+    - trace_id: Exact trace identifier to inspect a single trace
+    - app_slugs: Comma-separated app slugs
+    - environment: Filter by environment name
+    - since/until: ISO8601 timestamps for time range
+    - page/page_size: Pagination controls
+    """
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+
+    app_ids = None
+    if app_slugs:
+        slugs = [s.strip() for s in app_slugs.split(",") if s.strip()]
+        if slugs:
+            apps = AppService.get_apps_by_slugs(project, slugs)
+            app_ids = [str(app.id) for app in apps]
+
+    result = DataQueryService.get_project_spans(
+        project_id=str(project.id),
+        app_ids=app_ids,
+        environment=environment,
+        since=since,
+        until=until,
+        trace_id=trace_id,
+        page=page,
+        page_size=page_size,
+    )
+
+    return SpansQueryResponse(**result)

--- a/apps/api/routers/projects/schemas.py
+++ b/apps/api/routers/projects/schemas.py
@@ -5,6 +5,7 @@ Schemas for project-scoped API endpoints.
 from datetime import datetime
 from uuid import UUID
 
+from pydantic import Field
 from ninja import Schema
 
 
@@ -166,6 +167,12 @@ class LogItemResponse(Schema):
     level: str
     message: str
     logger_name: str
+    endpoint_method: str = ""
+    endpoint_path: str = ""
+    status_code: int = 0
+    consumer_id: str = ""
+    consumer_name: str = ""
+    consumer_group: str = ""
     trace_id: str = ""
     span_id: str = ""
     payload: str
@@ -208,7 +215,7 @@ class SpanItemResponse(Schema):
     environment: str
     trace_id: str
     span_id: str
-    parent_span_id: str
+    parent_span_id: str = ""
     name: str
     kind: str
     service_name: str
@@ -219,6 +226,52 @@ class SpanItemResponse(Schema):
 
 class TraceQueryResponse(Schema):
     spans: list[SpanItemResponse]
+
+
+class SpansQueryResponse(Schema):
+    items: list[SpanItemResponse]
+    total_count: int
+    page: int
+    page_size: int
+
+
+class SyntheticScenarioResponse(Schema):
+    key: str
+    name: str
+    industry: str
+    description: str
+    product_signal: str
+    apps: int
+    endpoints: int
+    consumers: int
+
+
+class SyntheticIngestRequest(Schema):
+    scenario_keys: list[str] = Field(default_factory=lambda: ["api_product_growth"])
+    count: int = 5000
+    days: int = 14
+    seed: int | None = None
+    accelerator: str = "auto"
+    include_logs: bool = True
+    include_spans: bool = True
+    ensure_apps: bool = True
+    app_slugs: list[str] = Field(default_factory=list)
+
+
+class SyntheticIngestResponse(Schema):
+    requests: int
+    logs: int
+    spans: int
+    written_requests: int
+    written_logs: int
+    written_spans: int
+    scenarios: list[str]
+    apps: list[str]
+    seed: int
+    accelerator_backend: str
+    used_gpu: bool
+    generated_at: str
+    mode: str
 
 
 class AnalyticsTimeseriesPointResponse(Schema):

--- a/apps/api/tests/test_app_service.py
+++ b/apps/api/tests/test_app_service.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from apps.projects.models import App, Project
+from apps.projects.services import AppService
+from apps.users.models import User
+
+
+class AppServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Demo Project",
+            slug="demo-project",
+        )
+
+    def test_update_app_name_preserves_stable_slug(self) -> None:
+        app = App.objects.create(
+            project=self.project,
+            name="Original App",
+            slug="stable-app-id",
+            framework=App.Framework.FASTAPI,
+        )
+
+        updated = AppService.update_app(
+            self.project,
+            "stable-app-id",
+            name="Renamed App",
+        )
+
+        self.assertEqual(updated.name, "Renamed App")
+        self.assertEqual(updated.slug, "stable-app-id")
+        self.assertTrue(
+            App.objects.filter(
+                project=self.project,
+                slug="stable-app-id",
+                name="Renamed App",
+            ).exists()
+        )

--- a/apps/api/tests/test_filters.py
+++ b/apps/api/tests/test_filters.py
@@ -1,0 +1,39 @@
+import sys
+from unittest import TestCase
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+from apps.projects.filters import build_where, parse_filter
+
+
+class RichFilterTests(TestCase):
+    def test_status_class_not_negates_status_range(self) -> None:
+        params = {}
+
+        where = build_where(parse_filter("status_class:not:2xx"), params)
+
+        self.assertIn("NOT", where)
+        self.assertIn("status_code >=", where)
+        self.assertIn("status_code <", where)
+        self.assertEqual(params["flt0_0_lo"], 200)
+        self.assertEqual(params["flt0_0_hi"], 300)
+
+    def test_status_class_is_keeps_positive_status_range(self) -> None:
+        params = {}
+
+        where = build_where(parse_filter("status_class:is:2xx"), params)
+
+        self.assertNotIn("NOT", where)
+        self.assertIn("status_code >=", where)
+        self.assertIn("status_code <", where)
+        self.assertEqual(params["flt0_0_lo"], 200)
+        self.assertEqual(params["flt0_0_hi"], 300)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/apps/api/tests/test_membership.py
+++ b/apps/api/tests/test_membership.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from apps.projects.membership import MembershipService
+from apps.projects.models import Project, ProjectInvitation
+from apps.users.models import User
+from core.exceptions.base import ValidationError
+
+
+class MembershipServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Demo Project",
+            slug="demo-project",
+        )
+
+    def test_invite_member_rejects_invalid_email(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "valid email"):
+            MembershipService.invite_member(
+                self.owner,
+                self.project,
+                "codex-invalid-email-no-at",
+                "viewer",
+            )
+
+        self.assertFalse(
+            ProjectInvitation.objects.filter(
+                project=self.project,
+                email="codex-invalid-email-no-at",
+            ).exists()
+        )

--- a/apps/api/tests/test_project_service.py
+++ b/apps/api/tests/test_project_service.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from apps.projects.models import Project
+from apps.projects.services import ProjectService
+from apps.users.models import User
+
+
+class ProjectServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Original Project",
+            slug="stable-project-id",
+        )
+
+    def test_update_project_name_preserves_stable_slug(self) -> None:
+        updated = ProjectService.update_project(
+            self.owner,
+            "stable-project-id",
+            name="Renamed Project",
+        )
+
+        self.assertEqual(updated.name, "Renamed Project")
+        self.assertEqual(updated.slug, "stable-project-id")
+        self.assertTrue(
+            Project.objects.filter(
+                id=self.project.id,
+                slug="stable-project-id",
+                name="Renamed Project",
+            ).exists()
+        )

--- a/apps/api/tests/test_synthetic_telemetry.py
+++ b/apps/api/tests/test_synthetic_telemetry.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+loaded_apps = sys.modules.get("apps")
+loaded_apps_file = str(getattr(loaded_apps, "__file__", "") or "")
+loaded_apps_paths = [str(path) for path in getattr(loaded_apps, "__path__", [])] if loaded_apps is not None else []
+api_apps_path = str(API_ROOT / "apps")
+if loaded_apps is not None and (
+    (loaded_apps_file and not loaded_apps_file.startswith(str(API_ROOT)))
+    or (loaded_apps_paths and api_apps_path not in loaded_apps_paths)
+):
+    del sys.modules["apps"]
+
+from apps.projects.synthetic.accelerators import RandomPlanner
+from apps.projects.synthetic.catalog import SCENARIOS, expand_scenario_keys
+from apps.projects.synthetic.generator import SyntheticRunConfig, SyntheticTelemetryEngine
+from apps.projects.synthetic.validation import (
+    validate_count_and_days,
+    validate_selected_scenarios,
+)
+from apps.projects.synthetic.writers import JsonlWriter
+
+
+class SyntheticTelemetryTests(unittest.TestCase):
+    def test_catalog_has_required_scenario_breadth(self) -> None:
+        self.assertGreaterEqual(len(SCENARIOS), 5)
+        for key in (
+            "api_product_growth",
+            "ecommerce_checkout",
+            "fintech_payments",
+            "healthtech_patient",
+            "logistics_fleet",
+            "ai_platform",
+            "telco_iot",
+            "internal_saas",
+            "enterprise_governance",
+        ):
+            self.assertIn(key, SCENARIOS)
+            self.assertGreaterEqual(len(SCENARIOS[key].apps), 1)
+            self.assertGreaterEqual(len(SCENARIOS[key].endpoints), 5)
+            self.assertGreaterEqual(len(SCENARIOS[key].consumers), 5)
+
+    def test_expand_all_scenarios(self) -> None:
+        self.assertEqual(tuple(SCENARIOS), expand_scenario_keys(("all",)))
+
+    def test_api_scenario_selection_requires_at_least_one_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "At least one synthetic scenario"):
+            validate_selected_scenarios([])
+        with self.assertRaisesRegex(ValueError, "At least one synthetic scenario"):
+            validate_selected_scenarios(["", "   "])
+        self.assertEqual(("ai_platform",), validate_selected_scenarios([" AI_PLATFORM "]))
+
+    def test_synthetic_count_and_days_validation_rejects_invalid_values(self) -> None:
+        for count, days in ((0, 1), (-1, 1), (1, 0), (1, -5)):
+            with self.subTest(count=count, days=days):
+                with self.assertRaises(ValueError):
+                    validate_count_and_days(count=count, days=days)
+
+        with self.assertRaisesRegex(ValueError, "count must be at most 50"):
+            validate_count_and_days(count=51, days=1, max_count=50)
+        with self.assertRaisesRegex(ValueError, "days must be at most 7"):
+            validate_count_and_days(count=1, days=8, max_days=7)
+        self.assertEqual((10, 3), validate_count_and_days(count=10, days=3))
+
+    def test_fixed_seed_is_repeatable(self) -> None:
+        config = SyntheticRunConfig(
+            scenario_keys=("ai_platform",),
+            count=30,
+            days=3,
+            now=datetime(2026, 7, 3, 10, tzinfo=timezone.utc),
+            seed=4242,
+            accelerator="cpu",
+            project_slug="qa",
+        )
+        first = SyntheticTelemetryEngine(config).generate()
+        second = SyntheticTelemetryEngine(config).generate()
+        self.assertEqual([row.as_ingest_dict() for row in first.requests], [row.as_ingest_dict() for row in second.requests])
+        self.assertEqual([row.as_ingest_dict() for row in first.spans], [row.as_ingest_dict() for row in second.spans])
+
+    def test_default_seed_rotates_by_hour(self) -> None:
+        first = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("fintech_payments",),
+                count=5,
+                now=datetime(2026, 7, 3, 10, tzinfo=timezone.utc),
+                accelerator="cpu",
+            )
+        ).generate()
+        second = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("fintech_payments",),
+                count=5,
+                now=datetime(2026, 7, 3, 11, tzinfo=timezone.utc),
+                accelerator="cpu",
+            )
+        ).generate()
+        self.assertNotEqual(first.seed, second.seed)
+        self.assertNotEqual([row.trace_id for row in first.requests], [row.trace_id for row in second.requests])
+
+    def test_requests_logs_and_spans_are_correlated(self) -> None:
+        result = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("ecommerce_checkout",),
+                count=120,
+                days=7,
+                seed=99,
+                accelerator="cpu",
+                project_slug="qa",
+            )
+        ).generate()
+
+        self.assertEqual(120, len(result.requests))
+        self.assertGreater(len(result.logs), 0)
+        self.assertGreaterEqual(len(result.spans), len(result.requests))
+
+        request_trace_ids = {event.trace_id for event in result.requests}
+        request_server_span_ids = {event.span_id for event in result.requests}
+        server_span_ids = {event.span_id for event in result.spans if event.parent_span_id == ""}
+
+        self.assertTrue({event.trace_id for event in result.logs}.issubset(request_trace_ids))
+        self.assertTrue({event.trace_id for event in result.spans}.issubset(request_trace_ids))
+        self.assertTrue(request_server_span_ids.issubset(server_span_ids))
+
+    def test_cpu_random_planner_reports_cpu_backend(self) -> None:
+        streams = RandomPlanner("cpu").plan(count=3, seed=7)
+        self.assertEqual("cpu-random", streams.backend)
+        self.assertFalse(streams.used_gpu)
+        self.assertEqual(3, len(streams.status_roll))
+
+    def test_jsonl_writer_outputs_manifest_and_rows(self) -> None:
+        result = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("internal_saas",),
+                count=15,
+                seed=123,
+                accelerator="cpu",
+                project_slug="qa",
+            )
+        ).generate()
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = JsonlWriter(tmp).write(result)
+            self.assertEqual("jsonl", summary.mode)
+            self.assertEqual(15, summary.requests)
+            manifest = json.loads((Path(tmp) / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(15, manifest["requests"])
+            request_lines = (Path(tmp) / "requests.jsonl").read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(15, len(request_lines))
+            first = json.loads(request_lines[0])
+            self.assertIn("trace_id", first)
+            self.assertEqual("qa", first["project_slug"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/api/tests/test_time_range.py
+++ b/apps/api/tests/test_time_range.py
@@ -1,0 +1,26 @@
+from datetime import timezone as tz
+from unittest import TestCase
+
+from apps.projects.services import _resolve_time_range
+from core.exceptions.base import ValidationError
+
+
+class TimeRangeTests(TestCase):
+    def test_invalid_since_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Invalid since timestamp"):
+            _resolve_time_range("not-a-date", None)
+
+    def test_invalid_until_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Invalid until timestamp"):
+            _resolve_time_range("2026-01-01T00:00:00Z", "also-bad")
+
+    def test_reversed_range_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "since.*before.*until"):
+            _resolve_time_range("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z")
+
+    def test_valid_z_timestamps_are_utc(self) -> None:
+        since, until = _resolve_time_range("2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z")
+
+        self.assertEqual(since.tzinfo, tz.utc)
+        self.assertEqual(until.tzinfo, tz.utc)
+        self.assertLess(since, until)

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -46,7 +46,8 @@
             "group": "Ingest",
             "pages": [
               "ingest/ingest-api",
-              "ingest/request-schema"
+              "ingest/request-schema",
+              "ingest/synthetic-telemetry-engine"
             ]
           },
           {

--- a/apps/docs/ingest/synthetic-telemetry-engine.mdx
+++ b/apps/docs/ingest/synthetic-telemetry-engine.mdx
@@ -1,0 +1,100 @@
+---
+title: Synthetic Telemetry
+description: Generate local APILens demo and QA traffic from the UI or CLI.
+---
+
+# Synthetic Telemetry
+
+Use synthetic telemetry when a local project needs realistic requests, logs, consumers, endpoints, and traces.
+
+Before direct writes, start the local datastore and apply migrations:
+
+```bash
+pnpm db:up
+python manage.py migrate
+python manage.py clickhouse_migrate
+```
+
+## Fastest Path
+
+1. Open a project.
+2. Go to **Synthetic Data**.
+3. Pick one or more scenarios.
+4. Choose the event count and time window.
+5. Click **Generate data**.
+6. Open **Traffic**, **Request logs**, or **Consumers**.
+
+The UI creates scenario apps when enabled, writes endpoint rows to Postgres, and writes request/log/span rows to ClickHouse.
+
+## Scenario Packs
+
+- `api_product_growth`
+- `ecommerce_checkout`
+- `fintech_payments`
+- `healthtech_patient`
+- `logistics_fleet`
+- `ai_platform`
+- `telco_iot`
+- `internal_saas`
+- `enterprise_governance`
+
+Each scenario includes app profiles, endpoint templates, consumer groups, environments, status-code mixes, latency profiles, and incident windows.
+
+## UI Defaults
+
+| Setting | Default |
+|---|---:|
+| Events | 5,000 |
+| Days | 14 |
+| Accelerator | Auto |
+| Create scenario apps | On |
+| Logs | On |
+| Traces | On |
+
+`Auto` tries CUDA random generation through CuPy or Torch. If neither is available, it uses CPU random generation.
+
+## CLI
+
+List scenarios:
+
+```bash
+python manage.py synthetic_telemetry --list-scenarios
+```
+
+Generate JSONL files:
+
+```bash
+python manage.py synthetic_telemetry \
+  --scenario fintech_payments \
+  --count 1000 \
+  --days 7 \
+  --mode jsonl \
+  --output-dir synthetic-output/fintech
+```
+
+Write directly to the local APILens datastore:
+
+```bash
+python manage.py synthetic_telemetry \
+  --ensure-demo-project \
+  --owner-email qa@example.com \
+  --project-slug synthetic-apilens-demo \
+  --scenario ai_platform \
+  --count 5000 \
+  --days 14 \
+  --mode direct
+```
+
+Use a fixed seed for repeatable fixtures:
+
+```bash
+python manage.py synthetic_telemetry --scenario ai_platform --count 1000 --seed 4242
+```
+
+## Safety
+
+- Domains use `.example`.
+- IPs use documentation ranges: `192.0.2.0/24`, `198.51.100.0/24`, and `203.0.113.0/24`.
+- Healthtech identifiers are synthetic tokens such as `pt_123456`.
+- The UI caps a run at 50,000 request events.
+- HTTP and direct modes write data; JSONL mode only writes files.

--- a/apps/ingest/app/ingest.py
+++ b/apps/ingest/app/ingest.py
@@ -142,6 +142,28 @@ def ensure_clickhouse_schema(client) -> None:
             TTL toDateTime(timestamp) + INTERVAL 30 DAY
             SETTINGS index_granularity = 8192
             """,
+            """
+            CREATE TABLE IF NOT EXISTS api_spans (
+                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+                app_id String CODEC(ZSTD(1)),
+                project_id String CODEC(ZSTD(1)),
+                environment LowCardinality(String) CODEC(ZSTD(1)),
+                trace_id String CODEC(ZSTD(1)),
+                span_id String CODEC(ZSTD(1)),
+                parent_span_id String CODEC(ZSTD(1)),
+                name String CODEC(ZSTD(2)),
+                kind LowCardinality(String) CODEC(ZSTD(1)),
+                service_name LowCardinality(String) CODEC(ZSTD(1)),
+                duration_ms Float64 CODEC(ZSTD(1)),
+                status LowCardinality(String) CODEC(ZSTD(1)),
+                status_code UInt16 CODEC(ZSTD(1)),
+                attributes_json String CODEC(ZSTD(3))
+            ) ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (project_id, app_id, trace_id, timestamp)
+            TTL toDateTime(timestamp) + INTERVAL 30 DAY
+            SETTINGS index_granularity = 8192
+            """,
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_payload String CODEC(ZSTD(3))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_payload String CODEC(ZSTD(3))",
@@ -155,9 +177,6 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS span_id String DEFAULT '' CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD INDEX IF NOT EXISTS idx_api_requests_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
-            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
-            # Log-correlation columns exist in the 004 migration but not in the
-            # legacy runtime-created api_logs table; ensure them before writing.
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_method LowCardinality(String) CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_path String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
@@ -166,43 +185,19 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
-            # Span storage for distributed traces (the waterfall view). The
-            # legacy `traces` table (tenant_id model) is intentionally unused.
-            """
-            CREATE TABLE IF NOT EXISTS api_spans (
-                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-                app_id String CODEC(ZSTD(1)),
-                project_id String CODEC(ZSTD(1)),
-                environment LowCardinality(String) CODEC(ZSTD(1)),
-                trace_id String CODEC(ZSTD(1)),
-                span_id String CODEC(ZSTD(1)),
-                parent_span_id String CODEC(ZSTD(1)),
-                name String CODEC(ZSTD(1)),
-                kind LowCardinality(String) CODEC(ZSTD(1)),
-                service_name LowCardinality(String) CODEC(ZSTD(1)),
-                duration_ms Float64 CODEC(Gorilla, ZSTD(1)),
-                status LowCardinality(String) CODEC(ZSTD(1)),
-                status_code UInt16 CODEC(ZSTD(1)),
-                attributes_json String CODEC(ZSTD(3))
-            ) ENGINE = MergeTree()
-            PARTITION BY toYYYYMM(timestamp)
-            ORDER BY (app_id, trace_id, timestamp)
-            TTL toDateTime(timestamp) + INTERVAL 30 DAY
-            SETTINGS index_granularity = 8192
-            """,
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
-            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",        ]
+            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+        ]
         for s in stmts:
             client.execute(s)
         _schema_ready = True
-
-
 # --- validation + resolution (mirrors router.py) ----------------------------
 
 def validate_project_slug(auth_slug: str, payload_slugs: set[str]) -> None:
@@ -400,7 +395,7 @@ def handle_spans(project_id: str, project_slug: str, records) -> int:
             trace_id = _safe_trace_component(r.trace_id, 32)
             span_id = _safe_trace_component(r.span_id, 16)
             if not trace_id or not span_id:
-                continue  # unusable without valid ids; drop silently (telemetry)
+                continue
             status = (r.status or "ok").strip().lower()
             rows.append((
                 r.timestamp, app_uuid, project_id,

--- a/apps/ingest/app/ingest.py
+++ b/apps/ingest/app/ingest.py
@@ -125,6 +125,23 @@ def ensure_clickhouse_schema(client) -> None:
         if _schema_ready:
             return
         stmts = [
+            """
+            CREATE TABLE IF NOT EXISTS api_logs (
+                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+                app_id String CODEC(ZSTD(1)),
+                project_id String CODEC(ZSTD(1)),
+                environment LowCardinality(String) CODEC(ZSTD(1)),
+                level LowCardinality(String) CODEC(ZSTD(1)),
+                message String CODEC(ZSTD(3)),
+                logger_name LowCardinality(String) CODEC(ZSTD(1)),
+                payload String CODEC(ZSTD(3)),
+                attributes_json String CODEC(ZSTD(3))
+            ) ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (project_id, app_id, environment, level, timestamp)
+            TTL toDateTime(timestamp) + INTERVAL 30 DAY
+            SETTINGS index_granularity = 8192
+            """,
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_payload String CODEC(ZSTD(3))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_payload String CODEC(ZSTD(3))",
@@ -150,6 +167,10 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
             # Span storage for distributed traces (the waterfall view). The
             # legacy `traces` table (tenant_id model) is intentionally unused.
             """
@@ -176,8 +197,7 @@ def ensure_clickhouse_schema(client) -> None:
             """,
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
-            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
-        ]
+            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",        ]
         for s in stmts:
             client.execute(s)
         _schema_ready = True

--- a/apps/ingest/app/schemas.py
+++ b/apps/ingest/app/schemas.py
@@ -81,10 +81,10 @@ class SpanRecord(BaseModel):
     span_id: str
     parent_span_id: str = ""
     name: str = ""
-    kind: str = "internal"  # server | client | http | db | internal | ...
+    kind: str = "internal"
     service_name: str = ""
     duration_ms: float = 0.0
-    status: str = "ok"  # ok | error
+    status: str = "ok"
     status_code: int = 0
     attributes: dict = Field(default_factory=dict)
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,16 +1,21 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
+  {
+    rules: {
+      "@next/next/no-html-link-for-pages": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "prefer-const": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react/no-unescaped-entities": "warn",
+    },
+  },
   {
     ignores: [
       "node_modules/**",

--- a/apps/web/src/app/api/account/passkeys/[id]/route.ts
+++ b/apps/web/src/app/api/account/passkeys/[id]/route.ts
@@ -1,38 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const { id } = await params;
 
-    const response = await fetch(
+    const response = await fetchWithAuthRefresh(
       `${AUTH_API_URL}/passkey/credentials/${id}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${session.accessToken}`,
-        },
-      }
+      { method: "DELETE" },
     );
 
     if (!response.ok) {
-      const data = await response.json();
+      const data = await response.json().catch(() => ({}));
       return NextResponse.json(
-        { error: data.detail || "Failed to delete passkey" },
+        { error: data.detail || data.error || "Failed to delete passkey" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/account/passkeys/register/options/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/options/route.ts
@@ -1,84 +1,16 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession, setSession, clearSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
-async function refreshAccessToken(refreshToken: string): Promise<{ access_token: string; refresh_token: string } | null> {
+export async function POST() {
   try {
-    const response = await fetch(`${AUTH_API_URL}/refresh`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/register/options`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh_token: refreshToken }),
-    });
-
-    if (!response.ok) return null;
-    return await response.json();
-  } catch {
-    return null;
-  }
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    let session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    let response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.accessToken}`,
-      },
       body: JSON.stringify({}),
     });
-
-    // If 401 or 422 (expired token), try to refresh
-    if (response.status === 401 || response.status === 422) {
-      console.log("Token expired, attempting refresh...");
-      const refreshResult = await refreshAccessToken(session.refreshToken);
-      if (!refreshResult) {
-        console.error("Token refresh failed");
-        await clearSession();
-        return NextResponse.json({ error: "Session expired, please log in again" }, { status: 401 });
-      }
-
-      console.log("Token refreshed successfully, retrying request...");
-      // Retry with new token
-      response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${refreshResult.access_token}`,
-        },
-        body: JSON.stringify({}),
-      });
-
-      // Get the data
-      const data = await response.json();
-
-      if (!response.ok) {
-        return NextResponse.json(
-          { error: data.detail || data.error || "Failed to generate registration options" },
-          { status: response.status },
-        );
-      }
-
-      // Update session with new tokens
-      await setSession({
-        accessToken: refreshResult.access_token,
-        refreshToken: refreshResult.refresh_token,
-        user: session.user,  // Keep existing user info
-      });
-
-      // Return success
-      return NextResponse.json(data);
-    }
 
     const data = await response.json();
 

--- a/apps/web/src/app/api/account/passkeys/register/verify/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/verify/route.ts
@@ -1,29 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
-    console.log("Verify request - challenge received:", body.challenge);
-    console.log("Verify request - credential ID:", body.credential?.id);
 
-    const response = await fetch(`${AUTH_API_URL}/passkey/register/verify`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/register/verify`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.accessToken}`,
-      },
       body: JSON.stringify({
         credential: body.credential,
         challenge: body.challenge,
@@ -32,11 +19,10 @@ export async function POST(request: NextRequest) {
     });
 
     const data = await response.json();
-    console.log("Django verify response:", response.status, data);
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data.detail || "Failed to verify passkey" },
+        { error: data.detail || data.error || "Failed to verify passkey" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/account/passkeys/route.ts
+++ b/apps/web/src/app/api/account/passkeys/route.ts
@@ -1,31 +1,21 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const response = await fetch(`${AUTH_API_URL}/passkey/credentials`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/credentials`, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${session.accessToken}`,
-      },
     });
 
     const data = await response.json();
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data.detail || "Failed to fetch passkeys" },
+        { error: data.detail || data.error || "Failed to fetch passkeys" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/projects/[slug]/analytics/consumer-stats/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/consumer-stats/route.ts
@@ -1,42 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Proxy for the project-wide rich consumer stats (requests, error rate, avg
-// response, last seen). Powers the dedicated Consumers page.
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/consumer-stats${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/consumers/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/consumers/route.ts
@@ -1,42 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Proxy for the project-wide consumer list (ranked by request volume).
-// Powers the consumer filter dropdown on Request logs / Traffic.
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/consumers${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-consumers${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-detail${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-histograms${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-requests/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-requests/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-requests${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-status-codes${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-timeseries${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoints/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoints/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoints${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/environments/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/environments/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,37 +7,15 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/environments${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch (error) {
-    return NextResponse.json(
-      { environments: [] },
-      { status: 200 }
-    );
+  const response = await proxyDjangoWithAuth(upstream);
+  if (response.status === 502) {
+    return NextResponse.json({ environments: [] }, { status: 200 });
   }
+  return response;
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/filter-values/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/filter-values/route.ts
@@ -1,41 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Typeahead source for the filter bar (distinct field values matching ?q=).
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/filter-values${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/summary/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/summary/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/summary${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/timeseries/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/timeseries/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/timeseries${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/apps/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/apps/route.ts
@@ -23,9 +23,12 @@ export const POST = (
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
+    const appSlug = typeof body.slug === "string" ? body.slug.trim() : "";
+
     // Call the backend API to create app within project
     const result = await apiClient.createProjectApp(slug, {
       name,
+      slug: appSlug,
       description: body.description || "",
       framework: body.framework || "fastapi",
     });

--- a/apps/web/src/app/api/projects/[slug]/data/requests/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/data/requests/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -9,34 +9,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/data/requests${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/data/spans/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/data/spans/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
+
+export const dynamic = "force-dynamic";
+
+// Project-scoped trace span query. Backs request detail trace inspection.
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/data/spans${qs ? `?${qs}` : ""}`;
+
+  return proxyDjangoWithAuth(upstream);
+}

--- a/apps/web/src/app/api/projects/[slug]/synthetic/ingest/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/synthetic/ingest/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { withAuth, apiResult } from "@/lib/proxy";
+import { apiClient } from "@/lib/api-client";
+
+const MAX_SYNTHETIC_COUNT = 50_000;
+const MAX_SYNTHETIC_DAYS = 365;
+
+export const POST = (
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) =>
+  withAuth(async () => {
+    const { slug } = await params;
+    const body = await request.json();
+    const count = Number(body.count || 0);
+    if (!Number.isFinite(count) || count < 1 || count > MAX_SYNTHETIC_COUNT) {
+      return NextResponse.json(
+        { error: `Count must be between 1 and ${MAX_SYNTHETIC_COUNT}` },
+        { status: 400 },
+      );
+    }
+    const days = Number(body.days || 0);
+    if (!Number.isFinite(days) || days < 1 || days > MAX_SYNTHETIC_DAYS) {
+      return NextResponse.json(
+        { error: `Days must be between 1 and ${MAX_SYNTHETIC_DAYS}` },
+        { status: 400 },
+      );
+    }
+    const scenarioKeys = Array.isArray(body.scenario_keys)
+      ? body.scenario_keys.map((key: unknown) => String(key).trim()).filter(Boolean)
+      : [];
+    if (scenarioKeys.length === 0) {
+      return NextResponse.json(
+        { error: "At least one synthetic scenario must be selected" },
+        { status: 400 },
+      );
+    }
+    const rawSeed = body.seed;
+    const parsedSeed = rawSeed === "" || rawSeed === undefined || rawSeed === null
+      ? null
+      : Number(rawSeed);
+    return apiResult(await apiClient.ingestSyntheticTelemetry(slug, {
+      scenario_keys: scenarioKeys,
+      count,
+      days,
+      seed: Number.isFinite(parsedSeed) ? parsedSeed : null,
+      accelerator: body.accelerator || "auto",
+      include_logs: body.include_logs !== false,
+      include_spans: body.include_spans !== false,
+      ensure_apps: body.ensure_apps !== false,
+      app_slugs: Array.isArray(body.app_slugs) ? body.app_slugs : [],
+    }));
+  });

--- a/apps/web/src/app/api/projects/[slug]/synthetic/scenarios/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/synthetic/scenarios/route.ts
@@ -1,0 +1,11 @@
+import { withAuth, apiResult } from "@/lib/proxy";
+import { apiClient } from "@/lib/api-client";
+
+export const GET = (
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) =>
+  withAuth(async () => {
+    const { slug } = await params;
+    return apiResult(await apiClient.getSyntheticScenarios(slug), "scenarios");
+  });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3240,6 +3240,342 @@ body {
   padding: 0;
 }
 
+/* Synthetic data */
+.synthetic-page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px;
+}
+
+.synthetic-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.synthetic-title {
+  font-size: 28px;
+  line-height: 1.15;
+  font-weight: 650;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.synthetic-subtitle {
+  margin: 0;
+  max-width: 680px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.synthetic-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+  align-items: start;
+}
+
+.synthetic-main,
+.synthetic-panel,
+.synthetic-result {
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  border-radius: 8px;
+}
+
+.synthetic-main {
+  padding: 20px;
+}
+
+.synthetic-panel {
+  padding: 18px;
+  position: sticky;
+  top: 88px;
+}
+
+.synthetic-section-head,
+.synthetic-result-head,
+.synthetic-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.synthetic-section-head {
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.synthetic-section-head h2,
+.synthetic-result-head h2 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--text-primary);
+}
+
+.synthetic-section-head p,
+.synthetic-result-head p {
+  margin: 3px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.synthetic-panel-title {
+  margin-bottom: 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.synthetic-scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 12px;
+}
+
+.synthetic-scenario {
+  min-height: 132px;
+  width: 100%;
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.synthetic-scenario:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-hover);
+}
+
+.synthetic-scenario-selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-primary));
+}
+
+.synthetic-scenario-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.synthetic-scenario-name {
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.synthetic-check {
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+.synthetic-scenario-industry {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.synthetic-scenario-meta {
+  margin-top: auto;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.synthetic-field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.synthetic-field span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.synthetic-field input,
+.synthetic-field select {
+  height: 38px;
+  width: 100%;
+  padding: 0 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.synthetic-field input:focus,
+.synthetic-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.synthetic-presets {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: -4px 0 14px;
+}
+
+.synthetic-preset {
+  height: 32px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.synthetic-preset-active {
+  border-color: var(--accent);
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-primary));
+}
+
+.synthetic-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 32px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.synthetic-toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.synthetic-run {
+  width: 100%;
+  margin-top: 16px;
+}
+
+.synthetic-alert,
+.synthetic-loading,
+.synthetic-selection {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  padding: 14px 16px;
+  margin-bottom: 18px;
+  font-size: 13px;
+}
+
+.synthetic-alert-error {
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #ef4444;
+}
+
+.synthetic-result {
+  margin-top: 24px;
+  padding: 18px;
+}
+
+.synthetic-result-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.synthetic-result-grid div {
+  min-height: 74px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  padding: 12px;
+}
+
+.synthetic-result-grid span {
+  display: block;
+  font-size: 22px;
+  font-weight: 650;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.synthetic-result-grid label {
+  display: block;
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.synthetic-result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.synthetic-selection {
+  margin-top: 18px;
+  align-items: flex-start;
+}
+
+.synthetic-selection span {
+  color: var(--text-secondary);
+}
+
+.synthetic-selection strong {
+  font-weight: 500;
+}
+
+@media (max-width: 920px) {
+  .synthetic-page {
+    padding: 20px;
+  }
+
+  .synthetic-header,
+  .synthetic-layout {
+    display: block;
+  }
+
+  .synthetic-header .settings-btn {
+    margin-top: 14px;
+  }
+
+  .synthetic-panel {
+    position: static;
+    margin-top: 18px;
+  }
+
+  .synthetic-result-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .synthetic-result-grid,
+  .synthetic-scenario-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .synthetic-presets {
+    grid-template-columns: 1fr;
+  }
+}
+
 .settings-inline-field {
   display: flex;
   align-items: stretch;
@@ -5858,6 +6194,7 @@ a.settings-btn {
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -6638,6 +6975,7 @@ a.settings-btn {
   color: var(--text-primary);
   display: -webkit-box;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -6648,6 +6986,7 @@ a.settings-btn {
   color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.45;
@@ -12605,6 +12944,7 @@ a.settings-btn {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
 }
 .ep-pm-when {
@@ -13938,7 +14278,7 @@ a.settings-btn {
 }
 .ep-section-chevron { color: var(--text-muted); transition: transform 120ms; transform: rotate(-90deg); }
 .ep-section-chevron.is-open { transform: rotate(0deg); }
-.ep-section-body { }
+/* .ep-section-body { } */
 
 /* Summary stat cards — fixed-ish width, left-aligned (don't stretch when few) */
 .ep-statcards {
@@ -14285,6 +14625,7 @@ a.settings-btn {
 
 .ep-rl-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; overflow: hidden; }
 .ep-rl-message { padding: 40px 16px; text-align: center; color: var(--text-muted); font-size: 13px; }
+.ep-rl-message-error { color: #f87171; }
 
 .ep-rl-pager {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;
@@ -14360,42 +14701,140 @@ a.settings-btn {
 }
 .ep-rel-dur { color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 
-/* Logs tab — trace-correlated log lines */
-.ep-log-row {
-  display: flex; align-items: baseline; gap: 10px; width: 100%;
-  padding: 8px 12px; border-bottom: 1px solid var(--border-color); font-size: 12px;
+/* Trace tab rows */
+.ep-trace-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  max-height: 420px;
+  overflow-y: auto;
 }
-.ep-log-row:last-child { border-bottom: none; }
-.ep-log-logger {
-  color: var(--text-muted); white-space: nowrap;
-  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
-}
-.ep-log-msg {
-  flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: var(--text-primary); overflow-wrap: anywhere;
-}
-
-/* Trace tab — span waterfall */
 .ep-trace-row {
-  display: flex; align-items: center; gap: 10px; width: 100%;
-  padding: 7px 12px; border-bottom: 1px solid var(--border-color); font-size: 12px;
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
 }
 .ep-trace-row:last-child { border-bottom: none; }
+.ep-trace-row.is-current {
+  background: rgba(20, 184, 166, 0.1);
+  box-shadow: inset 3px 0 0 #14b8a6;
+}
+.ep-trace-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
 .ep-trace-name {
-  flex: 0 0 44%; min-width: 0; display: flex; align-items: center; gap: 7px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
 }
-.ep-trace-kind {
-  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
-  flex-shrink: 0;
+.ep-trace-current {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #14b8a6;
+  background: rgba(20, 184, 166, 0.15);
+  padding: 1px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
 }
-.ep-trace-track {
-  position: relative; flex: 1; height: 8px; border-radius: 4px;
-  background: var(--bg-hover); overflow: hidden;
+.ep-trace-meta,
+.ep-trace-ids {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
-.ep-trace-bar {
-  position: absolute; top: 0; bottom: 0; border-radius: 4px; min-width: 2px;
+.ep-trace-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.ep-trace-ids {
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+}
+
+/* Logs tab rows */
+.ep-log-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  max-height: 420px;
+  overflow-y: auto;
+}
+.ep-log-row {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
+}
+.ep-log-row:last-child { border-bottom: none; }
+.ep-log-main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.ep-log-level {
+  flex: 0 0 auto;
+  min-width: 48px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.ep-log-row.level-error .ep-log-level,
+.ep-log-row.level-fatal .ep-log-level { color: #ef4444; }
+.ep-log-row.level-warn .ep-log-level,
+.ep-log-row.level-warning .ep-log-level { color: #f59e0b; }
+.ep-log-row.level-info .ep-log-level { color: #14b8a6; }
+.ep-log-message {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.ep-log-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.ep-log-payload {
+  margin: 0;
+  max-height: 140px;
+  overflow: auto;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.5;
+
 }
 
 @media (max-width: 860px) {

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { BookOpen, LifeBuoy, Mail, Settings } from "lucide-react";
+import { getSession } from "@/lib/session";
+import StandaloneShell from "@/components/dashboard/StandaloneShell";
+
+export const metadata = {
+  title: "Help & Support | APILens",
+};
+
+export default async function HelpPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <StandaloneShell>
+      <div className="apps-page">
+        <div className="apps-page-header">
+          <h1 className="apps-page-title">Help & Support</h1>
+        </div>
+
+        <div className="apps-grid">
+          <Link href="/projects" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Projects</h3>
+            </div>
+            <p className="app-card-description">Return to your projects and apps.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <BookOpen size={12} />
+                Dashboard
+              </span>
+            </div>
+          </Link>
+
+          <Link href="/account/general" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Account settings</h3>
+            </div>
+            <p className="app-card-description">Manage login methods, sessions, profile, and security.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <Settings size={12} />
+                Settings
+              </span>
+            </div>
+          </Link>
+
+          <a href="mailto:support@apilens.ai" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Contact support</h3>
+            </div>
+            <p className="app-card-description">Email support when you need help with access, setup, or telemetry.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <Mail size={12} />
+                support@apilens.ai
+              </span>
+            </div>
+          </a>
+        </div>
+
+        <div className="apps-empty" style={{ marginTop: 24 }}>
+          <div className="apps-empty-icon">
+            <LifeBuoy size={32} />
+          </div>
+          <h2 className="apps-empty-title">Need setup help?</h2>
+          <p className="apps-empty-text">
+            Open an app setup guide from Apps, or create a new app to get framework-specific instructions.
+          </p>
+        </div>
+      </div>
+    </StandaloneShell>
+  );
+}

--- a/apps/web/src/app/notifications/NotificationsPageContent.tsx
+++ b/apps/web/src/app/notifications/NotificationsPageContent.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bell, Check, Loader2, Users, X } from "lucide-react";
+
+interface PendingInvitation {
+  id: string;
+  project_name: string;
+  project_slug: string;
+  role: string;
+  inviter: string;
+  created_at: string;
+  expires_at: string;
+}
+
+export default function NotificationsPageContent() {
+  const router = useRouter();
+  const [invitations, setInvitations] = useState<PendingInvitation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const fetchPending = useCallback(async () => {
+    setError("");
+    try {
+      const res = await fetch("/api/projects/invitations/pending");
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to load notifications");
+      setInvitations(Array.isArray(data.invitations) ? data.invitations : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load notifications");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPending();
+  }, [fetchPending]);
+
+  const acceptInvitation = async (invitation: PendingInvitation) => {
+    setBusyId(invitation.id);
+    setError("");
+    try {
+      const res = await fetch(`/api/projects/invitations/${invitation.id}/accept`, { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to accept invitation");
+      router.push(`/projects/${data.project_slug || invitation.project_slug}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to accept invitation");
+      setBusyId(null);
+    }
+  };
+
+  const declineInvitation = async (invitation: PendingInvitation) => {
+    setBusyId(invitation.id);
+    setError("");
+    try {
+      const res = await fetch(`/api/projects/invitations/${invitation.id}/decline`, { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to decline invitation");
+      setInvitations((prev) => prev.filter((item) => item.id !== invitation.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to decline invitation");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="apps-page">
+      <div className="apps-page-header">
+        <h1 className="apps-page-title">Notifications</h1>
+        <button
+          type="button"
+          className="settings-btn settings-btn-secondary"
+          onClick={() => void fetchPending()}
+          disabled={isLoading}
+        >
+          {isLoading ? <Loader2 size={14} className="animate-spin" /> : null}
+          Refresh
+        </button>
+      </div>
+
+      {error ? <div className="create-app-error">{error}</div> : null}
+
+      {isLoading ? (
+        <div className="apps-page-loading">
+          <Loader2 size={24} className="animate-spin" />
+          <span>Loading notifications...</span>
+        </div>
+      ) : invitations.length === 0 ? (
+        <div className="apps-empty">
+          <div className="apps-empty-icon">
+            <Bell size={32} />
+          </div>
+          <h2 className="apps-empty-title">No notifications</h2>
+          <p className="apps-empty-text">You are all caught up.</p>
+        </div>
+      ) : (
+        <div className="apps-grid">
+          {invitations.map((invitation) => (
+            <div className="app-card" key={invitation.id}>
+              <div className="app-card-header">
+                <h3 className="app-card-name">{invitation.project_name}</h3>
+              </div>
+              <p className="app-card-description">
+                {invitation.inviter || "Someone"} invited you as {invitation.role}.
+              </p>
+              <div className="create-app-actions">
+                <button
+                  type="button"
+                  className="settings-btn settings-btn-primary"
+                  onClick={() => void acceptInvitation(invitation)}
+                  disabled={busyId === invitation.id}
+                >
+                  {busyId === invitation.id ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  className="settings-btn settings-btn-secondary"
+                  onClick={() => void declineInvitation(invitation)}
+                  disabled={busyId === invitation.id}
+                >
+                  <X size={14} />
+                  Decline
+                </button>
+              </div>
+              <div className="app-card-meta-row">
+                <span className="app-card-meta">
+                  <Users size={12} />
+                  {invitation.project_slug}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import StandaloneShell from "@/components/dashboard/StandaloneShell";
+import NotificationsPageContent from "./NotificationsPageContent";
+
+export const metadata = {
+  title: "Notifications | APILens",
+};
+
+export default async function NotificationsPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <StandaloneShell>
+      <NotificationsPageContent />
+    </StandaloneShell>
+  );
+}

--- a/apps/web/src/app/projects/[slug]/_shared/filters/FilterBar.tsx
+++ b/apps/web/src/app/projects/[slug]/_shared/filters/FilterBar.tsx
@@ -418,7 +418,7 @@ export default function FilterBar({ projectSlug, value, onChange, exclude }: Pro
           ref={inputRef}
           className="flt-input"
           value={text}
-          placeholder={predicates.length ? "" : "Filter… (e.g. status:>=500 path:~/v1/orders)"}
+          placeholder={predicates.length ? "" : "Filter… (e.g. status:>=500; path:~/v1/orders)"}
           onChange={(e) => { setText(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
           onKeyDown={onKeyDown}

--- a/apps/web/src/app/projects/[slug]/_shared/timeRange.tsx
+++ b/apps/web/src/app/projects/[slug]/_shared/timeRange.tsx
@@ -40,13 +40,26 @@ export const CALENDAR_PRESETS = [
 export const DEFAULT_PRESET_ID = "24h";
 export const DEFAULT_RANGE: RangeValue = { type: "preset", id: DEFAULT_PRESET_ID };
 
+const LEGACY_HOUR_RANGE_IDS: Record<string, string> = Object.fromEntries(
+  ROLLING_PRESETS.map((preset) => [String(preset.hours), preset.id]),
+);
+
+function validCustomRange(since: string, until: string): boolean {
+  const sinceMs = new Date(since).getTime();
+  const untilMs = new Date(until).getTime();
+  return Number.isFinite(sinceMs) && Number.isFinite(untilMs) && sinceMs < untilMs;
+}
+
 // Reconstruct the range from URL params: custom (since+until) wins, else a known
 // preset id, else the default.
 export function parseRange(f?: { range?: string; since?: string; until?: string }): RangeValue {
-  if (f?.since && f?.until) return { type: "custom", since: f.since, until: f.until };
+  if (f?.since && f?.until && validCustomRange(f.since, f.until)) {
+    return { type: "custom", since: f.since, until: f.until };
+  }
   if (f?.range) {
-    const known = [...ROLLING_PRESETS, ...CALENDAR_PRESETS].some((p) => p.id === f.range);
-    if (known) return { type: "preset", id: f.range };
+    const id = LEGACY_HOUR_RANGE_IDS[f.range] ?? f.range;
+    const known = [...ROLLING_PRESETS, ...CALENDAR_PRESETS].some((p) => p.id === id);
+    if (known) return { type: "preset", id };
   }
   return DEFAULT_RANGE;
 }

--- a/apps/web/src/app/projects/[slug]/apps/[app_slug]/setup/page.tsx
+++ b/apps/web/src/app/projects/[slug]/apps/[app_slug]/setup/page.tsx
@@ -26,6 +26,7 @@ export default function ProjectAppSetupPage() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    let cancelled = false;
 
     const metaKey = `apilens_setup_meta_${projectSlug}_${appSlug}`;
     const legacyMetaKey = `apilens_setup_meta_${appSlug}`;
@@ -34,13 +35,53 @@ export default function ProjectAppSetupPage() {
     if (rawMeta) {
       try {
         setMeta(JSON.parse(rawMeta));
+        setLoading(false);
+        return;
       } catch {
         // ignore
       }
     }
 
-    setLoading(false);
-  }, [appSlug]);
+    async function loadSetupMeta() {
+      try {
+        const [appRes, keysRes] = await Promise.all([
+          fetch(`/api/projects/${projectSlug}/apps/${appSlug}`),
+          fetch(`/api/projects/${projectSlug}/api-keys`),
+        ]);
+
+        if (!appRes.ok) {
+          if (!cancelled) router.replace(`/projects/${projectSlug}/apps`);
+          return;
+        }
+
+        const app = await appRes.json();
+        const keysData = keysRes.ok ? await keysRes.json().catch(() => ({})) : {};
+        const keys = Array.isArray(keysData)
+          ? keysData
+          : Array.isArray(keysData.keys)
+            ? keysData.keys
+            : [];
+
+        if (!cancelled) {
+          setMeta({
+            appName: app.name || appSlug,
+            framework: app.framework || "fastapi",
+            apiKeyPrefix: keys.length > 0 ? keys[0].prefix : "apilens_****",
+            projectSlug,
+            createdAt: Date.now(),
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadSetupMeta();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appSlug, projectSlug, router]);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,10 +116,7 @@ export default function ProjectAppSetupPage() {
     );
   }
 
-  if (!meta) {
-    router.push(`/projects/${projectSlug}`);
-    return null;
-  }
+  if (!meta) return null;
 
   return (
     <div className="create-app-container">

--- a/apps/web/src/app/projects/[slug]/consumers/ConsumersContent.tsx
+++ b/apps/web/src/app/projects/[slug]/consumers/ConsumersContent.tsx
@@ -131,8 +131,7 @@ export default function ConsumersContent({ projectSlug }: ConsumersContentProps)
     p.set("filter", serializeFilter(preds));
     // Carry the range when it maps to a Request-logs preset window.
     if (rangeValue.type === "preset") {
-      const hours = ROLLING_PRESETS.find((r) => r.id === rangeValue.id)?.hours;
-      if (hours && hours !== 24 && [1, 6, 168, 720].includes(hours)) p.set("range", String(hours));
+      if (rangeValue.id !== "24h") p.set("range", rangeValue.id);
     }
     router.push(`/projects/${projectSlug}/endpoints?${p.toString()}`);
   };

--- a/apps/web/src/app/projects/[slug]/endpoints/EndpointDetailPane.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/EndpointDetailPane.tsx
@@ -66,6 +66,8 @@ interface RequestRow {
   request_headers?: string;
   response_headers?: string;
   base_url?: string;
+  trace_id?: string;
+  span_id?: string;
 }
 
 type StatTone = "good" | "warn" | "bad";

--- a/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
@@ -89,6 +89,7 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [requestError, setRequestError] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
 
   const [openRow, setOpenRow] = useState<RequestItem | null>(null);
@@ -195,14 +196,31 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
       p.set("page_size", String(PAGE_SIZE));
       try {
         const res = await fetch(`/api/projects/${projectSlug}/data/requests?${p.toString()}`);
-        const data: RequestsResponse = res.ok
-          ? await res.json()
-          : { items: [], total_count: 0, page: 1, page_size: PAGE_SIZE };
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          const message =
+            typeof errorData?.detail === "string"
+              ? errorData.detail
+              : typeof errorData?.error === "string"
+                ? errorData.error
+                : `Request failed with status ${res.status}`;
+          if (cancelled) return;
+          setItems([]);
+          setTotalCount(0);
+          setRequestError(message);
+          return;
+        }
+        const data: RequestsResponse = await res.json();
         if (cancelled) return;
         setItems(data.items || []);
         setTotalCount(data.total_count || 0);
+        setRequestError("");
       } catch {
-        if (!cancelled) { setItems([]); setTotalCount(0); }
+        if (!cancelled) {
+          setItems([]);
+          setTotalCount(0);
+          setRequestError("Unable to load requests. Check your connection and try again.");
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -256,6 +274,8 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
       <section className="ep-rl-card">
         {loading && items.length === 0 ? (
           <div className="ep-rl-message">Loading requests…</div>
+        ) : requestError ? (
+          <div className="ep-rl-message ep-rl-message-error">{requestError}</div>
         ) : items.length === 0 ? (
           <div className="ep-rl-message">No requests match these filters in this period.</div>
         ) : (

--- a/apps/web/src/app/projects/[slug]/endpoints/RequestLogDetailModal.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/RequestLogDetailModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ArrowDownToLine, ArrowUpFromLine, Check, Copy, Fingerprint, Globe, Link2, Server, Terminal, Timer, X } from "lucide-react";
+import { ArrowDownToLine, ArrowUpFromLine, Check, Copy, Fingerprint, GitBranch, Globe, Link2, Server, Terminal, Timer, X } from "lucide-react";
 import {
   formatBytes,
   formatDateTime,
@@ -50,21 +50,6 @@ interface PayloadRow {
   span_id?: string;
 }
 
-// A log line correlated with this request via trace_id (from /data/logs).
-interface LogItem {
-  timestamp: string;
-  app_id: string;
-  environment: string;
-  level: string;
-  message: string;
-  logger_name: string;
-  trace_id?: string;
-  span_id?: string;
-  payload: string;
-  attributes: Record<string, string>;
-}
-
-// A span of the distributed trace this request belongs to (from /data/trace).
 interface SpanItem {
   timestamp: string;
   app_id: string;
@@ -81,15 +66,38 @@ interface SpanItem {
   attributes: Record<string, string>;
 }
 
-type TabKey = "details" | "headers" | "response" | "trace" | "related";
+interface LogItem {
+  timestamp: string;
+  app_id: string;
+  environment: string;
+  level: string;
+  message: string;
+  logger_name: string;
+  endpoint_method: string;
+  endpoint_path: string;
+  status_code: number;
+  consumer_id: string;
+  consumer_name: string;
+  consumer_group: string;
+  trace_id?: string;
+  span_id?: string;
+  payload: string;
+  attributes: Record<string, string>;
+}
 
-const TABS: Array<{ key: TabKey; label: string }> = [
+type TraceState = SpanItem[] | "loading" | "error";
+type LogState = LogItem[] | "loading" | "error";
+
+type TabKey = "details" | "headers" | "response" | "related" | "logs" | "trace";
+
+const BASE_TABS: Array<{ key: TabKey; label: string }> = [
   { key: "details", label: "Details" },
   { key: "headers", label: "Headers" },
   { key: "response", label: "Payload" },
-  { key: "trace", label: "Trace" },
   { key: "related", label: "Related" },
 ];
+const LOGS_TAB: { key: TabKey; label: string } = { key: "logs", label: "Logs" };
+const TRACE_TAB: { key: TabKey; label: string } = { key: "trace", label: "Trace" };
 
 function methodColor(m: string): string {
   const k = m.toUpperCase();
@@ -472,118 +480,184 @@ function Waterfall({ spans }: { spans: SpanItem[] }) {
   );
 }
 
-function TraceTab({
+/* ── Modal ───────────────────────────────────────────────────────────── */
+
+function LogsTab({
   projectSlug,
-  traceId,
-  loadingTrace,
+  row,
   appSlugs,
   environment,
   since,
   until,
 }: {
   projectSlug: string;
-  traceId: string;
-  loadingTrace: boolean;
+  row: RequestItem;
   appSlugs: string[];
   environment?: string;
   since: string;
   until?: string;
 }) {
-  const [spans, setSpans] = useState<SpanItem[] | null>(null);
-  const [logs, setLogs] = useState<LogItem[] | null>(null);
+  const [logs, setLogs] = useState<LogState>("loading");
 
   useEffect(() => {
-    if (!traceId) { setSpans(null); setLogs(null); return; }
     let cancelled = false;
-    setSpans(null);
-    setLogs(null);
+    if (!row.trace_id) {
+      setLogs([]);
+      return () => { cancelled = true; };
+    }
+    setLogs("loading");
     (async () => {
+      const p = new URLSearchParams();
+      p.set("trace_id", row.trace_id || "");
+      p.set("since", since);
+      if (until) p.set("until", until);
+      if (environment) p.set("environment", environment);
+      if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
+      p.set("page_size", "100");
       try {
-        const res = await fetch(`/api/projects/${projectSlug}/data/trace?trace_id=${encodeURIComponent(traceId)}`);
-        const data = res.ok ? await res.json() : { spans: [] };
-        if (!cancelled) setSpans(data.spans || []);
-      } catch { if (!cancelled) setSpans([]); }
-    })();
-    (async () => {
-      try {
-        const p = new URLSearchParams();
-        p.set("trace_id", traceId);
-        p.set("since", since);
-        if (until) p.set("until", until);
-        if (environment) p.set("environment", environment);
-        if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
-        p.set("page_size", "100");
         const res = await fetch(`/api/projects/${projectSlug}/data/logs?${p.toString()}`);
-        const data = res.ok ? await res.json() : { items: [] };
-        if (cancelled) return;
-        const items: LogItem[] = (data.items || []).slice();
-        // The API returns newest-first; a single request's logs read naturally
-        // in chronological order.
-        items.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-        setLogs(items);
-      } catch { if (!cancelled) setLogs([]); }
+        if (!res.ok) {
+          if (!cancelled) setLogs("error");
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) setLogs(data.items || []);
+      } catch {
+        if (!cancelled) setLogs("error");
+      }
     })();
     return () => { cancelled = true; };
-  }, [projectSlug, traceId, appSlugs, environment, since, until]);
+  }, [projectSlug, row.trace_id, appSlugs, environment, since, until]);
 
-  if (!traceId) {
-    return loadingTrace ? (
-      <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-    ) : (
-      <div className="endpoint-detail-empty">
-        No trace id was captured for this request, so its trace can&apos;t be shown.
-        Requests recorded before trace support don&apos;t carry one — upgrade the APILens SDK to enable it.
-      </div>
-    );
+  if (logs === "loading") {
+    return <div className="endpoint-skeleton" style={{ height: 160 }} aria-hidden />;
+  }
+  if (logs === "error") {
+    return <div className="endpoint-detail-empty">Logs could not be loaded.</div>;
+  }
+  if (logs.length === 0) {
+    return <div className="endpoint-detail-empty">No logs captured for this trace.</div>;
   }
 
   return (
-    <>
-      <div className="ep-rl-headblock">
-        <h4 className="ep-rl-subhead">
-          Spans
-          {spans?.length ? <span className="ep-rl-count">{spans.length}</span> : null}
-        </h4>
-        {spans === null ? (
-          <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-        ) : spans.length === 0 ? (
-          <div className="endpoint-detail-empty">
-            No spans recorded for this trace yet. The middleware records the request span automatically;
-            add <code>with apilens.span(&quot;name&quot;)</code> around interesting work to break the time down further.
+    <div className="ep-rl-headblock">
+      <h4 className="ep-rl-subhead">
+        Trace logs
+        <span className="ep-rl-count">{logs.length}</span>
+      </h4>
+      <div className="ep-log-list">
+        {logs.map((log, index) => (
+          <div key={`${log.timestamp}-${index}`} className={`ep-log-row level-${log.level.toLowerCase()}`}>
+            <div className="ep-log-main">
+              <span className="ep-log-level">{log.level}</span>
+              <span className="ep-log-message">{log.message || "Log event"}</span>
+            </div>
+            <div className="ep-log-meta">
+              <span>{formatDateTime(log.timestamp)}</span>
+              {log.logger_name ? <span>{log.logger_name}</span> : null}
+              {log.endpoint_method || log.endpoint_path ? <span>{`${log.endpoint_method} ${log.endpoint_path}`.trim()}</span> : null}
+              {log.status_code ? <span>{log.status_code}</span> : null}
+            </div>
+            {log.payload ? <pre className="ep-log-payload">{formatPayload(log.payload)}</pre> : null}
           </div>
-        ) : (
-          <Waterfall spans={spans} />
-        )}
+        ))}
       </div>
-      <div className="ep-rl-headblock">
-        <h4 className="ep-rl-subhead">
-          Logs in this trace
-          {logs?.length ? <span className="ep-rl-count">{logs.length}</span> : null}
-        </h4>
-        {logs === null ? (
-          <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-        ) : logs.length === 0 ? (
-          <div className="endpoint-detail-empty">
-            No logs correlated with this request. Ship application logs with this trace id to see them here.
-          </div>
-        ) : (
-          <div className="ep-rel-list">
-            {logs.map((l, i) => (
-              <div key={`${l.timestamp}-${i}`} className="ep-log-row">
-                <span className="ep-rel-time">{timeShort(l.timestamp)}</span>
-                <span className={`endpoint-status-pill ${levelTone(l.level)}`}>{(l.level || "INFO").toUpperCase()}</span>
-                {l.logger_name ? <span className="ep-log-logger" title={l.logger_name}>{l.logger_name}</span> : null}
-                <span className="ep-log-msg" title={l.message}>{l.message}</span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </>
+    </div>
   );
 }
 
-/* ── Modal ───────────────────────────────────────────────────────────── */
+function TraceTab({
+  projectSlug,
+  row,
+  appSlugs,
+  environment,
+  since,
+  until,
+}: {
+  projectSlug: string;
+  row: RequestItem;
+  appSlugs: string[];
+  environment?: string;
+  since: string;
+  until?: string;
+}) {
+  const [spans, setSpans] = useState<TraceState>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!row.trace_id) {
+      setSpans([]);
+      return () => { cancelled = true; };
+    }
+    setSpans("loading");
+    (async () => {
+      const p = new URLSearchParams();
+      p.set("trace_id", row.trace_id || "");
+      p.set("since", since);
+      if (until) p.set("until", until);
+      if (environment) p.set("environment", environment);
+      if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
+      p.set("page_size", "200");
+      try {
+        const res = await fetch(`/api/projects/${projectSlug}/data/spans?${p.toString()}`);
+        if (!res.ok) {
+          if (!cancelled) setSpans("error");
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) setSpans(data.items || []);
+      } catch {
+        if (!cancelled) setSpans("error");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectSlug, row.trace_id, appSlugs, environment, since, until]);
+
+  if (spans === "loading") {
+    return <div className="endpoint-skeleton" style={{ height: 160 }} aria-hidden />;
+  }
+  if (spans === "error") {
+    return <div className="endpoint-detail-empty">Trace spans could not be loaded.</div>;
+  }
+  if (spans.length === 0) {
+    return <div className="endpoint-detail-empty">No spans captured for this trace.</div>;
+  }
+
+  return (
+    <div className="ep-rl-headblock">
+      <h4 className="ep-rl-subhead">
+        Trace spans
+        <span className="ep-rl-count">{spans.length}</span>
+      </h4>
+      <div className="ep-trace-list">
+        {spans.map((span, index) => {
+          const isCurrent = !!row.span_id && span.span_id === row.span_id;
+          return (
+            <div key={`${span.span_id}-${index}`} className={`ep-trace-row${isCurrent ? " is-current" : ""}`}>
+              <div className="ep-trace-main">
+                <span className={`endpoint-status-pill ${statusTone(span.status_code || 200)}`}>
+                  {span.status || span.status_code || "OK"}
+                </span>
+                <span className="ep-trace-name">{span.name || "Unnamed span"}</span>
+                {isCurrent ? <span className="ep-trace-current">request span</span> : null}
+              </div>
+              <div className="ep-trace-meta">
+                <span><Server size={12} /> {span.service_name || "unknown service"}</span>
+                <span><GitBranch size={12} /> {span.kind || "span"}</span>
+                <span>{formatMs(span.duration_ms)}</span>
+                <span>{formatDateTime(span.timestamp)}</span>
+              </div>
+              <div className="ep-trace-ids">
+                <span>span {span.span_id}</span>
+                {span.parent_span_id ? <span>parent {span.parent_span_id}</span> : <span>root span</span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 interface Props {
   projectSlug: string;
@@ -610,6 +684,13 @@ export default function RequestLogDetailModal({
   const [payload, setPayload] = useState<PayloadRow | null | "loading">("loading");
   // A related request opened on top of this one (stacked modal).
   const [relatedOpen, setRelatedOpen] = useState<RequestItem | null>(null);
+  const tabs = useMemo(() => (row.trace_id ? [...BASE_TABS, LOGS_TAB, TRACE_TAB] : BASE_TABS), [row.trace_id]);
+
+  useEffect(() => {
+    if ((activeTab === "logs" || activeTab === "trace") && !row.trace_id) {
+      setActiveTab("details");
+    }
+  }, [activeTab, row.trace_id]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -720,7 +801,7 @@ export default function RequestLogDetailModal({
         </div>
 
         <nav className="ep-emodal-tabs" role="tablist">
-          {TABS.map((t) => (
+          {tabs.map((t) => (
             <button
               key={t.key}
               type="button"
@@ -782,6 +863,7 @@ export default function RequestLogDetailModal({
                     }
                   />
                 ) : null}
+                {row.span_id ? <DetailRow label="Span ID" value={<span className="ep-rl-mono">{row.span_id}</span>} /> : null}
                 {row.user_agent ? <DetailRow label="User agent" value={<span className="ep-rl-ua">{row.user_agent}</span>} /> : null}
               </div>
             </>
@@ -809,18 +891,6 @@ export default function RequestLogDetailModal({
             )
           )}
 
-          {activeTab === "trace" && (
-            <TraceTab
-              projectSlug={projectSlug}
-              traceId={traceId}
-              loadingTrace={loadingPayload}
-              appSlugs={appSlugs}
-              environment={environment}
-              since={since}
-              until={until}
-            />
-          )}
-
           {activeTab === "related" && (
             <RelatedTab
               projectSlug={projectSlug}
@@ -830,6 +900,28 @@ export default function RequestLogDetailModal({
               since={since}
               until={until}
               onOpen={setRelatedOpen}
+            />
+          )}
+
+          {activeTab === "logs" && (
+            <LogsTab
+              projectSlug={projectSlug}
+              row={row}
+              appSlugs={appSlugs}
+              environment={environment}
+              since={since}
+              until={until}
+            />
+          )}
+
+          {activeTab === "trace" && (
+            <TraceTab
+              projectSlug={projectSlug}
+              row={row}
+              appSlugs={appSlugs}
+              environment={environment}
+              since={since}
+              until={until}
             />
           )}
         </div>

--- a/apps/web/src/app/projects/[slug]/endpoints/detail/EndpointDetailContent.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/detail/EndpointDetailContent.tsx
@@ -49,6 +49,29 @@ const TIME_RANGES: Array<{ label: string; value: number }> = [
 
 /* ── Page component ──────────────────────────────────────────────────── */
 
+function parseUrlDateParam(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getInitialCustomRange(params: { get(name: string): string | null }): { active: boolean; since: string; until: string } {
+  const rawSince = params.get("custom_since");
+  const rawUntil = params.get("custom_until");
+  const since = parseUrlDateParam(rawSince);
+  if (!since) return { active: false, since: "", until: "" };
+
+  const until = rawUntil ? parseUrlDateParam(rawUntil) : null;
+  if (rawUntil && !until) return { active: false, since: "", until: "" };
+  if (until && since >= until) return { active: false, since: "", until: "" };
+
+  return {
+    active: true,
+    since: since.toISOString(),
+    until: until ? until.toISOString() : "",
+  };
+}
+
 export default function EndpointDetailContent({ projectSlug }: { projectSlug: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -74,12 +97,13 @@ export default function EndpointDetailContent({ projectSlug }: { projectSlug: st
   const [environments, setEnvironments] = useState<string[]>([]);
 
   // Custom range.
-  const [customActive, setCustomActive] = useState<boolean>(() => !!searchParams.get("custom_since"));
-  const [customSince, setCustomSince] = useState<string>(() => searchParams.get("custom_since") || "");
-  const [customUntil, setCustomUntil] = useState<string>(() => searchParams.get("custom_until") || "");
+  const initialCustomRange = getInitialCustomRange(searchParams);
+  const [customActive, setCustomActive] = useState<boolean>(() => initialCustomRange.active);
+  const [customSince, setCustomSince] = useState<string>(() => initialCustomRange.since);
+  const [customUntil, setCustomUntil] = useState<string>(() => initialCustomRange.until);
   const [customPanelOpen, setCustomPanelOpen] = useState(false);
-  const [customSinceDraft, setCustomSinceDraft] = useState<string>(() => searchParams.get("custom_since") || "");
-  const [customUntilDraft, setCustomUntilDraft] = useState<string>(() => searchParams.get("custom_until") || "");
+  const [customSinceDraft, setCustomSinceDraft] = useState<string>(() => initialCustomRange.since);
+  const [customUntilDraft, setCustomUntilDraft] = useState<string>(() => initialCustomRange.until);
   const [customRangeError, setCustomRangeError] = useState("");
   const customPopoverRef = useRef<HTMLDivElement | null>(null);
 

--- a/apps/web/src/app/projects/[slug]/endpoints/detail/sections.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/detail/sections.tsx
@@ -94,6 +94,8 @@ export interface RequestRow {
   response_payload?: string;
   request_headers?: string;
   response_headers?: string;
+  trace_id?: string;
+  span_id?: string;
 }
 
 export interface HistogramBucket {

--- a/apps/web/src/app/projects/[slug]/new-app/CreateProjectAppForm.tsx
+++ b/apps/web/src/app/projects/[slug]/new-app/CreateProjectAppForm.tsx
@@ -131,8 +131,13 @@ export default function CreateProjectAppForm({ projectSlug }: CreateProjectAppFo
 
       // Get the project's API key (should always exist since it's auto-created with project)
       const keysRes = await fetch(`/api/projects/${projectSlug}/api-keys`);
-      const keys = await keysRes.json();
-      const apiKeyPrefix = keys && keys.length > 0 ? keys[0].prefix : "apilens_****";
+      const keysData = await keysRes.json().catch(() => ({}));
+      const keys = Array.isArray(keysData)
+        ? keysData
+        : Array.isArray(keysData.keys)
+          ? keysData.keys
+          : [];
+      const apiKeyPrefix = keys.length > 0 ? keys[0].prefix : "apilens_****";
 
       // Store setup metadata for the setup page
       if (typeof window !== "undefined") {

--- a/apps/web/src/app/projects/[slug]/synthetic/SyntheticDataContent.tsx
+++ b/apps/web/src/app/projects/[slug]/synthetic/SyntheticDataContent.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  CheckCircle2,
+  DatabaseZap,
+  Loader2,
+  Play,
+  RefreshCw,
+  Settings2,
+  TriangleAlert,
+} from "lucide-react";
+
+type Scenario = {
+  key: string;
+  name: string;
+  industry: string;
+  description: string;
+  product_signal: string;
+  apps: number;
+  endpoints: number;
+  consumers: number;
+};
+
+type IngestResult = {
+  requests: number;
+  logs: number;
+  spans: number;
+  written_requests: number;
+  written_logs: number;
+  written_spans: number;
+  scenarios: string[];
+  apps: string[];
+  seed: number;
+  accelerator_backend: string;
+  used_gpu: boolean;
+  generated_at: string;
+  mode: string;
+};
+
+interface SyntheticDataContentProps {
+  projectSlug: string;
+}
+
+const COUNT_PRESETS = [1000, 5000, 25000];
+
+export default function SyntheticDataContent({ projectSlug }: SyntheticDataContentProps) {
+  const [scenarios, setScenarios] = useState<Scenario[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [count, setCount] = useState(5000);
+  const [days, setDays] = useState(14);
+  const [seed, setSeed] = useState("");
+  const [accelerator, setAccelerator] = useState<"auto" | "cpu" | "gpu">("auto");
+  const [includeLogs, setIncludeLogs] = useState(true);
+  const [includeSpans, setIncludeSpans] = useState(true);
+  const [ensureApps, setEnsureApps] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<IngestResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const response = await fetch(`/api/projects/${projectSlug}/synthetic/scenarios`);
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(body.error || "Failed to load scenarios");
+        const items = Array.isArray(body.scenarios) ? body.scenarios : [];
+        if (cancelled) return;
+        setScenarios(items);
+        setSelected((prev) => prev.length ? prev : items.slice(0, 2).map((item: Scenario) => item.key));
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load scenarios");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectSlug]);
+
+  const selectedScenarios = useMemo(
+    () => scenarios.filter((scenario) => selected.includes(scenario.key)),
+    [scenarios, selected],
+  );
+
+  const toggleScenario = (key: string) => {
+    setSelected((prev) => (
+      prev.includes(key)
+        ? prev.filter((item) => item !== key)
+        : [...prev, key]
+    ));
+  };
+
+  const runIngest = async () => {
+    if (selected.length === 0 || running) return;
+    setRunning(true);
+    setError("");
+    setResult(null);
+    try {
+      const response = await fetch(`/api/projects/${projectSlug}/synthetic/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scenario_keys: selected,
+          count,
+          days,
+          seed: seed.trim() ? Number(seed) : null,
+          accelerator,
+          include_logs: includeLogs,
+          include_spans: includeSpans,
+          ensure_apps: ensureApps,
+        }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.error || "Synthetic ingest failed");
+      setResult(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Synthetic ingest failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="synthetic-page">
+      <div className="synthetic-header">
+        <div>
+          <h1 className="synthetic-title">Synthetic Data</h1>
+          <p className="synthetic-subtitle">Generate local request, log, consumer, and trace data for this project.</p>
+        </div>
+        <Link href={`/projects/${projectSlug}/traffic`} className="settings-btn">
+          <RefreshCw size={16} />
+          Traffic
+        </Link>
+      </div>
+
+      {error && (
+        <div className="synthetic-alert synthetic-alert-error">
+          <TriangleAlert size={16} />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="synthetic-loading">
+          <Loader2 size={22} className="animate-spin" />
+          <span>Loading scenarios...</span>
+        </div>
+      ) : (
+        <div className="synthetic-layout">
+          <section className="synthetic-main">
+            <div className="synthetic-section-head">
+              <div>
+                <h2>Scenarios</h2>
+                <p>{selected.length} selected</p>
+              </div>
+              <button
+                type="button"
+                className="settings-btn settings-btn-sm"
+                onClick={() => setSelected(scenarios.map((scenario) => scenario.key))}
+              >
+                Select all
+              </button>
+            </div>
+
+            <div className="synthetic-scenario-grid">
+              {scenarios.map((scenario) => {
+                const isSelected = selected.includes(scenario.key);
+                return (
+                  <button
+                    key={scenario.key}
+                    type="button"
+                    className={`synthetic-scenario ${isSelected ? "synthetic-scenario-selected" : ""}`}
+                    onClick={() => toggleScenario(scenario.key)}
+                  >
+                    <span className="synthetic-scenario-top">
+                      <span className="synthetic-scenario-name">{scenario.name}</span>
+                      <span className="synthetic-check">
+                        {isSelected && <CheckCircle2 size={16} />}
+                      </span>
+                    </span>
+                    <span className="synthetic-scenario-industry">{scenario.industry}</span>
+                    <span className="synthetic-scenario-meta">
+                      {scenario.apps} apps / {scenario.endpoints} endpoints / {scenario.consumers} consumers
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <aside className="synthetic-panel">
+            <div className="synthetic-panel-title">
+              <Settings2 size={16} />
+              Run
+            </div>
+
+            <label className="synthetic-field">
+              <span>Events</span>
+              <input
+                type="number"
+                min={1}
+                max={50000}
+                value={count}
+                onChange={(event) => setCount(Math.max(1, Math.min(50000, Number(event.target.value) || 1)))}
+              />
+            </label>
+
+            <div className="synthetic-presets">
+              {COUNT_PRESETS.map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={count === value ? "synthetic-preset synthetic-preset-active" : "synthetic-preset"}
+                  onClick={() => setCount(value)}
+                >
+                  {value.toLocaleString()}
+                </button>
+              ))}
+            </div>
+
+            <label className="synthetic-field">
+              <span>Days</span>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={days}
+                onChange={(event) => setDays(Math.max(1, Math.min(365, Number(event.target.value) || 1)))}
+              />
+            </label>
+
+            <label className="synthetic-field">
+              <span>Accelerator</span>
+              <select value={accelerator} onChange={(event) => setAccelerator(event.target.value as "auto" | "cpu" | "gpu")}>
+                <option value="auto">Auto</option>
+                <option value="cpu">CPU</option>
+                <option value="gpu">GPU</option>
+              </select>
+            </label>
+
+            <label className="synthetic-field">
+              <span>Seed</span>
+              <input
+                type="number"
+                value={seed}
+                placeholder="Rotating"
+                onChange={(event) => setSeed(event.target.value)}
+              />
+            </label>
+
+            <label className="synthetic-toggle">
+              <input type="checkbox" checked={ensureApps} onChange={(event) => setEnsureApps(event.target.checked)} />
+              <span>Create scenario apps</span>
+            </label>
+            <label className="synthetic-toggle">
+              <input type="checkbox" checked={includeLogs} onChange={(event) => setIncludeLogs(event.target.checked)} />
+              <span>Logs</span>
+            </label>
+            <label className="synthetic-toggle">
+              <input type="checkbox" checked={includeSpans} onChange={(event) => setIncludeSpans(event.target.checked)} />
+              <span>Traces</span>
+            </label>
+
+            <button
+              type="button"
+              className="settings-btn settings-btn-primary synthetic-run"
+              disabled={running || selected.length === 0}
+              onClick={runIngest}
+            >
+              {running ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
+              {running ? "Generating..." : "Generate data"}
+            </button>
+          </aside>
+        </div>
+      )}
+
+      {result && (
+        <section className="synthetic-result">
+          <div className="synthetic-result-head">
+            <DatabaseZap size={18} />
+            <div>
+              <h2>Data written</h2>
+              <p>{result.mode} / {result.accelerator_backend} / seed {result.seed}</p>
+            </div>
+          </div>
+          <div className="synthetic-result-grid">
+            <div><span>{result.written_requests.toLocaleString()}</span><label>Requests</label></div>
+            <div><span>{result.written_logs.toLocaleString()}</span><label>Logs</label></div>
+            <div><span>{result.written_spans.toLocaleString()}</span><label>Spans</label></div>
+            <div><span>{result.apps.length.toLocaleString()}</span><label>Apps</label></div>
+          </div>
+          <div className="synthetic-result-actions">
+            <Link href={`/projects/${projectSlug}/traffic`} className="settings-btn settings-btn-primary">Open Traffic</Link>
+            <Link href={`/projects/${projectSlug}/endpoints`} className="settings-btn">Open Request logs</Link>
+            <Link href={`/projects/${projectSlug}/consumers`} className="settings-btn">Open Consumers</Link>
+          </div>
+        </section>
+      )}
+
+      {!loading && selectedScenarios.length > 0 && (
+        <div className="synthetic-selection">
+          <span>Selected</span>
+          <strong>{selectedScenarios.map((scenario) => scenario.name).join(", ")}</strong>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/projects/[slug]/synthetic/page.tsx
+++ b/apps/web/src/app/projects/[slug]/synthetic/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import SyntheticDataContent from "./SyntheticDataContent";
+
+export const metadata = {
+  title: "Synthetic Data | APILens",
+};
+
+export default async function ProjectSyntheticDataPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  const { slug } = await params;
+  return <SyntheticDataContent projectSlug={slug} />;
+}

--- a/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
+++ b/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
@@ -729,6 +729,10 @@ function AppFilter({
         : `${selected.length} apps`;
 
   const toggle = (slug: string) => {
+    if (allSelected) {
+      onChange([slug]);
+      return;
+    }
     if (selected.includes(slug)) onChange(selected.filter((s) => s !== slug));
     else onChange([...selected, slug]);
   };

--- a/apps/web/src/components/dashboard/Sidebar.tsx
+++ b/apps/web/src/components/dashboard/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ScrollText,
   TrendingUp,
   Activity,
+  DatabaseZap,
   Users,
   Settings,
   Bell,
@@ -84,6 +85,7 @@ export default function Sidebar() {
       { name: "Traffic", href: `/projects/${projectSlug}/traffic`, icon: Activity },
       { name: "Request logs", href: `/projects/${projectSlug}/endpoints`, icon: TrendingUp },
       { name: "Consumers", href: `/projects/${projectSlug}/consumers`, icon: Users },
+      { name: "Synthetic Data", href: `/projects/${projectSlug}/synthetic`, icon: DatabaseZap },
       { name: "Settings", href: `/projects/${projectSlug}/settings`, icon: Settings },
     ]
     : [

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -134,6 +134,45 @@ export interface ProjectListItem {
   created_at: string;
 }
 
+export interface SyntheticScenario {
+  key: string;
+  name: string;
+  industry: string;
+  description: string;
+  product_signal: string;
+  apps: number;
+  endpoints: number;
+  consumers: number;
+}
+
+export interface SyntheticIngestPayload {
+  scenario_keys: string[];
+  count: number;
+  days: number;
+  seed?: number | null;
+  accelerator: "auto" | "cpu" | "gpu";
+  include_logs: boolean;
+  include_spans: boolean;
+  ensure_apps: boolean;
+  app_slugs?: string[];
+}
+
+export interface SyntheticIngestResult {
+  requests: number;
+  logs: number;
+  spans: number;
+  written_requests: number;
+  written_logs: number;
+  written_spans: number;
+  scenarios: string[];
+  apps: string[];
+  seed: number;
+  accelerator_backend: string;
+  used_gpu: boolean;
+  generated_at: string;
+  mode: string;
+}
+
 export interface AppInfo {
   id: string;
   name: string;
@@ -535,6 +574,20 @@ export const apiClient = {
   async deleteProject(slug: string): Promise<ApiResponse<{ message: string }>> {
     return fetchDjango<{ message: string }>(`/projects/${slug}`, {
       method: "DELETE",
+    });
+  },
+
+  async getSyntheticScenarios(projectSlug: string): Promise<ApiResponse<SyntheticScenario[]>> {
+    return fetchDjango<SyntheticScenario[]>(`/projects/${projectSlug}/synthetic/scenarios`);
+  },
+
+  async ingestSyntheticTelemetry(
+    projectSlug: string,
+    data: SyntheticIngestPayload,
+  ): Promise<ApiResponse<SyntheticIngestResult>> {
+    return fetchDjango<SyntheticIngestResult>(`/projects/${projectSlug}/synthetic/ingest`, {
+      method: "POST",
+      body: JSON.stringify(data),
     });
   },
 

--- a/apps/web/src/lib/proxy.ts
+++ b/apps/web/src/lib/proxy.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { clearSession, getSession, setSession } from "@/lib/session";
 import type { ApiResponse } from "@/lib/api-client";
+
+const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+const AUTH_API_URL = process.env.AUTH_API_URL || `${DJANGO_API_URL}/auth`;
 
 /**
  * Wraps a route handler with session authentication and error handling.
@@ -18,6 +21,127 @@ export async function withAuth(
   } catch (error) {
     console.error("Route error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+type RefreshResult = { accessToken: string; refreshToken: string } | null;
+
+const REFRESH_CACHE_TTL_MS = 15_000;
+const refreshInflight = new Map<string, Promise<RefreshResult>>();
+const refreshRecent = new Map<string, { result: RefreshResult; at: number }>();
+
+async function refreshTokens(refreshToken: string): Promise<RefreshResult> {
+  const cached = refreshRecent.get(refreshToken);
+  if (cached && Date.now() - cached.at < REFRESH_CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  const existing = refreshInflight.get(refreshToken);
+  if (existing) return existing;
+
+  const inflight = (async (): Promise<RefreshResult> => {
+    try {
+      const response = await fetch(`${AUTH_API_URL}/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+        cache: "no-store",
+      });
+
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      const session = await getSession();
+      if (session) {
+        await setSession({
+          ...session,
+          accessToken: data.access_token,
+          refreshToken: data.refresh_token,
+        });
+      }
+
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+      };
+    } catch {
+      return null;
+    }
+  })();
+
+  refreshInflight.set(refreshToken, inflight);
+  try {
+    const result = await inflight;
+    refreshRecent.set(refreshToken, { result, at: Date.now() });
+    if (refreshRecent.size > 50) {
+      const cutoff = Date.now() - REFRESH_CACHE_TTL_MS;
+      for (const [key, val] of refreshRecent) {
+        if (val.at < cutoff) refreshRecent.delete(key);
+      }
+    }
+    return result;
+  } finally {
+    refreshInflight.delete(refreshToken);
+  }
+}
+
+function withBearer(headers: HeadersInit | undefined, accessToken: string): Headers {
+  const nextHeaders = new Headers(headers);
+  if (!nextHeaders.has("Content-Type")) {
+    nextHeaders.set("Content-Type", "application/json");
+  }
+  nextHeaders.set("Authorization", `Bearer ${accessToken}`);
+  return nextHeaders;
+}
+
+export async function fetchWithAuthRefresh(
+  upstream: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const session = await getSession();
+  if (!session) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const response = await fetch(upstream, {
+    ...init,
+    headers: withBearer(init.headers, session.accessToken),
+    cache: init.cache || "no-store",
+  });
+
+  if (response.status !== 401) return response;
+
+  const refreshed = await refreshTokens(session.refreshToken);
+  if (!refreshed) {
+    await clearSession();
+    return Response.json({ error: "Session expired" }, { status: 401 });
+  }
+
+  return fetch(upstream, {
+    ...init,
+    headers: withBearer(init.headers, refreshed.accessToken),
+    cache: init.cache || "no-store",
+  });
+}
+
+async function toNextResponse(response: Response): Promise<NextResponse> {
+  const body = await response.text();
+  return new NextResponse(body, {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") || "application/json",
+    },
+  });
+}
+
+export async function proxyDjangoWithAuth(
+  upstream: string,
+  init: RequestInit = {},
+): Promise<NextResponse> {
+  try {
+    return toNextResponse(await fetchWithAuthRefresh(upstream, init));
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
   }
 }
 


### PR DESCRIPTION
## Summary
- Rebased the combined workflow fixes on current `upstream/main`.
- Keeps the earlier workflow-dead-end fixes already in this PR.
- Adds the 19 verified product workflow bug fixes from the sweep, including stale auth proxy refreshes, project/app validation gaps, synthetic telemetry, trace/log/span visibility, rich filters/time ranges, malformed range handling, and consumer/email validation.
- Folds the Traffic app single-selection filter fix from #144 into this PR.

## Validation
- `node scripts/run-venv.js apps/api python -m py_compile apps/projects/services.py routers/projects/router.py routers/projects/schemas.py`
- `.\.venv\Scripts\python.exe -m py_compile app\ingest.py app\main.py app\schemas.py`
- `node scripts/run-venv.js apps/api python manage.py test` - 18 tests passed
- `pnpm.cmd --filter frontend lint` - 0 errors, 142 warnings
- `pnpm.cmd --filter frontend build` - passed

Supersedes #144.