### PR TITLE
Fix Traffic app filter single selection

### DIFF
--- a/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
+++ b/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
@@ -729,6 +729,10 @@ function AppFilter({
         : `${selected.length} apps`;
 
   const toggle = (slug: string) => {
+    if (allSelected) {
+      onChange([slug]);
+      return;
+    }
     if (selected.includes(slug)) onChange(selected.filter((s) => s !== slug));
     else onChange([...selected, slug]);
   };


### PR DESCRIPTION
## Summary

- Fixes the Traffic app filter single-selection behavior when the filter is currently in the implicit "All apps" state.
- Confirms the high-severity app row routes are available on current `main`: app settings and setup guide routes both resolve and render from the Apps row menu.
- Keeps the PR scoped to the product code fix only; local QA artifacts and unrelated dirty workspace files are not included.

## Current Behavior Fixed Locally

Before this change, clicking an app such as `Live Checkout` while the Traffic app filter showed `All apps` behaved like a deselect operation. The resulting URL could include every other app slug, for example selecting all apps except the one the user clicked.

After this change, clicking an app while `All apps` is active scopes Traffic to that one app:

- Filter button label changes to the selected app name.
- URL query becomes `apps=live-checkout`.
- Other app slugs are not carried into the selected state.

## App Route Verification

The app route issue was verified against the current local workspace server:

- `/projects/codex-uptime-qa/apps/no-data-api/settings/general` loaded successfully and showed `App Details`.
- `/projects/codex-uptime-qa/apps/live-checkout/settings/setup` loaded successfully and showed setup guide identifiers including project slug and app ID.

No route-code change is included in this PR because current `main` already contains the relevant app settings/setup route files.

## Local QA Evidence

Focused Playwright regression was rerun against `http://localhost:3000` using the documented cases in `product-playwright-deep-dive/11_final_reports/qa_test_case_opportunities.md`.

Result:

- 12 documented cases executed.
- 11 passed.
- 1 marked `not_observed`.
- 0 failed.

The `not_observed` case was `Traffic status filter empty state`: the current Traffic screen exposes app, environment, time range, metric tabs, and endpoint search, but does not expose the rich `Add filter` status control required by that documented case.

Validation commands run locally:

- `tsc -p apps/web/tsconfig.json --noEmit`
- `pnpm.cmd --filter frontend lint`
- Focused Playwright regression script against the local dev server

Lint exited `0` with existing warnings. The earlier ESLint circular-structure blocker did not reproduce in this local pass.

## Safety Notes

- No destructive actions were executed during QA.
- API key and account delete workflows were opened only to verify disabled/safeguarded states.
- Unrelated local dirty files were intentionally left out of this PR.
