### PR TITLE
[Dharmik] Add synthetic telemetry generation engine

### DIFF
--- a/apps/api/apps/projects/management/commands/synthetic_telemetry.py
+++ b/apps/api/apps/projects/management/commands/synthetic_telemetry.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.text import slugify
+
+from apps.projects.models import App, Environment, Project
+from apps.projects.synthetic.catalog import expand_scenario_keys, get_scenario, list_scenarios
+from apps.projects.synthetic.generator import AppTarget, SyntheticRunConfig, SyntheticTelemetryEngine
+from apps.projects.synthetic.writers import DirectClickHouseWriter, HttpIngestWriter, JsonlWriter
+
+
+class Command(BaseCommand):
+    help = "Generate rich synthetic APILens request, log, and trace telemetry for demos, QA, and load data."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--list-scenarios", action="store_true", help="Print available scenario keys and exit")
+        parser.add_argument(
+            "--scenario",
+            action="append",
+            default=[],
+            help="Scenario key to generate. Repeat or pass comma-separated values. Defaults to all.",
+        )
+        parser.add_argument("--project-slug", default="", help="Target project slug for direct/http modes")
+        parser.add_argument("--owner-email", default="", help="Owner email used with --ensure-demo-project")
+        parser.add_argument(
+            "--ensure-demo-project",
+            action="store_true",
+            help="Create/update a synthetic project, apps, and environments before generation.",
+        )
+        parser.add_argument("--app-slugs", default="", help="Comma-separated real app slugs to target")
+        parser.add_argument("--count", type=int, default=5000, help="Number of request events to generate")
+        parser.add_argument("--days", type=int, default=14, help="Past time window to cover")
+        parser.add_argument("--seed", type=int, default=None, help="Fixed seed for repeatable output. Omit for hourly rotation.")
+        parser.add_argument(
+            "--accelerator",
+            choices=("auto", "cpu", "gpu"),
+            default="auto",
+            help="Random planner accelerator. auto uses CUDA through CuPy/Torch when available, otherwise CPU.",
+        )
+        parser.add_argument(
+            "--mode",
+            choices=("jsonl", "http", "direct"),
+            default="jsonl",
+            help="Output mode. jsonl is safe; http posts to ingest; direct writes local ClickHouse.",
+        )
+        parser.add_argument("--output-dir", default="", help="JSONL output directory")
+        parser.add_argument("--ingest-url", default="", help="Base ingest URL for --mode http, e.g. http://127.0.0.1:8001")
+        parser.add_argument("--api-key", default="", help="Project API key for --mode http")
+        parser.add_argument("--batch-size", type=int, default=1000, help="Write batch size, capped at 1000")
+        parser.add_argument("--no-logs", action="store_true", help="Do not generate correlated log events")
+        parser.add_argument("--no-spans", action="store_true", help="Do not generate correlated trace spans")
+        parser.add_argument("--dry-run", action="store_true", help="Generate and summarize without writing")
+
+    def handle(self, *args, **options):
+        if options["list_scenarios"]:
+            self._print_scenarios()
+            return
+
+        scenario_keys = self._scenario_keys(options["scenario"])
+        mode = options["mode"]
+        project = None
+        project_slug = (options["project_slug"] or "").strip()
+
+        if options["ensure_demo_project"]:
+            project = self._ensure_demo_project(
+                project_slug=project_slug or "synthetic-apilens-demo",
+                owner_email=(options["owner_email"] or "").strip(),
+                scenario_keys=scenario_keys,
+            )
+            project_slug = project.slug
+        elif project_slug:
+            try:
+                project = Project.objects.get(slug=project_slug, is_active=True)
+            except Project.DoesNotExist as exc:
+                raise CommandError(f"Active project '{project_slug}' was not found") from exc
+
+        if mode in {"http", "direct"} and project is None:
+            raise CommandError("--project-slug or --ensure-demo-project is required for http/direct modes")
+        if mode == "http" and (not options["ingest_url"] or not options["api_key"]):
+            raise CommandError("--ingest-url and --api-key are required for --mode http")
+
+        app_targets = self._resolve_app_targets(
+            project=project,
+            app_slugs=(options["app_slugs"] or "").strip(),
+            scenario_keys=scenario_keys,
+        )
+        if mode in {"http", "direct"} and not app_targets:
+            raise CommandError("No target apps found. Pass --app-slugs or use --ensure-demo-project.")
+
+        config = SyntheticRunConfig(
+            scenario_keys=scenario_keys,
+            count=max(0, int(options["count"])),
+            days=max(1, int(options["days"])),
+            seed=options["seed"],
+            accelerator=options["accelerator"],
+            include_logs=not options["no_logs"],
+            include_spans=not options["no_spans"],
+            project_slug=project_slug,
+            app_targets=app_targets,
+        )
+        result = SyntheticTelemetryEngine(config).generate()
+        self._print_generation_summary(result.summary())
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run complete. No data was written."))
+            return
+
+        if mode == "jsonl":
+            output_dir = options["output_dir"] or self._default_output_dir()
+            summary = JsonlWriter(output_dir).write(result)
+        elif mode == "http":
+            summary = HttpIngestWriter(
+                options["ingest_url"],
+                options["api_key"],
+                batch_size=options["batch_size"],
+            ).write(result)
+        else:
+            summary = DirectClickHouseWriter(batch_size=options["batch_size"]).write(result)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Synthetic telemetry written: "
+                f"mode={summary.mode}, requests={summary.requests}, logs={summary.logs}, spans={summary.spans}"
+            )
+        )
+        if summary.output_dir:
+            self.stdout.write(f"Output directory: {summary.output_dir}")
+        if summary.details:
+            for key, value in summary.details.items():
+                self.stdout.write(f"{key}: {value}")
+
+    def _print_scenarios(self) -> None:
+        self.stdout.write("Available synthetic telemetry scenarios:")
+        for scenario in list_scenarios():
+            self.stdout.write(
+                f"- {scenario.key}: {scenario.name} [{scenario.industry}] "
+                f"apps={len(scenario.apps)} endpoints={len(scenario.endpoints)} consumers={len(scenario.consumers)}"
+            )
+
+    def _scenario_keys(self, values: list[str]) -> tuple[str, ...]:
+        tokens: list[str] = []
+        for raw in values:
+            tokens.extend(part.strip() for part in raw.split(",") if part.strip())
+        try:
+            return expand_scenario_keys(tokens or ("all",))
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+    def _ensure_demo_project(self, *, project_slug: str, owner_email: str, scenario_keys: tuple[str, ...]) -> Project:
+        if not owner_email:
+            raise CommandError("--owner-email is required with --ensure-demo-project")
+        User = get_user_model()
+        user, _created = User.objects.get_or_create(
+            email=owner_email.lower(),
+            defaults={
+                "email_verified": True,
+                "auth_provider": "synthetic",
+                "is_active": True,
+            },
+        )
+        if not user.email_verified:
+            user.email_verified = True
+            user.save(update_fields=["email_verified", "updated_at"])
+
+        slug = slugify(project_slug) or "synthetic-apilens-demo"
+        project, _created = Project.objects.get_or_create(
+            slug=slug,
+            defaults={
+                "owner": user,
+                "name": "Synthetic APILens Demo",
+                "description": "Synthetic telemetry project for APILens demos, QA, and regression data.",
+            },
+        )
+        if not project.is_active:
+            project.is_active = True
+            project.save(update_fields=["is_active", "updated_at"])
+
+        for scenario_key in scenario_keys:
+            scenario = get_scenario(scenario_key)
+            for profile in scenario.apps:
+                app, _created = App.objects.get_or_create(
+                    project=project,
+                    slug=profile.slug,
+                    defaults={
+                        "name": profile.name,
+                        "description": profile.description,
+                        "framework": profile.framework,
+                        "icon": profile.icon[:8],
+                    },
+                )
+                updates = []
+                if app.name != profile.name:
+                    app.name = profile.name
+                    updates.append("name")
+                if app.description != profile.description:
+                    app.description = profile.description
+                    updates.append("description")
+                if app.framework != profile.framework:
+                    app.framework = profile.framework
+                    updates.append("framework")
+                if app.icon != profile.icon[:8]:
+                    app.icon = profile.icon[:8]
+                    updates.append("icon")
+                if not app.is_active:
+                    app.is_active = True
+                    updates.append("is_active")
+                if updates:
+                    app.save(update_fields=updates + ["updated_at"])
+                self._ensure_environments(app, scenario.environments)
+
+        self.stdout.write(self.style.SUCCESS(f"Demo project ready: {project.slug}"))
+        return project
+
+    def _ensure_environments(self, app: App, environments) -> None:
+        colors = {
+            "production": "#16a34a",
+            "staging": "#2563eb",
+            "development": "#9333ea",
+        }
+        for order, env in enumerate(environments):
+            slug = slugify(env.value)
+            Environment.objects.get_or_create(
+                app=app,
+                slug=slug,
+                defaults={
+                    "name": env.value.title(),
+                    "color": colors.get(slug, "#6b7280"),
+                    "order": order,
+                },
+            )
+
+    def _resolve_app_targets(self, *, project: Project | None, app_slugs: str, scenario_keys: tuple[str, ...]) -> tuple[AppTarget, ...]:
+        if project is None:
+            return ()
+        requested = [slug.strip() for slug in app_slugs.split(",") if slug.strip()]
+        queryset = App.objects.filter(project=project, is_active=True)
+        if requested:
+            queryset = queryset.filter(slug__in=requested)
+        else:
+            scenario_app_slugs = {profile.slug for key in scenario_keys for profile in get_scenario(key).apps}
+            queryset = queryset.filter(slug__in=scenario_app_slugs)
+        apps = list(queryset.order_by("slug"))
+        found = {app.slug for app in apps}
+        missing = sorted(set(requested) - found)
+        if missing:
+            raise CommandError(f"Target app slug(s) not found in project '{project.slug}': {', '.join(missing)}")
+        return tuple(
+            AppTarget(
+                slug=app.slug,
+                name=app.name,
+                app_id=str(app.id),
+                project_id=str(project.id),
+                project_slug=project.slug,
+                framework=app.framework,
+            )
+            for app in apps
+        )
+
+    def _default_output_dir(self) -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return str(Path("synthetic-output") / stamp)
+
+    def _print_generation_summary(self, summary: dict) -> None:
+        self.stdout.write(
+            "Generated synthetic telemetry: "
+            f"requests={summary['requests']}, logs={summary['logs']}, spans={summary['spans']}, "
+            f"scenarios={','.join(summary['scenarios'])}, accelerator={summary['accelerator_backend']}, "
+            f"used_gpu={summary['used_gpu']}, seed={summary['seed']}"
+        )

--- a/apps/api/apps/projects/synthetic/__init__.py
+++ b/apps/api/apps/projects/synthetic/__init__.py
@@ -1,0 +1,26 @@
+"""Synthetic telemetry generation for APILens demo, QA, and load data."""
+
+from .accelerators import RandomPlanner
+from .catalog import SCENARIOS, expand_scenario_keys, get_scenario, list_scenarios
+from .generator import (
+    AppTarget,
+    GenerationResult,
+    SyntheticTelemetryEngine,
+    SyntheticRunConfig,
+)
+from .writers import DirectClickHouseWriter, HttpIngestWriter, JsonlWriter
+
+__all__ = [
+    "AppTarget",
+    "DirectClickHouseWriter",
+    "GenerationResult",
+    "HttpIngestWriter",
+    "JsonlWriter",
+    "RandomPlanner",
+    "SCENARIOS",
+    "SyntheticRunConfig",
+    "SyntheticTelemetryEngine",
+    "expand_scenario_keys",
+    "get_scenario",
+    "list_scenarios",
+]

--- a/apps/api/apps/projects/synthetic/accelerators.py
+++ b/apps/api/apps/projects/synthetic/accelerators.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Literal
+
+AcceleratorMode = Literal["auto", "cpu", "gpu"]
+
+
+@dataclass(frozen=True)
+class RandomStreams:
+    backend: str
+    used_gpu: bool
+    seed: int
+    time_roll: list[float]
+    scenario_roll: list[float]
+    app_roll: list[float]
+    endpoint_roll: list[float]
+    consumer_roll: list[float]
+    environment_roll: list[float]
+    status_roll: list[float]
+    latency_roll: list[float]
+    tail_roll: list[float]
+    payload_roll: list[float]
+    log_roll: list[float]
+    span_roll: list[float]
+
+
+class RandomPlanner:
+    """Generate numeric random streams, preferring GPU batch generation when available.
+
+    The telemetry engine is mostly text and JSON synthesis, but high-volume runs
+    still need millions of random numbers for timestamps, weighted choices,
+    statuses, latency, log sampling, and span fan-out. This planner centralizes
+    that work and can move it to CUDA through optional CuPy or Torch installs.
+    """
+
+    STREAM_COUNT = 12
+
+    def __init__(self, mode: AcceleratorMode = "auto") -> None:
+        if mode not in {"auto", "cpu", "gpu"}:
+            raise ValueError("accelerator mode must be one of: auto, cpu, gpu")
+        self.mode = mode
+
+    def plan(self, *, count: int, seed: int) -> RandomStreams:
+        safe_count = max(0, int(count))
+        if safe_count == 0:
+            return self._empty(seed, "cpu-random", used_gpu=False)
+
+        if self.mode in {"auto", "gpu"}:
+            for maker in (self._cupy_plan, self._torch_plan):
+                try:
+                    streams = maker(safe_count, seed)
+                except Exception:
+                    streams = None
+                if streams is not None:
+                    return streams
+            if self.mode == "gpu":
+                raise RuntimeError("GPU accelerator requested, but neither CuPy nor Torch CUDA is available")
+
+        return self._cpu_plan(safe_count, seed)
+
+    def _empty(self, seed: int, backend: str, *, used_gpu: bool) -> RandomStreams:
+        return RandomStreams(
+            backend=backend,
+            used_gpu=used_gpu,
+            seed=seed,
+            time_roll=[],
+            scenario_roll=[],
+            app_roll=[],
+            endpoint_roll=[],
+            consumer_roll=[],
+            environment_roll=[],
+            status_roll=[],
+            latency_roll=[],
+            tail_roll=[],
+            payload_roll=[],
+            log_roll=[],
+            span_roll=[],
+        )
+
+    def _from_matrix(self, *, matrix: list[list[float]], seed: int, backend: str, used_gpu: bool) -> RandomStreams:
+        return RandomStreams(
+            backend=backend,
+            used_gpu=used_gpu,
+            seed=seed,
+            time_roll=matrix[0],
+            scenario_roll=matrix[1],
+            app_roll=matrix[2],
+            endpoint_roll=matrix[3],
+            consumer_roll=matrix[4],
+            environment_roll=matrix[5],
+            status_roll=matrix[6],
+            latency_roll=matrix[7],
+            tail_roll=matrix[8],
+            payload_roll=matrix[9],
+            log_roll=matrix[10],
+            span_roll=matrix[11],
+        )
+
+    def _cpu_plan(self, count: int, seed: int) -> RandomStreams:
+        rng = random.Random(seed)
+        matrix = [[rng.random() for _ in range(count)] for _ in range(self.STREAM_COUNT)]
+        return self._from_matrix(matrix=matrix, seed=seed, backend="cpu-random", used_gpu=False)
+
+    def _cupy_plan(self, count: int, seed: int) -> RandomStreams | None:
+        import cupy  # type: ignore[import-not-found]
+
+        device_count = int(cupy.cuda.runtime.getDeviceCount())
+        if device_count <= 0:
+            return None
+        rng = cupy.random.default_rng(seed)
+        values = rng.random((self.STREAM_COUNT, count), dtype=cupy.float32)
+        matrix = values.get().tolist()
+        return self._from_matrix(matrix=matrix, seed=seed, backend="cupy-cuda", used_gpu=True)
+
+    def _torch_plan(self, count: int, seed: int) -> RandomStreams | None:
+        import torch  # type: ignore[import-not-found]
+
+        if not torch.cuda.is_available():
+            return None
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(seed)
+        values = torch.rand((self.STREAM_COUNT, count), generator=generator, device="cuda")
+        matrix = values.cpu().tolist()
+        return self._from_matrix(matrix=matrix, seed=seed, backend="torch-cuda", used_gpu=True)

--- a/apps/api/apps/projects/synthetic/catalog.py
+++ b/apps/api/apps/projects/synthetic/catalog.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class WeightedValue:
+    value: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class LatencyProfile:
+    base_ms: float
+    jitter_ms: float
+    tail_ms: float
+    error_multiplier: float = 1.8
+
+
+@dataclass(frozen=True)
+class EndpointTemplate:
+    method: str
+    path: str
+    description: str
+    weight: float
+    status_weights: tuple[tuple[int, float], ...]
+    latency: LatencyProfile
+    payload_kind: str
+    service_name: str
+
+
+@dataclass(frozen=True)
+class ConsumerSegment:
+    key: str
+    name: str
+    group: str
+    weight: float
+    user_agents: tuple[str, ...]
+    base_error_rate: float = 0.0
+    latency_multiplier: float = 1.0
+
+
+@dataclass(frozen=True)
+class AppProfile:
+    slug: str
+    name: str
+    framework: str
+    description: str
+    icon: str
+    weight: float
+    base_urls: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IncidentProfile:
+    key: str
+    description: str
+    path_contains: tuple[str, ...]
+    status_code: int
+    start_ratio: float
+    end_ratio: float
+    extra_error_rate: float
+    latency_multiplier: float
+    environments: tuple[str, ...] = ("production",)
+
+
+@dataclass(frozen=True)
+class ScenarioProfile:
+    key: str
+    name: str
+    industry: str
+    description: str
+    product_signal: str
+    traffic_weight: float
+    apps: tuple[AppProfile, ...]
+    endpoints: tuple[EndpointTemplate, ...]
+    consumers: tuple[ConsumerSegment, ...]
+    environments: tuple[WeightedValue, ...]
+    regions: tuple[WeightedValue, ...]
+    incidents: tuple[IncidentProfile, ...] = ()
+
+
+COMMON_CONSUMERS: tuple[ConsumerSegment, ...] = (
+    ConsumerSegment(
+        key="free_developer",
+        name="Free Developer",
+        group="free",
+        weight=18,
+        user_agents=("curl/8.6", "postman-runtime/7.39", "apilens-js-demo/1.0"),
+        base_error_rate=0.015,
+        latency_multiplier=1.0,
+    ),
+    ConsumerSegment(
+        key="pro_team",
+        name="Pro Team",
+        group="pro",
+        weight=24,
+        user_agents=("api-client-node/3.4", "python-requests/2.32", "go-http-client/1.1"),
+        base_error_rate=0.008,
+        latency_multiplier=0.96,
+    ),
+    ConsumerSegment(
+        key="enterprise",
+        name="Enterprise Account",
+        group="enterprise",
+        weight=20,
+        user_agents=("enterprise-gateway/5.8", "java-sdk/4.2", "apilens-enterprise-proxy/2.1"),
+        base_error_rate=0.004,
+        latency_multiplier=0.9,
+    ),
+    ConsumerSegment(
+        key="partner_integration",
+        name="Partner Integration",
+        group="partner",
+        weight=14,
+        user_agents=("partner-sync/6.2", "zapier-hook/1.0", "workato-connector/3.7"),
+        base_error_rate=0.012,
+        latency_multiplier=1.08,
+    ),
+    ConsumerSegment(
+        key="internal_service",
+        name="Internal Service",
+        group="internal",
+        weight=12,
+        user_agents=("billing-worker/2.3", "backoffice-job/1.9", "internal-dashboard/0.12"),
+        base_error_rate=0.006,
+        latency_multiplier=0.86,
+    ),
+    ConsumerSegment(
+        key="trial_tenant",
+        name="Trial Tenant",
+        group="trial",
+        weight=8,
+        user_agents=("sandbox-client/0.9", "api-explorer/1.4", "insomnia/9.2"),
+        base_error_rate=0.024,
+        latency_multiplier=1.14,
+    ),
+    ConsumerSegment(
+        key="automation_bot",
+        name="Automation Bot",
+        group="automation",
+        weight=4,
+        user_agents=("uptime-checker/1.7", "load-verifier/0.8", "synthetic-monitor/2.5"),
+        base_error_rate=0.01,
+        latency_multiplier=0.8,
+    ),
+)
+
+
+COMMON_ENVIRONMENTS: tuple[WeightedValue, ...] = (
+    WeightedValue("production", 72),
+    WeightedValue("staging", 18),
+    WeightedValue("development", 10),
+)
+
+
+COMMON_REGIONS: tuple[WeightedValue, ...] = (
+    WeightedValue("us-east-1", 30),
+    WeightedValue("us-west-2", 18),
+    WeightedValue("eu-west-1", 20),
+    WeightedValue("ap-south-1", 18),
+    WeightedValue("ap-southeast-1", 14),
+)
+
+
+def _statuses(*items: tuple[int, float]) -> tuple[tuple[int, float], ...]:
+    return tuple(items)
+
+
+def _endpoint(
+    method: str,
+    path: str,
+    description: str,
+    weight: float,
+    statuses: tuple[tuple[int, float], ...],
+    base: float,
+    jitter: float,
+    tail: float,
+    payload: str,
+    service: str,
+) -> EndpointTemplate:
+    return EndpointTemplate(
+        method=method,
+        path=path,
+        description=description,
+        weight=weight,
+        status_weights=statuses,
+        latency=LatencyProfile(base, jitter, tail),
+        payload_kind=payload,
+        service_name=service,
+    )
+
+
+SCENARIOS: dict[str, ScenarioProfile] = {
+    "api_product_growth": ScenarioProfile(
+        key="api_product_growth",
+        name="API Product Growth",
+        industry="API product / developer platform",
+        description="Developer-facing API usage with plans, quotas, SDKs, onboarding, and customer adoption analysis.",
+        product_signal=(
+            "Inspired by competitor-visible product analytics patterns such as API usage, customer segments, "
+            "quotas, billing, and developer experience."
+        ),
+        traffic_weight=12,
+        apps=(
+            AppProfile(
+                slug="developer-platform",
+                name="Developer Platform API",
+                framework="fastapi",
+                description="Public API for developers, API keys, plans, and usage dashboards.",
+                icon="API",
+                weight=70,
+                base_urls=("https://api.dev-platform.example", "https://sandbox.dev-platform.example"),
+            ),
+            AppProfile(
+                slug="billing-metering",
+                name="Billing Metering API",
+                framework="django",
+                description="Usage metering, quota checks, invoices, and prepaid credit ledgers.",
+                icon="$",
+                weight=30,
+                base_urls=("https://billing.dev-platform.example",),
+            ),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/apps", "List registered applications.", 9, _statuses((200, 95), (401, 2), (500, 3)), 42, 58, 260, "app", "platform-api"),
+            _endpoint("POST", "/v1/api-keys", "Create scoped API keys.", 4, _statuses((201, 82), (400, 6), (409, 5), (429, 3), (500, 4)), 84, 92, 420, "api_key", "platform-api"),
+            _endpoint("GET", "/v1/usage", "Fetch usage metrics by consumer.", 13, _statuses((200, 92), (400, 4), (429, 2), (503, 2)), 118, 160, 780, "usage", "analytics-api"),
+            _endpoint("POST", "/v1/events", "Ingest product events.", 18, _statuses((202, 94), (400, 3), (413, 1), (503, 2)), 48, 82, 360, "event", "events-api"),
+            _endpoint("GET", "/v1/plans/{plan_id}", "Read a pricing plan.", 5, _statuses((200, 91), (404, 6), (500, 3)), 34, 38, 180, "plan", "billing-api"),
+            _endpoint("POST", "/v1/quotas/check", "Check quota and entitlement.", 16, _statuses((200, 90), (402, 2), (403, 2), (429, 4), (503, 2)), 52, 70, 330, "quota", "billing-api"),
+            _endpoint("POST", "/v1/webhooks/test", "Send a webhook test event.", 4, _statuses((202, 84), (400, 5), (422, 5), (502, 4), (504, 2)), 180, 260, 1400, "webhook", "webhook-worker"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("quota-cache-miss", "Quota cache miss increases latency near the middle of the range.", ("quotas",), 503, 0.42, 0.50, 0.08, 2.6),
+        ),
+    ),
+    "ecommerce_checkout": ScenarioProfile(
+        key="ecommerce_checkout",
+        name="Commerce Checkout",
+        industry="E-commerce / retail",
+        description="Cart, checkout, promotions, fulfillment, and payment API behavior for a retail platform.",
+        product_signal="Captures high-cardinality consumer traffic, conversion-critical latency, and payment failures.",
+        traffic_weight=14,
+        apps=(
+            AppProfile("storefront-api", "Storefront API", "express", "Customer-facing catalog, cart, and checkout API.", "CRT", 60, ("https://api.shop.example",)),
+            AppProfile("fulfillment-api", "Fulfillment API", "django", "Inventory, shipment, and order lifecycle service.", "BOX", 25, ("https://fulfillment.shop.example",)),
+            AppProfile("payment-edge", "Payment Edge API", "fastapi", "Payment orchestration and fraud checks.", "PAY", 15, ("https://payments.shop.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/products", "Browse catalog products.", 18, _statuses((200, 96), (400, 1), (404, 1), (500, 2)), 46, 70, 300, "catalog", "storefront"),
+            _endpoint("GET", "/v1/products/{product_id}", "Read product detail.", 14, _statuses((200, 92), (404, 6), (500, 2)), 38, 54, 220, "catalog", "storefront"),
+            _endpoint("POST", "/v1/carts", "Create cart.", 7, _statuses((201, 92), (400, 4), (409, 2), (500, 2)), 64, 80, 360, "cart", "cart"),
+            _endpoint("PATCH", "/v1/carts/{cart_id}", "Update cart lines.", 11, _statuses((200, 86), (400, 5), (409, 5), (422, 2), (503, 2)), 78, 110, 520, "cart", "cart"),
+            _endpoint("POST", "/v1/checkout", "Submit checkout.", 10, _statuses((201, 82), (400, 6), (402, 4), (409, 4), (503, 4)), 210, 280, 1650, "checkout", "checkout"),
+            _endpoint("POST", "/v1/payments/authorize", "Authorize a card payment.", 8, _statuses((200, 84), (400, 4), (402, 6), (429, 2), (502, 2), (504, 2)), 260, 340, 2200, "payment", "payments"),
+            _endpoint("GET", "/v1/orders/{order_id}", "Read order status.", 9, _statuses((200, 92), (404, 5), (500, 3)), 58, 90, 380, "order", "orders"),
+            _endpoint("POST", "/v1/webhooks/carrier", "Receive carrier webhook.", 4, _statuses((202, 90), (400, 5), (409, 3), (500, 2)), 82, 100, 460, "shipment", "fulfillment"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("payment-provider-timeout", "External payment provider intermittently times out.", ("payments", "checkout"), 504, 0.64, 0.72, 0.14, 3.2),
+            IncidentProfile("inventory-contention", "Inventory writes return conflicts during a launch window.", ("carts", "checkout"), 409, 0.30, 0.36, 0.10, 1.8),
+        ),
+    ),
+    "fintech_payments": ScenarioProfile(
+        key="fintech_payments",
+        name="Fintech Payments",
+        industry="Financial technology",
+        description="Payment initiation, ledger, KYC, payouts, risk scoring, and webhook workloads.",
+        product_signal="Covers regulated customer segments, high-value endpoints, retries, auth failures, and audit-style traces.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("payment-core", "Payment Core API", "fastapi", "Payment lifecycle and authorization service.", "FIN", 55, ("https://api.payments.example",)),
+            AppProfile("risk-screening", "Risk Screening API", "django", "Fraud, sanctions, and transaction risk scoring.", "RSK", 25, ("https://risk.payments.example",)),
+            AppProfile("ledger-api", "Ledger API", "django", "Immutable ledger and reconciliation API.", "LED", 20, ("https://ledger.payments.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/payments", "Create payment instruction.", 16, _statuses((201, 82), (400, 5), (401, 2), (402, 3), (409, 3), (422, 2), (503, 3)), 180, 240, 1400, "payment", "payments"),
+            _endpoint("GET", "/v1/payments/{payment_id}", "Fetch payment status.", 14, _statuses((200, 91), (404, 5), (429, 2), (500, 2)), 70, 110, 460, "payment", "payments"),
+            _endpoint("POST", "/v1/kyc/verifications", "Start KYC verification.", 5, _statuses((202, 80), (400, 6), (409, 5), (422, 5), (503, 4)), 260, 320, 1800, "kyc", "kyc"),
+            _endpoint("POST", "/v1/risk/score", "Score transaction risk.", 12, _statuses((200, 88), (400, 4), (429, 3), (502, 3), (504, 2)), 190, 260, 1700, "risk", "risk"),
+            _endpoint("GET", "/v1/ledger/entries", "List ledger entries.", 8, _statuses((200, 94), (400, 2), (500, 4)), 132, 180, 900, "ledger", "ledger"),
+            _endpoint("POST", "/v1/payouts", "Create payout.", 6, _statuses((201, 82), (400, 5), (403, 3), (409, 5), (503, 5)), 220, 300, 1600, "payout", "payouts"),
+            _endpoint("POST", "/v1/webhooks/bank-events", "Receive bank event webhook.", 9, _statuses((202, 90), (400, 5), (409, 3), (500, 2)), 86, 130, 520, "webhook", "webhooks"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("risk-provider-degradation", "Risk provider degradation increases 502s and tail latency.", ("risk",), 502, 0.54, 0.62, 0.16, 3.8),
+        ),
+    ),
+    "healthtech_patient": ScenarioProfile(
+        key="healthtech_patient",
+        name="Healthtech Patient Platform",
+        industry="Healthcare technology",
+        description="Patient, appointment, claims, eligibility, and consent APIs using synthetic identifiers only.",
+        product_signal="Models regulated traffic without real personal data by using tokenized test identifiers.",
+        traffic_weight=10,
+        apps=(
+            AppProfile("patient-access", "Patient Access API", "django", "Patient portal and appointment APIs.", "HLT", 55, ("https://patient-api.health.example",)),
+            AppProfile("claims-gateway", "Claims Gateway API", "fastapi", "Eligibility and claims integration layer.", "CLM", 45, ("https://claims.health.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/patients/{patient_token}", "Read synthetic patient summary.", 9, _statuses((200, 90), (401, 2), (403, 2), (404, 4), (500, 2)), 82, 120, 560, "patient", "patient-access"),
+            _endpoint("GET", "/v1/appointments", "List appointments.", 11, _statuses((200, 94), (400, 2), (500, 4)), 76, 100, 420, "appointment", "patient-access"),
+            _endpoint("POST", "/v1/appointments", "Create appointment request.", 6, _statuses((201, 84), (400, 5), (409, 5), (422, 3), (503, 3)), 154, 210, 960, "appointment", "scheduling"),
+            _endpoint("POST", "/v1/eligibility/checks", "Run insurance eligibility check.", 10, _statuses((200, 86), (400, 5), (409, 2), (502, 4), (504, 3)), 310, 380, 2300, "eligibility", "claims"),
+            _endpoint("POST", "/v1/claims", "Submit claim.", 5, _statuses((202, 82), (400, 6), (409, 4), (422, 4), (503, 4)), 260, 340, 1800, "claim", "claims"),
+            _endpoint("PATCH", "/v1/consents/{consent_id}", "Update consent.", 4, _statuses((200, 88), (400, 5), (403, 3), (404, 2), (500, 2)), 92, 130, 540, "consent", "consent"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("eligibility-clearinghouse-lag", "Eligibility clearinghouse lag causes timeouts.", ("eligibility",), 504, 0.18, 0.24, 0.18, 4.0),
+        ),
+    ),
+    "logistics_fleet": ScenarioProfile(
+        key="logistics_fleet",
+        name="Logistics Fleet",
+        industry="Logistics / supply chain",
+        description="Shipment tracking, fleet telemetry, warehouse scans, and customer delivery APIs.",
+        product_signal="Models high-volume device and partner integrations with bursty geographic activity.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("tracking-api", "Tracking API", "fastapi", "Customer and partner shipment tracking API.", "TRK", 50, ("https://tracking.logistics.example",)),
+            AppProfile("fleet-ingest", "Fleet Ingest API", "starlette", "Vehicle and scanner event ingestion API.", "FLT", 35, ("https://fleet.logistics.example",)),
+            AppProfile("warehouse-api", "Warehouse API", "django", "Inventory, picking, and scan operations.", "WH", 15, ("https://warehouse.logistics.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/shipments/{shipment_id}", "Read shipment detail.", 15, _statuses((200, 92), (404, 5), (429, 1), (500, 2)), 68, 96, 420, "shipment", "tracking"),
+            _endpoint("GET", "/v1/shipments/{shipment_id}/events", "Read tracking events.", 12, _statuses((200, 93), (404, 4), (500, 3)), 92, 130, 620, "shipment", "tracking"),
+            _endpoint("POST", "/v1/fleet/positions", "Ingest vehicle positions.", 19, _statuses((202, 95), (400, 2), (413, 1), (503, 2)), 42, 74, 280, "position", "fleet-ingest"),
+            _endpoint("POST", "/v1/scans", "Ingest warehouse scan.", 14, _statuses((202, 92), (400, 3), (409, 3), (503, 2)), 54, 82, 330, "scan", "warehouse"),
+            _endpoint("PATCH", "/v1/routes/{route_id}", "Update delivery route.", 6, _statuses((200, 84), (400, 5), (409, 7), (500, 4)), 150, 230, 1000, "route", "routing"),
+            _endpoint("POST", "/v1/webhooks/customer-events", "Send customer delivery webhooks.", 5, _statuses((202, 88), (400, 4), (502, 4), (504, 4)), 180, 260, 1400, "webhook", "webhooks"),
+        ),
+        consumers=COMMON_CONSUMERS
+        + (
+            ConsumerSegment("iot_device", "Fleet Device", "iot", 28, ("vehicle-agent/3.2", "handheld-scanner/4.7", "edge-gateway/2.0"), 0.018, 1.18),
+        ),
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("warehouse-scan-duplicates", "Scan duplicates increase conflicts.", ("scans",), 409, 0.76, 0.84, 0.12, 1.5),
+        ),
+    ),
+    "ai_platform": ScenarioProfile(
+        key="ai_platform",
+        name="AI Platform",
+        industry="AI / machine learning infrastructure",
+        description="Model inference, embeddings, vector search, token metering, and prompt safety APIs.",
+        product_signal="Reflects API and AI product monetization patterns such as token counts, traces, quota checks, and heavy payloads.",
+        traffic_weight=12,
+        apps=(
+            AppProfile("inference-api", "Inference API", "fastapi", "LLM and model inference API.", "AI", 55, ("https://inference.ai.example",)),
+            AppProfile("vector-api", "Vector API", "starlette", "Embeddings and vector search API.", "VEC", 25, ("https://vectors.ai.example",)),
+            AppProfile("ai-metering", "AI Metering API", "django", "Token and credit metering service.", "TOK", 20, ("https://metering.ai.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/chat/completions", "Generate chat completion.", 15, _statuses((200, 86), (400, 4), (401, 1), (429, 5), (500, 2), (503, 2)), 620, 900, 5200, "completion", "inference"),
+            _endpoint("POST", "/v1/embeddings", "Generate embedding vectors.", 13, _statuses((200, 90), (400, 4), (413, 2), (429, 2), (503, 2)), 220, 360, 2100, "embedding", "embedding"),
+            _endpoint("POST", "/v1/vector/search", "Search vector index.", 11, _statuses((200, 90), (400, 3), (404, 2), (500, 3), (503, 2)), 150, 240, 1300, "vector_search", "vector"),
+            _endpoint("POST", "/v1/safety/moderations", "Run prompt moderation.", 6, _statuses((200, 91), (400, 3), (429, 3), (503, 3)), 110, 170, 900, "moderation", "safety"),
+            _endpoint("POST", "/v1/tokens/meter", "Record token usage.", 16, _statuses((202, 95), (400, 2), (409, 1), (503, 2)), 45, 64, 240, "token_meter", "metering"),
+            _endpoint("GET", "/v1/models", "List available models.", 7, _statuses((200, 96), (401, 1), (500, 3)), 42, 56, 210, "model", "inference"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("model-capacity-429", "Model capacity pushes quota and rate-limit responses.", ("chat", "embeddings"), 429, 0.58, 0.68, 0.18, 2.4),
+        ),
+    ),
+    "telco_iot": ScenarioProfile(
+        key="telco_iot",
+        name="Telco IoT",
+        industry="Telecommunications / IoT",
+        description="SIM lifecycle, device telemetry, usage counters, and network policy APIs.",
+        product_signal="Models large-scale device traffic and operational dashboards for billions-style API estates.",
+        traffic_weight=10,
+        apps=(
+            AppProfile("device-api", "Device API", "fastapi", "Device registration and lifecycle API.", "SIM", 45, ("https://devices.telco.example",)),
+            AppProfile("usage-api", "Usage API", "django", "Data usage and billing counter API.", "GB", 35, ("https://usage.telco.example",)),
+            AppProfile("network-policy", "Network Policy API", "starlette", "Policy and provisioning API.", "NET", 20, ("https://network.telco.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/devices/register", "Register device.", 8, _statuses((201, 88), (400, 5), (409, 4), (503, 3)), 96, 130, 620, "device", "device"),
+            _endpoint("GET", "/v1/devices/{device_id}", "Read device.", 13, _statuses((200, 92), (404, 5), (500, 3)), 50, 72, 300, "device", "device"),
+            _endpoint("POST", "/v1/telemetry", "Ingest device telemetry.", 22, _statuses((202, 96), (400, 2), (413, 1), (503, 1)), 34, 56, 210, "telemetry", "telemetry"),
+            _endpoint("GET", "/v1/usage/{device_id}", "Read usage counters.", 14, _statuses((200, 92), (404, 4), (429, 2), (500, 2)), 72, 100, 440, "usage", "usage"),
+            _endpoint("PATCH", "/v1/policies/{policy_id}", "Update network policy.", 5, _statuses((200, 85), (400, 5), (403, 3), (409, 4), (503, 3)), 130, 180, 900, "policy", "network-policy"),
+        ),
+        consumers=COMMON_CONSUMERS
+        + (
+            ConsumerSegment("iot_device", "IoT Device", "iot", 42, ("iot-modem/7.2", "edge-router/5.0", "sim-agent/2.4"), 0.02, 1.1),
+        ),
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("telemetry-burst", "Regional device reconnect burst creates ingestion pressure.", ("telemetry",), 503, 0.10, 0.16, 0.10, 2.2),
+        ),
+    ),
+    "internal_saas": ScenarioProfile(
+        key="internal_saas",
+        name="Internal SaaS Operations",
+        industry="B2B SaaS / internal operations",
+        description="Admin, CRM, billing, notifications, support, and audit APIs for internal teams.",
+        product_signal="Creates data for RBAC, support debugging, audit-oriented logs, and operational workflows.",
+        traffic_weight=9,
+        apps=(
+            AppProfile("admin-api", "Admin API", "django", "Tenant administration and settings API.", "ADM", 45, ("https://admin.saas.example",)),
+            AppProfile("notification-api", "Notification API", "fastapi", "Email, SMS, webhook, and in-app notification API.", "NTF", 30, ("https://notify.saas.example",)),
+            AppProfile("support-api", "Support API", "express", "Support workflow and ticket API.", "SUP", 25, ("https://support.saas.example",)),
+        ),
+        endpoints=(
+            _endpoint("GET", "/v1/tenants", "List tenants.", 7, _statuses((200, 95), (401, 2), (500, 3)), 58, 82, 330, "tenant", "admin"),
+            _endpoint("PATCH", "/v1/tenants/{tenant_id}/settings", "Update tenant settings.", 5, _statuses((200, 84), (400, 6), (403, 4), (409, 3), (500, 3)), 110, 160, 760, "settings", "admin"),
+            _endpoint("POST", "/v1/notifications/email", "Send email notification.", 12, _statuses((202, 90), (400, 4), (429, 2), (502, 2), (504, 2)), 150, 230, 1300, "notification", "notifications"),
+            _endpoint("POST", "/v1/notifications/webhook", "Send webhook notification.", 10, _statuses((202, 86), (400, 4), (429, 2), (502, 5), (504, 3)), 180, 260, 1600, "webhook", "notifications"),
+            _endpoint("GET", "/v1/audit/events", "Read audit events.", 9, _statuses((200, 94), (400, 2), (500, 4)), 130, 190, 900, "audit", "audit"),
+            _endpoint("POST", "/v1/support/tickets", "Create support ticket.", 5, _statuses((201, 90), (400, 4), (409, 2), (500, 4)), 96, 120, 520, "ticket", "support"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("webhook-destination-errors", "Webhook destinations return transient 502/504 responses.", ("webhook",), 502, 0.70, 0.80, 0.14, 2.8),
+        ),
+    ),
+    "enterprise_governance": ScenarioProfile(
+        key="enterprise_governance",
+        name="Enterprise Governance",
+        industry="Enterprise API platform",
+        description="API catalog, OpenAPI linting, policy checks, runtime drift, and security review workflows.",
+        product_signal="Aligned to enterprise API governance and runtime security patterns observed in competitor positioning.",
+        traffic_weight=9,
+        apps=(
+            AppProfile("catalog-api", "API Catalog API", "django", "API catalog and spec inventory API.", "CAT", 40, ("https://catalog.enterprise.example",)),
+            AppProfile("governance-api", "Governance API", "fastapi", "Design-time and runtime policy API.", "GOV", 35, ("https://governance.enterprise.example",)),
+            AppProfile("security-api", "Security Review API", "fastapi", "Runtime security findings and audit API.", "SEC", 25, ("https://security.enterprise.example",)),
+        ),
+        endpoints=(
+            _endpoint("POST", "/v1/specs/lint", "Lint OpenAPI spec.", 9, _statuses((200, 86), (400, 5), (422, 6), (500, 3)), 190, 260, 1600, "spec", "governance"),
+            _endpoint("GET", "/v1/apis", "List APIs.", 11, _statuses((200, 95), (401, 2), (500, 3)), 74, 96, 400, "api_catalog", "catalog"),
+            _endpoint("POST", "/v1/apis/{api_id}/reviews", "Start API review.", 5, _statuses((202, 84), (400, 4), (403, 4), (409, 4), (500, 4)), 170, 230, 1100, "review", "governance"),
+            _endpoint("GET", "/v1/security/findings", "List security findings.", 8, _statuses((200, 93), (400, 3), (500, 4)), 140, 190, 900, "finding", "security"),
+            _endpoint("POST", "/v1/runtime/drift", "Record runtime drift.", 12, _statuses((202, 92), (400, 4), (409, 2), (503, 2)), 66, 98, 420, "drift", "runtime"),
+            _endpoint("PATCH", "/v1/policies/{policy_id}", "Update policy.", 4, _statuses((200, 84), (400, 5), (403, 5), (409, 3), (500, 3)), 118, 160, 780, "policy", "governance"),
+        ),
+        consumers=COMMON_CONSUMERS,
+        environments=COMMON_ENVIRONMENTS,
+        regions=COMMON_REGIONS,
+        incidents=(
+            IncidentProfile("spec-linter-overload", "Large spec lint jobs overload linter workers.", ("specs",), 503, 0.34, 0.40, 0.12, 3.1),
+        ),
+    ),
+}
+
+
+def list_scenarios() -> tuple[ScenarioProfile, ...]:
+    return tuple(SCENARIOS.values())
+
+
+def get_scenario(key: str) -> ScenarioProfile:
+    normalized = (key or "").strip().lower()
+    try:
+        return SCENARIOS[normalized]
+    except KeyError as exc:
+        choices = ", ".join(sorted(SCENARIOS))
+        raise ValueError(f"Unknown synthetic scenario '{key}'. Available scenarios: {choices}") from exc
+
+
+def expand_scenario_keys(keys: Iterable[str] | None) -> tuple[str, ...]:
+    requested = [k.strip().lower() for k in (keys or ()) if k and k.strip()]
+    if not requested or "all" in requested:
+        return tuple(SCENARIOS)
+    unknown = [k for k in requested if k not in SCENARIOS]
+    if unknown:
+        choices = ", ".join(sorted(SCENARIOS))
+        raise ValueError(f"Unknown synthetic scenario(s): {', '.join(unknown)}. Available scenarios: {choices}")
+    return tuple(dict.fromkeys(requested))

--- a/apps/api/apps/projects/synthetic/generator.py
+++ b/apps/api/apps/projects/synthetic/generator.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from .accelerators import AcceleratorMode, RandomPlanner, RandomStreams
+from .catalog import (
+    AppProfile,
+    ConsumerSegment,
+    EndpointTemplate,
+    IncidentProfile,
+    ScenarioProfile,
+    WeightedValue,
+    expand_scenario_keys,
+    get_scenario,
+)
+
+
+@dataclass(frozen=True)
+class AppTarget:
+    slug: str
+    name: str = ""
+    app_id: str = ""
+    project_id: str = ""
+    project_slug: str = ""
+    framework: str = ""
+    base_urls: tuple[str, ...] = ()
+
+    @property
+    def ingest_identifier(self) -> str:
+        return self.app_id or self.slug
+
+
+@dataclass(frozen=True)
+class SyntheticRunConfig:
+    scenario_keys: tuple[str, ...] = ("all",)
+    count: int = 5000
+    days: int = 14
+    now: datetime | None = None
+    seed: int | None = None
+    accelerator: AcceleratorMode = "auto"
+    include_logs: bool = True
+    include_spans: bool = True
+    project_slug: str = ""
+    app_targets: tuple[AppTarget, ...] = ()
+
+
+@dataclass(frozen=True)
+class RequestEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    method: str
+    path: str
+    status_code: int
+    response_time_ms: float
+    request_size: int
+    response_size: int
+    ip_address: str
+    user_agent: str
+    consumer_id: str
+    consumer_name: str
+    consumer_group: str
+    request_payload: str
+    response_payload: str
+    request_headers: str
+    response_headers: str
+    base_url: str
+    trace_id: str
+    span_id: str
+    endpoint_service: str = ""
+    endpoint_description: str = ""
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "method": self.method,
+            "path": self.path,
+            "status_code": self.status_code,
+            "response_time_ms": self.response_time_ms,
+            "request_size": self.request_size,
+            "response_size": self.response_size,
+            "ip_address": self.ip_address,
+            "user_agent": self.user_agent,
+            "consumer_id": self.consumer_id,
+            "consumer_name": self.consumer_name,
+            "consumer_group": self.consumer_group,
+            "request_payload": self.request_payload,
+            "response_payload": self.response_payload,
+            "request_headers": self.request_headers,
+            "response_headers": self.response_headers,
+            "base_url": self.base_url,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+        }
+
+
+@dataclass(frozen=True)
+class LogEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    level: str
+    message: str
+    logger_name: str
+    endpoint_method: str
+    endpoint_path: str
+    status_code: int
+    consumer_id: str
+    consumer_name: str
+    consumer_group: str
+    trace_id: str
+    span_id: str
+    payload: str
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "level": self.level,
+            "message": self.message,
+            "logger_name": self.logger_name,
+            "endpoint_method": self.endpoint_method,
+            "endpoint_path": self.endpoint_path,
+            "status_code": self.status_code,
+            "consumer_id": self.consumer_id,
+            "consumer_name": self.consumer_name,
+            "consumer_group": self.consumer_group,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "payload": self.payload,
+            "attributes": dict(self.attributes),
+        }
+
+
+@dataclass(frozen=True)
+class SpanEvent:
+    timestamp: datetime
+    app_id: str
+    app_slug: str
+    project_id: str
+    project_slug: str
+    scenario_key: str
+    environment: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str
+    name: str
+    kind: str
+    service_name: str
+    duration_ms: float
+    status: str
+    status_code: int
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def as_ingest_dict(self) -> dict[str, Any]:
+        return {
+            "project_slug": self.project_slug,
+            "app_id": self.app_id or self.app_slug,
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "name": self.name,
+            "kind": self.kind,
+            "service_name": self.service_name,
+            "duration_ms": self.duration_ms,
+            "status": self.status,
+            "status_code": self.status_code,
+            "attributes": dict(self.attributes),
+        }
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    requests: list[RequestEvent]
+    logs: list[LogEvent]
+    spans: list[SpanEvent]
+    scenarios: tuple[str, ...]
+    accelerator_backend: str
+    used_gpu: bool
+    seed: int
+    generated_at: datetime
+    app_targets: tuple[AppTarget, ...]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "requests": len(self.requests),
+            "logs": len(self.logs),
+            "spans": len(self.spans),
+            "scenarios": list(self.scenarios),
+            "accelerator_backend": self.accelerator_backend,
+            "used_gpu": self.used_gpu,
+            "seed": self.seed,
+            "generated_at": self.generated_at.isoformat(),
+            "apps": [target.slug for target in self.app_targets],
+        }
+
+
+class SyntheticTelemetryEngine:
+    def __init__(self, config: SyntheticRunConfig) -> None:
+        if config.count < 0:
+            raise ValueError("count must be greater than or equal to 0")
+        if config.days <= 0:
+            raise ValueError("days must be greater than 0")
+        self.config = config
+        self.now = _normalize_now(config.now)
+        self.scenario_keys = expand_scenario_keys(config.scenario_keys)
+        self.scenarios = tuple(get_scenario(key) for key in self.scenario_keys)
+        self.seed = config.seed if config.seed is not None else self._rotating_seed()
+        self.rng = random.Random(self.seed)
+
+    def generate(self) -> GenerationResult:
+        planner = RandomPlanner(self.config.accelerator)
+        streams = planner.plan(count=self.config.count, seed=self.seed)
+        requests: list[RequestEvent] = []
+        logs: list[LogEvent] = []
+        spans: list[SpanEvent] = []
+        app_targets_seen: dict[str, AppTarget] = {}
+
+        for idx in range(self.config.count):
+            scenario = _weighted_choice(self.scenarios, streams.scenario_roll[idx], "traffic_weight")
+            endpoint = _weighted_choice(scenario.endpoints, streams.endpoint_roll[idx], "weight")
+            app_profile = _app_profile_for_endpoint(scenario, endpoint, streams.app_roll[idx])
+            app_target = self._resolve_app_target(app_profile, scenario)
+            app_targets_seen[app_target.slug] = app_target
+            consumer = _weighted_choice(scenario.consumers, streams.consumer_roll[idx], "weight")
+            environment = _weighted_choice(scenario.environments, streams.environment_roll[idx], "weight").value
+            timestamp = self._timestamp_for_roll(streams.time_roll[idx], consumer)
+            path = _materialize_path(endpoint.path, self.rng)
+            active_incident = _active_incident(scenario.incidents, endpoint, environment, streams.time_roll[idx])
+            status_code = self._status_for(endpoint, consumer, active_incident, streams.status_roll[idx])
+            latency_ms = self._latency_for(endpoint, consumer, active_incident, status_code, streams.latency_roll[idx], streams.tail_roll[idx])
+            trace_id = _hex_id(self.rng, 32)
+            span_id = _hex_id(self.rng, 16)
+            consumer_id = _consumer_id(scenario.key, consumer, self.rng)
+            base_url = self._base_url(app_target, app_profile)
+            request_payload, response_payload = _payloads(
+                endpoint=endpoint,
+                scenario=scenario,
+                path=path,
+                status_code=status_code,
+                consumer_id=consumer_id,
+                rng=self.rng,
+            )
+            request_size = _request_size(endpoint, request_payload, streams.payload_roll[idx])
+            response_size = _response_size(endpoint, response_payload, status_code, streams.tail_roll[idx])
+            event = RequestEvent(
+                timestamp=timestamp,
+                app_id=app_target.app_id,
+                app_slug=app_target.slug,
+                project_id=app_target.project_id,
+                project_slug=app_target.project_slug or self.config.project_slug,
+                scenario_key=scenario.key,
+                environment=environment,
+                method=endpoint.method,
+                path=path,
+                status_code=status_code,
+                response_time_ms=latency_ms,
+                request_size=request_size,
+                response_size=response_size,
+                ip_address=_ip_address(self.rng),
+                user_agent=self.rng.choice(consumer.user_agents),
+                consumer_id=consumer_id,
+                consumer_name=f"{consumer.name} {consumer_id.rsplit('-', 1)[-1]}",
+                consumer_group=consumer.group,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                request_headers=_headers(trace_id, consumer, scenario, request=True),
+                response_headers=_headers(trace_id, consumer, scenario, request=False),
+                base_url=base_url,
+                trace_id=trace_id,
+                span_id=span_id,
+                endpoint_service=endpoint.service_name,
+                endpoint_description=endpoint.description,
+            )
+            requests.append(event)
+
+            if self.config.include_logs:
+                logs.extend(self._logs_for(event, endpoint, scenario, active_incident, streams.log_roll[idx]))
+
+            if self.config.include_spans:
+                spans.extend(self._spans_for(event, endpoint, scenario, active_incident, streams.span_roll[idx]))
+
+        return GenerationResult(
+            requests=requests,
+            logs=logs,
+            spans=spans,
+            scenarios=self.scenario_keys,
+            accelerator_backend=streams.backend,
+            used_gpu=streams.used_gpu,
+            seed=streams.seed,
+            generated_at=self.now,
+            app_targets=tuple(app_targets_seen.values()),
+        )
+
+    def _rotating_seed(self) -> int:
+        hour_bucket = self.now.strftime("%Y%m%d%H")
+        material = "|".join(
+            [
+                "apilens-synthetic",
+                hour_bucket,
+                ",".join(self.scenario_keys),
+                str(self.config.count),
+                str(self.config.days),
+                self.config.project_slug,
+                ",".join(target.slug for target in self.config.app_targets),
+            ]
+        )
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+        return int(digest[:16], 16)
+
+    def _resolve_app_target(self, app_profile: AppProfile, scenario: ScenarioProfile) -> AppTarget:
+        if self.config.app_targets:
+            by_slug = {target.slug: target for target in self.config.app_targets}
+            if app_profile.slug in by_slug:
+                return by_slug[app_profile.slug]
+            # Allow a caller to provide fewer real apps than the scenario has
+            # app profiles; weighted choice still spreads traffic over supplied
+            # apps deterministically.
+            index = int(self.rng.random() * len(self.config.app_targets))
+            return self.config.app_targets[index]
+        return AppTarget(
+            slug=app_profile.slug,
+            name=app_profile.name,
+            project_slug=self.config.project_slug,
+            framework=app_profile.framework,
+            base_urls=app_profile.base_urls,
+        )
+
+    def _timestamp_for_roll(self, roll: float, consumer: ConsumerSegment) -> datetime:
+        start = self.now - timedelta(days=self.config.days)
+        day = int(min(0.999999, max(0.0, roll)) * self.config.days)
+        if consumer.group in {"iot", "automation"}:
+            seconds = self.rng.randint(0, 86_399)
+        elif consumer.group in {"enterprise", "internal"}:
+            seconds = int(self.rng.triangular(7 * 3600, 20 * 3600, 11 * 3600))
+        else:
+            seconds = int(self.rng.triangular(0, 86_399, 15 * 3600))
+        return start + timedelta(days=day, seconds=max(0, min(seconds, 86_399)))
+
+    def _status_for(
+        self,
+        endpoint: EndpointTemplate,
+        consumer: ConsumerSegment,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> int:
+        if incident and roll < incident.extra_error_rate:
+            return incident.status_code
+        if roll < consumer.base_error_rate:
+            return 429 if consumer.group in {"free", "trial", "iot"} else 400
+        adjusted_roll = min(0.999999, max(0.0, roll - consumer.base_error_rate))
+        return _weighted_status(endpoint.status_weights, adjusted_roll)
+
+    def _latency_for(
+        self,
+        endpoint: EndpointTemplate,
+        consumer: ConsumerSegment,
+        incident: IncidentProfile | None,
+        status_code: int,
+        latency_roll: float,
+        tail_roll: float,
+    ) -> float:
+        profile = endpoint.latency
+        value = profile.base_ms + (profile.jitter_ms * latency_roll)
+        if tail_roll > 0.965:
+            value += profile.tail_ms * ((tail_roll - 0.965) / 0.035)
+        if status_code >= 500:
+            value *= profile.error_multiplier
+        elif status_code >= 400:
+            value *= 1.18
+        value *= consumer.latency_multiplier
+        if incident:
+            value *= incident.latency_multiplier
+        return round(max(1.0, value), 2)
+
+    def _base_url(self, app_target: AppTarget, app_profile: AppProfile) -> str:
+        urls = app_target.base_urls or app_profile.base_urls
+        return self.rng.choice(urls) if urls else ""
+
+    def _logs_for(
+        self,
+        event: RequestEvent,
+        endpoint: EndpointTemplate,
+        scenario: ScenarioProfile,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> list[LogEvent]:
+        should_log = event.status_code >= 500 or (event.status_code >= 400 and roll < 0.72) or roll < 0.10
+        if not should_log:
+            return []
+        if event.status_code >= 500:
+            level = "ERROR"
+            message = f"{endpoint.service_name} returned {event.status_code} for {event.method} {endpoint.path}"
+        elif event.status_code >= 400:
+            level = "WARNING"
+            message = f"{endpoint.service_name} rejected {event.method} {endpoint.path} with {event.status_code}"
+        else:
+            level = "INFO"
+            message = f"{endpoint.service_name} completed {event.method} {endpoint.path}"
+        attrs = {
+            "scenario": scenario.key,
+            "consumer_group": event.consumer_group,
+            "endpoint_template": endpoint.path,
+            "latency_ms": str(event.response_time_ms),
+        }
+        if incident:
+            attrs["incident"] = incident.key
+        return [
+            LogEvent(
+                timestamp=event.timestamp + timedelta(milliseconds=min(event.response_time_ms, 250)),
+                app_id=event.app_id,
+                app_slug=event.app_slug,
+                project_id=event.project_id,
+                project_slug=event.project_slug,
+                scenario_key=event.scenario_key,
+                environment=event.environment,
+                level=level,
+                message=message,
+                logger_name=f"{endpoint.service_name}.request",
+                endpoint_method=event.method,
+                endpoint_path=event.path,
+                status_code=event.status_code,
+                consumer_id=event.consumer_id,
+                consumer_name=event.consumer_name,
+                consumer_group=event.consumer_group,
+                trace_id=event.trace_id,
+                span_id=event.span_id,
+                payload=_json({"path": event.path, "status_code": event.status_code, "base_url": event.base_url}),
+                attributes=attrs,
+            )
+        ]
+
+    def _spans_for(
+        self,
+        event: RequestEvent,
+        endpoint: EndpointTemplate,
+        scenario: ScenarioProfile,
+        incident: IncidentProfile | None,
+        roll: float,
+    ) -> list[SpanEvent]:
+        status = "error" if event.status_code >= 500 else "ok"
+        spans = [
+            SpanEvent(
+                timestamp=event.timestamp,
+                app_id=event.app_id,
+                app_slug=event.app_slug,
+                project_id=event.project_id,
+                project_slug=event.project_slug,
+                scenario_key=event.scenario_key,
+                environment=event.environment,
+                trace_id=event.trace_id,
+                span_id=event.span_id,
+                parent_span_id="",
+                name=f"{event.method} {endpoint.path}",
+                kind="server",
+                service_name=endpoint.service_name,
+                duration_ms=event.response_time_ms,
+                status=status,
+                status_code=event.status_code,
+                attributes={
+                    "http.method": event.method,
+                    "http.route": endpoint.path,
+                    "consumer.group": event.consumer_group,
+                    "scenario": scenario.key,
+                },
+            )
+        ]
+        child_count = 1 + int(roll * 3)
+        remaining = max(event.response_time_ms * 0.74, 1.0)
+        child_names = _child_span_names(endpoint, incident)
+        parent_start_offset = 4.0
+        for child_index in range(child_count):
+            duration = max(1.0, remaining * self.rng.uniform(0.18, 0.42))
+            remaining -= duration * 0.35
+            name, kind = child_names[child_index % len(child_names)]
+            spans.append(
+                SpanEvent(
+                    timestamp=event.timestamp + timedelta(milliseconds=parent_start_offset + child_index * 3),
+                    app_id=event.app_id,
+                    app_slug=event.app_slug,
+                    project_id=event.project_id,
+                    project_slug=event.project_slug,
+                    scenario_key=event.scenario_key,
+                    environment=event.environment,
+                    trace_id=event.trace_id,
+                    span_id=_hex_id(self.rng, 16),
+                    parent_span_id=event.span_id,
+                    name=name,
+                    kind=kind,
+                    service_name=endpoint.service_name,
+                    duration_ms=round(duration, 2),
+                    status=status if child_index == child_count - 1 and event.status_code >= 500 else "ok",
+                    status_code=event.status_code if child_index == child_count - 1 else 0,
+                    attributes={
+                        "endpoint.template": endpoint.path,
+                        "payload.kind": endpoint.payload_kind,
+                        "scenario": scenario.key,
+                    },
+                )
+            )
+        return spans
+
+
+def _normalize_now(now: datetime | None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _weighted_choice(items: Iterable[Any], roll: float, weight_attr: str) -> Any:
+    values = tuple(items)
+    if not values:
+        raise ValueError("weighted choice requires at least one item")
+    total = sum(max(0.0, float(getattr(item, weight_attr))) for item in values)
+    if total <= 0:
+        return values[0]
+    cursor = min(0.999999, max(0.0, roll)) * total
+    running = 0.0
+    for item in values:
+        running += max(0.0, float(getattr(item, weight_attr)))
+        if cursor <= running:
+            return item
+    return values[-1]
+
+
+def _weighted_status(items: tuple[tuple[int, float], ...], roll: float) -> int:
+    total = sum(max(0.0, weight) for _, weight in items)
+    if total <= 0:
+        return 200
+    cursor = min(0.999999, max(0.0, roll)) * total
+    running = 0.0
+    for status, weight in items:
+        running += max(0.0, weight)
+        if cursor <= running:
+            return int(status)
+    return int(items[-1][0])
+
+
+def _app_profile_for_endpoint(scenario: ScenarioProfile, endpoint: EndpointTemplate, roll: float) -> AppProfile:
+    service_tokens = [token for token in endpoint.service_name.lower().replace("_", "-").split("-") if token]
+    candidates: list[AppProfile] = []
+    for profile in scenario.apps:
+        searchable = " ".join([profile.slug, profile.name, profile.description]).lower()
+        if any(token in searchable for token in service_tokens):
+            candidates.append(profile)
+    if candidates:
+        return _weighted_choice(candidates, roll, "weight")
+    return _weighted_choice(scenario.apps, roll, "weight")
+
+
+def _active_incident(
+    incidents: tuple[IncidentProfile, ...],
+    endpoint: EndpointTemplate,
+    environment: str,
+    time_roll: float,
+) -> IncidentProfile | None:
+    for incident in incidents:
+        if environment not in incident.environments:
+            continue
+        if not (incident.start_ratio <= time_roll <= incident.end_ratio):
+            continue
+        if any(fragment in endpoint.path for fragment in incident.path_contains):
+            return incident
+    return None
+
+
+def _materialize_path(path: str, rng: random.Random) -> str:
+    replacements = {
+        "{api_id}": f"api_{rng.randint(1000, 9999)}",
+        "{cart_id}": f"cart_{rng.randint(10000, 99999)}",
+        "{consent_id}": f"consent_{rng.randint(1000, 9999)}",
+        "{device_id}": f"dev_{rng.randint(100000, 999999)}",
+        "{order_id}": f"ord_{rng.randint(100000, 999999)}",
+        "{patient_token}": f"pt_{rng.randint(100000, 999999)}",
+        "{payment_id}": f"pay_{rng.randint(100000, 999999)}",
+        "{plan_id}": f"plan_{rng.choice(['free', 'pro', 'business', 'enterprise'])}",
+        "{policy_id}": f"pol_{rng.randint(1000, 9999)}",
+        "{product_id}": f"sku_{rng.randint(10000, 99999)}",
+        "{route_id}": f"route_{rng.randint(1000, 9999)}",
+        "{shipment_id}": f"ship_{rng.randint(100000, 999999)}",
+        "{tenant_id}": f"tenant_{rng.randint(1000, 9999)}",
+    }
+    output = path
+    for token, value in replacements.items():
+        output = output.replace(token, value)
+    return output
+
+
+def _payloads(
+    *,
+    endpoint: EndpointTemplate,
+    scenario: ScenarioProfile,
+    path: str,
+    status_code: int,
+    consumer_id: str,
+    rng: random.Random,
+) -> tuple[str, str]:
+    request: dict[str, Any] = {
+        "scenario": scenario.key,
+        "consumer_id": consumer_id,
+        "request_id": f"req_{rng.randint(1000000, 9999999)}",
+    }
+    kind = endpoint.payload_kind
+    if endpoint.method == "GET":
+        request = {}
+    elif kind in {"payment", "checkout", "payout"}:
+        request.update({"amount": rng.randint(900, 250000) / 100, "currency": rng.choice(["USD", "EUR", "INR", "GBP"]), "idempotency_key": f"idem_{rng.randint(100000, 999999)}"})
+    elif kind in {"completion", "embedding", "moderation"}:
+        request.update({"model": rng.choice(["apex-mini", "apex-pro", "embed-small"]), "input_tokens": rng.randint(24, 4096), "prompt_ref": f"prompt_{rng.randint(1000, 9999)}"})
+    elif kind in {"telemetry", "position"}:
+        request.update({"device_ref": f"dev_{rng.randint(100000, 999999)}", "sample_count": rng.randint(1, 200), "battery_pct": rng.randint(4, 100)})
+    elif kind in {"patient", "appointment", "claim", "eligibility"}:
+        request.update({"patient_token": f"pt_{rng.randint(100000, 999999)}", "facility_code": f"fac_{rng.randint(100, 999)}", "test_data": True})
+    elif kind in {"webhook", "notification"}:
+        request.update({"destination_ref": f"dest_{rng.randint(1000, 9999)}", "event_type": rng.choice(["created", "updated", "failed", "delivered"])})
+    else:
+        request.update({"entity_ref": f"{kind}_{rng.randint(100000, 999999)}"})
+
+    if status_code >= 400:
+        response = {
+            "ok": False,
+            "error": {
+                "code": _error_code(status_code),
+                "message": "Synthetic error generated for APILens QA data.",
+            },
+            "path": path,
+        }
+    else:
+        response = {
+            "ok": True,
+            "status": status_code,
+            "result_ref": f"{kind}_{rng.randint(1000000, 9999999)}",
+        }
+        if kind in {"completion", "embedding", "token_meter"}:
+            response["usage"] = {"input_tokens": rng.randint(20, 4096), "output_tokens": rng.randint(8, 2048)}
+        if kind in {"usage", "quota"}:
+            response["quota"] = {"used": rng.randint(1, 95), "limit": 100}
+
+    return (_json(request) if request else "", _json(response))
+
+
+def _error_code(status_code: int) -> str:
+    if status_code == 400:
+        return "bad_request"
+    if status_code == 401:
+        return "authentication_required"
+    if status_code == 402:
+        return "payment_required"
+    if status_code == 403:
+        return "permission_denied"
+    if status_code == 404:
+        return "not_found"
+    if status_code == 409:
+        return "conflict"
+    if status_code == 413:
+        return "payload_too_large"
+    if status_code == 422:
+        return "validation_error"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code in {502, 503, 504}:
+        return "upstream_unavailable"
+    return "internal_error"
+
+
+def _request_size(endpoint: EndpointTemplate, payload: str, roll: float) -> int:
+    baseline = 120 + len(payload.encode("utf-8"))
+    multiplier = 1 + (roll * 2.5)
+    if endpoint.payload_kind in {"completion", "embedding", "spec"}:
+        multiplier *= 2.8
+    return int(baseline * multiplier)
+
+
+def _response_size(endpoint: EndpointTemplate, payload: str, status_code: int, roll: float) -> int:
+    baseline = 220 + len(payload.encode("utf-8"))
+    multiplier = 1 + (roll * 4.5)
+    if endpoint.payload_kind in {"catalog", "api_catalog", "audit", "ledger"}:
+        multiplier *= 3.2
+    if status_code >= 400:
+        multiplier *= 0.65
+    return int(baseline * multiplier)
+
+
+def _headers(trace_id: str, consumer: ConsumerSegment, scenario: ScenarioProfile, *, request: bool) -> str:
+    if request:
+        return _json(
+            {
+                "content-type": "application/json",
+                "x-request-source": consumer.group,
+                "x-scenario": scenario.key,
+                "traceparent": f"00-{trace_id}-{trace_id[:16]}-01",
+            }
+        )
+    return _json({"content-type": "application/json", "x-synthetic-data": "true"})
+
+
+def _consumer_id(scenario_key: str, consumer: ConsumerSegment, rng: random.Random) -> str:
+    return f"{scenario_key[:8]}-{consumer.group}-{rng.randint(1000, 9999)}"
+
+
+def _ip_address(rng: random.Random) -> str:
+    block = rng.choice(("192.0.2", "198.51.100", "203.0.113"))
+    return f"{block}.{rng.randint(1, 254)}"
+
+
+def _hex_id(rng: random.Random, length: int) -> str:
+    bits = length * 4
+    return f"{rng.getrandbits(bits):0{length}x}"[-length:]
+
+
+def _child_span_names(endpoint: EndpointTemplate, incident: IncidentProfile | None) -> tuple[tuple[str, str], ...]:
+    names = [
+        (f"{endpoint.service_name}.validate", "internal"),
+        (f"{endpoint.service_name}.db", "db"),
+        (f"{endpoint.service_name}.cache", "internal"),
+    ]
+    if endpoint.payload_kind in {"payment", "risk", "eligibility", "webhook", "notification", "completion", "embedding"}:
+        names.append((f"{endpoint.service_name}.upstream", "client"))
+    if incident:
+        names.append((f"{endpoint.service_name}.{incident.key}", "client"))
+    return tuple(names)
+
+
+def _json(value: dict[str, Any]) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)

--- a/apps/api/apps/projects/synthetic/writers.py
+++ b/apps/api/apps/projects/synthetic/writers.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .generator import GenerationResult, LogEvent, RequestEvent, SpanEvent
+
+REQUEST_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "endpoint_id",
+    "environment",
+    "method",
+    "path",
+    "status_code",
+    "response_time_ms",
+    "request_size",
+    "response_size",
+    "ip_address",
+    "user_agent",
+    "consumer_id",
+    "consumer_name",
+    "consumer_group",
+    "request_payload",
+    "response_payload",
+    "request_headers",
+    "response_headers",
+    "base_url",
+    "trace_id",
+    "span_id",
+]
+
+LOG_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "environment",
+    "level",
+    "message",
+    "logger_name",
+    "endpoint_method",
+    "endpoint_path",
+    "status_code",
+    "consumer_id",
+    "consumer_name",
+    "consumer_group",
+    "trace_id",
+    "span_id",
+    "payload",
+    "attributes_json",
+]
+
+SPAN_COLUMNS = [
+    "timestamp",
+    "app_id",
+    "project_id",
+    "environment",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "name",
+    "kind",
+    "service_name",
+    "duration_ms",
+    "status",
+    "status_code",
+    "attributes_json",
+]
+
+
+@dataclass(frozen=True)
+class WriteSummary:
+    mode: str
+    requests: int = 0
+    logs: int = 0
+    spans: int = 0
+    output_dir: str = ""
+    details: dict[str, Any] | None = None
+
+
+class JsonlWriter:
+    def __init__(self, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        request_path = self.output_dir / "requests.jsonl"
+        log_path = self.output_dir / "logs.jsonl"
+        span_path = self.output_dir / "spans.jsonl"
+        manifest_path = self.output_dir / "manifest.json"
+
+        request_count = _write_jsonl(request_path, (event.as_ingest_dict() for event in result.requests))
+        log_count = _write_jsonl(log_path, (event.as_ingest_dict() for event in result.logs))
+        span_count = _write_jsonl(span_path, (event.as_ingest_dict() for event in result.spans))
+        manifest_path.write_text(json.dumps(result.summary(), indent=2, sort_keys=True), encoding="utf-8")
+
+        return WriteSummary(
+            mode="jsonl",
+            requests=request_count,
+            logs=log_count,
+            spans=span_count,
+            output_dir=str(self.output_dir),
+            details={
+                "requests": str(request_path),
+                "logs": str(log_path),
+                "spans": str(span_path),
+                "manifest": str(manifest_path),
+            },
+        )
+
+
+class HttpIngestWriter:
+    def __init__(self, ingest_url: str, api_key: str, *, batch_size: int = 1000, timeout: float = 30.0) -> None:
+        if not ingest_url:
+            raise ValueError("ingest_url is required for HTTP ingest")
+        if not api_key:
+            raise ValueError("api_key is required for HTTP ingest")
+        self.ingest_url = ingest_url.rstrip("/")
+        self.api_key = api_key
+        self.batch_size = max(1, min(int(batch_size), 1000))
+        self.timeout = timeout
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        import httpx
+
+        headers = {"X-API-Key": self.api_key}
+        accepted_requests = accepted_logs = accepted_spans = 0
+        with httpx.Client(timeout=self.timeout, headers=headers) as client:
+            for batch in _chunks([event.as_ingest_dict() for event in result.requests], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/requests", json={"requests": batch})
+                response.raise_for_status()
+                accepted_requests += int(response.json().get("accepted", 0))
+            for batch in _chunks([event.as_ingest_dict() for event in result.logs], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/logs", json={"logs": batch})
+                response.raise_for_status()
+                accepted_logs += int(response.json().get("accepted", 0))
+            for batch in _chunks([event.as_ingest_dict() for event in result.spans], self.batch_size):
+                response = client.post(f"{self.ingest_url}/v1/traces", json={"spans": batch})
+                response.raise_for_status()
+                accepted_spans += int(response.json().get("accepted", 0))
+
+        return WriteSummary(mode="http", requests=accepted_requests, logs=accepted_logs, spans=accepted_spans)
+
+
+class DirectClickHouseWriter:
+    def __init__(self, *, batch_size: int = 1000) -> None:
+        self.batch_size = max(1, min(int(batch_size), 1000))
+
+    def write(self, result: GenerationResult) -> WriteSummary:
+        from apps.projects.models import App, Endpoint
+        from apps.projects.services import IngestService
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        client = get_clickhouse_client()
+        self._ensure_schema(client, IngestService)
+
+        app_by_slug = {
+            app.slug: app
+            for app in App.objects.filter(slug__in={event.app_slug for event in result.requests}, is_active=True).select_related("project")
+        }
+        missing = sorted({event.app_slug for event in result.requests} - set(app_by_slug))
+        if missing:
+            raise ValueError(f"Cannot direct-write telemetry because app slug(s) were not found: {', '.join(missing)}")
+
+        endpoint_map = self._ensure_endpoints(Endpoint, app_by_slug, result.requests)
+        accepted_requests = accepted_logs = accepted_spans = 0
+
+        for batch in _chunks(result.requests, self.batch_size):
+            rows = [self._request_row(event, app_by_slug, endpoint_map) for event in batch]
+            client.insert("api_requests", rows, columns=REQUEST_COLUMNS)
+            accepted_requests += len(rows)
+
+        for batch in _chunks(result.logs, self.batch_size):
+            rows = [self._log_row(event, app_by_slug) for event in batch]
+            if rows:
+                client.insert("api_logs", rows, columns=LOG_COLUMNS)
+                accepted_logs += len(rows)
+
+        for batch in _chunks(result.spans, self.batch_size):
+            rows = [self._span_row(event, app_by_slug) for event in batch]
+            if rows:
+                client.insert("api_spans", rows, columns=SPAN_COLUMNS)
+                accepted_spans += len(rows)
+
+        return WriteSummary(mode="direct", requests=accepted_requests, logs=accepted_logs, spans=accepted_spans)
+
+    def _ensure_schema(self, client, ingest_service) -> None:
+        ingest_service.ensure_payload_columns(client)
+        ingest_service.ensure_header_columns(client)
+        ingest_service.ensure_consumer_columns(client)
+        ingest_service.ensure_base_url_column(client)
+        ingest_service.ensure_trace_columns(client)
+        ingest_service.ensure_api_logs_table(client)
+        ingest_service.ensure_api_spans_table(client)
+        client.execute("ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))")
+        client.execute("ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))")
+
+    def _ensure_endpoints(self, endpoint_model, app_by_slug: dict[str, Any], requests: list[RequestEvent]) -> dict[tuple[str, str, str], str]:
+        seen: dict[tuple[str, str, str], datetime] = {}
+        for event in requests:
+            key = (event.app_slug, event.method.upper(), event.path)
+            previous = seen.get(key)
+            if previous is None or event.timestamp > previous:
+                seen[key] = event.timestamp
+
+        endpoint_ids: dict[tuple[str, str, str], str] = {}
+        for (app_slug, method, path), last_seen_at in seen.items():
+            endpoint, _created = endpoint_model.objects.update_or_create(
+                app=app_by_slug[app_slug],
+                method=method,
+                path=path,
+                defaults={
+                    "description": "",
+                    "is_active": True,
+                    "last_seen_at": last_seen_at,
+                },
+            )
+            endpoint_ids[(app_slug, method, path)] = str(endpoint.id)
+        return endpoint_ids
+
+    def _request_row(self, event: RequestEvent, app_by_slug: dict[str, Any], endpoint_map: dict[tuple[str, str, str], str]) -> dict[str, Any]:
+        app = app_by_slug[event.app_slug]
+        method = event.method.upper()
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "endpoint_id": endpoint_map.get((event.app_slug, method, event.path), ""),
+            "environment": event.environment,
+            "method": method,
+            "path": event.path,
+            "status_code": event.status_code,
+            "response_time_ms": event.response_time_ms,
+            "request_size": event.request_size,
+            "response_size": event.response_size,
+            "ip_address": event.ip_address,
+            "user_agent": event.user_agent,
+            "consumer_id": event.consumer_id,
+            "consumer_name": event.consumer_name,
+            "consumer_group": event.consumer_group,
+            "request_payload": event.request_payload,
+            "response_payload": event.response_payload,
+            "request_headers": event.request_headers,
+            "response_headers": event.response_headers,
+            "base_url": event.base_url,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+        }
+
+    def _log_row(self, event: LogEvent, app_by_slug: dict[str, Any]) -> dict[str, Any]:
+        app = app_by_slug[event.app_slug]
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "environment": event.environment,
+            "level": event.level,
+            "message": event.message,
+            "logger_name": event.logger_name,
+            "endpoint_method": event.endpoint_method,
+            "endpoint_path": event.endpoint_path,
+            "status_code": event.status_code,
+            "consumer_id": event.consumer_id,
+            "consumer_name": event.consumer_name,
+            "consumer_group": event.consumer_group,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+            "payload": event.payload,
+            "attributes_json": json.dumps(event.attributes, separators=(",", ":"), sort_keys=True),
+        }
+
+    def _span_row(self, event: SpanEvent, app_by_slug: dict[str, Any]) -> dict[str, Any]:
+        app = app_by_slug[event.app_slug]
+        return {
+            "timestamp": event.timestamp,
+            "app_id": str(app.id),
+            "project_id": str(app.project_id),
+            "environment": event.environment,
+            "trace_id": event.trace_id,
+            "span_id": event.span_id,
+            "parent_span_id": event.parent_span_id,
+            "name": event.name,
+            "kind": event.kind,
+            "service_name": event.service_name,
+            "duration_ms": event.duration_ms,
+            "status": event.status,
+            "status_code": event.status_code,
+            "attributes_json": json.dumps(event.attributes, separators=(",", ":"), sort_keys=True),
+        }
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+            count += 1
+    return count
+
+
+def _chunks(items, size: int):
+    for idx in range(0, len(items), size):
+        yield items[idx : idx + size]

--- a/apps/api/tests/test_synthetic_telemetry.py
+++ b/apps/api/tests/test_synthetic_telemetry.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+loaded_apps = sys.modules.get("apps")
+loaded_apps_file = str(getattr(loaded_apps, "__file__", "") or "")
+loaded_apps_paths = [str(path) for path in getattr(loaded_apps, "__path__", [])] if loaded_apps is not None else []
+api_apps_path = str(API_ROOT / "apps")
+if loaded_apps is not None and (
+    (loaded_apps_file and not loaded_apps_file.startswith(str(API_ROOT)))
+    or (loaded_apps_paths and api_apps_path not in loaded_apps_paths)
+):
+    del sys.modules["apps"]
+
+from apps.projects.synthetic.accelerators import RandomPlanner
+from apps.projects.synthetic.catalog import SCENARIOS, expand_scenario_keys
+from apps.projects.synthetic.generator import SyntheticRunConfig, SyntheticTelemetryEngine
+from apps.projects.synthetic.writers import JsonlWriter
+
+
+class SyntheticTelemetryTests(unittest.TestCase):
+    def test_catalog_has_required_scenario_breadth(self) -> None:
+        self.assertGreaterEqual(len(SCENARIOS), 5)
+        for key in (
+            "api_product_growth",
+            "ecommerce_checkout",
+            "fintech_payments",
+            "healthtech_patient",
+            "logistics_fleet",
+            "ai_platform",
+            "telco_iot",
+            "internal_saas",
+            "enterprise_governance",
+        ):
+            self.assertIn(key, SCENARIOS)
+            self.assertGreaterEqual(len(SCENARIOS[key].apps), 1)
+            self.assertGreaterEqual(len(SCENARIOS[key].endpoints), 5)
+            self.assertGreaterEqual(len(SCENARIOS[key].consumers), 5)
+
+    def test_expand_all_scenarios(self) -> None:
+        self.assertEqual(tuple(SCENARIOS), expand_scenario_keys(("all",)))
+
+    def test_fixed_seed_is_repeatable(self) -> None:
+        config = SyntheticRunConfig(
+            scenario_keys=("ai_platform",),
+            count=30,
+            days=3,
+            now=datetime(2026, 7, 3, 10, tzinfo=timezone.utc),
+            seed=4242,
+            accelerator="cpu",
+            project_slug="qa",
+        )
+        first = SyntheticTelemetryEngine(config).generate()
+        second = SyntheticTelemetryEngine(config).generate()
+        self.assertEqual([row.as_ingest_dict() for row in first.requests], [row.as_ingest_dict() for row in second.requests])
+        self.assertEqual([row.as_ingest_dict() for row in first.spans], [row.as_ingest_dict() for row in second.spans])
+
+    def test_default_seed_rotates_by_hour(self) -> None:
+        first = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("fintech_payments",),
+                count=5,
+                now=datetime(2026, 7, 3, 10, tzinfo=timezone.utc),
+                accelerator="cpu",
+            )
+        ).generate()
+        second = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("fintech_payments",),
+                count=5,
+                now=datetime(2026, 7, 3, 11, tzinfo=timezone.utc),
+                accelerator="cpu",
+            )
+        ).generate()
+        self.assertNotEqual(first.seed, second.seed)
+        self.assertNotEqual([row.trace_id for row in first.requests], [row.trace_id for row in second.requests])
+
+    def test_requests_logs_and_spans_are_correlated(self) -> None:
+        result = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("ecommerce_checkout",),
+                count=120,
+                days=7,
+                seed=99,
+                accelerator="cpu",
+                project_slug="qa",
+            )
+        ).generate()
+
+        self.assertEqual(120, len(result.requests))
+        self.assertGreater(len(result.logs), 0)
+        self.assertGreaterEqual(len(result.spans), len(result.requests))
+
+        request_trace_ids = {event.trace_id for event in result.requests}
+        request_server_span_ids = {event.span_id for event in result.requests}
+        server_span_ids = {event.span_id for event in result.spans if event.parent_span_id == ""}
+
+        self.assertTrue({event.trace_id for event in result.logs}.issubset(request_trace_ids))
+        self.assertTrue({event.trace_id for event in result.spans}.issubset(request_trace_ids))
+        self.assertTrue(request_server_span_ids.issubset(server_span_ids))
+
+    def test_cpu_random_planner_reports_cpu_backend(self) -> None:
+        streams = RandomPlanner("cpu").plan(count=3, seed=7)
+        self.assertEqual("cpu-random", streams.backend)
+        self.assertFalse(streams.used_gpu)
+        self.assertEqual(3, len(streams.status_roll))
+
+    def test_jsonl_writer_outputs_manifest_and_rows(self) -> None:
+        result = SyntheticTelemetryEngine(
+            SyntheticRunConfig(
+                scenario_keys=("internal_saas",),
+                count=15,
+                seed=123,
+                accelerator="cpu",
+                project_slug="qa",
+            )
+        ).generate()
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = JsonlWriter(tmp).write(result)
+            self.assertEqual("jsonl", summary.mode)
+            self.assertEqual(15, summary.requests)
+            manifest = json.loads((Path(tmp) / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(15, manifest["requests"])
+            request_lines = (Path(tmp) / "requests.jsonl").read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(15, len(request_lines))
+            first = json.loads(request_lines[0])
+            self.assertIn("trace_id", first)
+            self.assertEqual("qa", first["project_slug"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -46,7 +46,8 @@
             "group": "Ingest",
             "pages": [
               "ingest/ingest-api",
-              "ingest/request-schema"
+              "ingest/request-schema",
+              "ingest/synthetic-telemetry-engine"
             ]
           },
           {

--- a/apps/docs/ingest/synthetic-telemetry-engine.mdx
+++ b/apps/docs/ingest/synthetic-telemetry-engine.mdx
@@ -1,0 +1,141 @@
+---
+title: Synthetic Telemetry Engine
+description: Generate realistic APILens request, log, and trace data for demos, QA, regression, and load exploration.
+---
+
+# Synthetic Telemetry Engine
+
+APILens includes a code-based synthetic telemetry engine for creating realistic request, log, and trace data across multiple industries, user types, and API maturity stages.
+
+The engine is designed for:
+
+- Product demos with rich multi-app data.
+- QA and regression setup without hand-writing rows.
+- Local ClickHouse backfills for dashboards, Traffic, Logs, and Traces.
+- Ingest API testing through the same `/v1/requests`, `/v1/logs`, and `/v1/traces` paths used by SDKs.
+- Rotating datasets that do not look identical every time.
+
+## Research Input
+
+The scenario catalog is based on APILens' current ingest model plus publicly visible competitor positioning:
+
+- Moesif highlights API analytics, logs, monitoring, traces, monetization, quotas, behavioral cohorts, and industries such as AI, healthtech, fintech, logistics, and telco.
+- Treblle highlights runtime API visibility, governance, runtime security, compliance, shadow endpoint detection, consumer fingerprinting, executive dashboards, and enterprise roles.
+- APITally-specific public pages were not reliably available during implementation, so no APITally-only behavior is represented as verified fact.
+
+## Scenarios
+
+Run:
+
+```bash
+python manage.py synthetic_telemetry --list-scenarios
+```
+
+Current scenario keys:
+
+- `api_product_growth`
+- `ecommerce_checkout`
+- `fintech_payments`
+- `healthtech_patient`
+- `logistics_fleet`
+- `ai_platform`
+- `telco_iot`
+- `internal_saas`
+- `enterprise_governance`
+
+Each scenario contains app profiles, endpoint templates, consumer segments, environment weights, region labels, status distributions, latency profiles, and incident windows.
+
+## Safe Data Rules
+
+Generated data uses only synthetic values:
+
+- Domains use `.example`.
+- IPs use documentation-reserved ranges: `192.0.2.0/24`, `198.51.100.0/24`, and `203.0.113.0/24`.
+- Healthtech data uses token-like identifiers such as `pt_123456`; it does not generate names, emails, or real patient data.
+- Request payloads, response payloads, headers, logs, and spans are synthetic.
+
+## Output Modes
+
+### JSONL Mode
+
+JSONL mode is the safest default. It writes `requests.jsonl`, `logs.jsonl`, `spans.jsonl`, and `manifest.json`.
+
+```bash
+python manage.py synthetic_telemetry \
+  --scenario ecommerce_checkout \
+  --count 1000 \
+  --days 7 \
+  --mode jsonl \
+  --output-dir synthetic-output/checkout
+```
+
+### HTTP Ingest Mode
+
+HTTP mode posts to the standalone ingest service and exercises API key auth, app resolution, endpoint discovery, and ClickHouse writes.
+
+```bash
+python manage.py synthetic_telemetry \
+  --ensure-demo-project \
+  --owner-email qa@example.com \
+  --project-slug synthetic-apilens-demo \
+  --scenario api_product_growth,ai_platform \
+  --count 5000 \
+  --mode http \
+  --ingest-url http://127.0.0.1:8001 \
+  --api-key "$APILENS_PROJECT_API_KEY"
+```
+
+### Direct ClickHouse Mode
+
+Direct mode is intended for local/demo environments where the Django app can reach Postgres and ClickHouse.
+
+```bash
+python manage.py synthetic_telemetry \
+  --ensure-demo-project \
+  --owner-email qa@example.com \
+  --project-slug synthetic-apilens-demo \
+  --scenario all \
+  --count 25000 \
+  --days 30 \
+  --mode direct
+```
+
+Direct mode creates or updates endpoint rows in Postgres and writes request, log, and span rows to ClickHouse using the current APILens column layout.
+
+## Rotating and Repeatable Data
+
+If `--seed` is omitted, the engine derives a rotating seed from the current UTC hour, scenario list, count, days, project slug, and app slugs. This keeps repeated demo runs from producing identical data.
+
+For repeatable QA fixtures, pass a fixed seed:
+
+```bash
+python manage.py synthetic_telemetry --scenario fintech_payments --count 500 --seed 4242
+```
+
+## GPU Acceleration
+
+The generator supports:
+
+- `--accelerator auto`
+- `--accelerator cpu`
+- `--accelerator gpu`
+
+`auto` tries CUDA-backed CuPy first, then Torch CUDA, then CPU. GPU acceleration is used for high-volume numeric random streams: timestamps, weighted choices, statuses, latency rolls, log sampling, and span fan-out. Text and JSON payload materialization still runs on CPU.
+
+If `--accelerator gpu` is requested and no supported CUDA backend is installed, the command fails clearly instead of silently falling back.
+
+## Dry Run
+
+Use dry run to verify counts, selected scenarios, accelerator backend, and seed without writing:
+
+```bash
+python manage.py synthetic_telemetry --scenario all --count 10000 --dry-run
+```
+
+## Operational Notes
+
+- Keep `--batch-size` at or below 1000 for ingest compatibility.
+- Prefer JSONL mode when reviewing generated payloads.
+- Prefer HTTP mode when validating API key auth and standalone ingest.
+- Prefer direct mode when you need local dashboards populated quickly.
+- Use `--no-logs` or `--no-spans` when testing request-only screens.


### PR DESCRIPTION
## Summary

Adds a reusable APILens synthetic telemetry engine for generating realistic request, log, and trace data across multiple product scenarios, industries, user types, environments, and incident patterns.

## What Changed

- Added `apps.projects.synthetic` with:
  - scenario catalog for API product growth, e-commerce, fintech, healthtech, logistics, AI platforms, telco/IoT, internal SaaS, and enterprise governance
  - optional GPU-backed random stream planning through CuPy or Torch CUDA, with CPU fallback
  - correlated request/log/span generation with trace IDs, span IDs, payloads, headers, consumers, environments, incidents, status distributions, latency profiles, and safe synthetic identifiers
  - JSONL, HTTP ingest, and direct ClickHouse writers
- Added `manage.py synthetic_telemetry` with:
  - `--list-scenarios`
  - `--scenario`
  - `--ensure-demo-project`
  - `--mode jsonl|http|direct`
  - `--accelerator auto|cpu|gpu`
  - `--seed` for repeatable fixtures and rotating default seeds when omitted
- Added docs under `apps/docs/ingest/synthetic-telemetry-engine.mdx`.
- Added unit tests for catalog breadth, seed behavior, request/log/span correlation, CPU planner behavior, and JSONL output.

## Safety Notes

- Generated domains use `.example`.
- Generated IPs use documentation-reserved ranges.
- Healthtech scenario uses tokenized synthetic identifiers only.
- JSONL mode remains the default safe mode.
- HTTP/direct modes require explicit project/app context.

## Local Validation

- `py -3 -m unittest tests.test_synthetic_telemetry` from `apps/api`
  - Result: `Ran 7 tests ... OK`
- API venv unittest:
  - `& "...apps/api/.venv/Scripts/python.exe" -m unittest tests.test_synthetic_telemetry`
  - Result: `Ran 7 tests ... OK`
- In-memory syntax compile for 7 new Python files
  - Result: `compiled 7 files`
- Django command list mode:
  - `manage.py synthetic_telemetry --list-scenarios`
  - Result: listed 9 scenarios
- Django command dry run:
  - `manage.py synthetic_telemetry --scenario ai_platform --count 25 --seed 101 --accelerator cpu --dry-run`
  - Result: generated 25 requests, 7 logs, 74 spans; no writes
- Accelerator auto dry run:
  - `manage.py synthetic_telemetry --scenario ai_platform --count 10 --seed 303 --accelerator auto --dry-run`
  - Result on this machine: `accelerator=cpu-random`, `used_gpu=False`
- JSONL writer validation:
  - `manage.py synthetic_telemetry --scenario fintech_payments --count 20 --seed 202 --accelerator cpu --mode jsonl --output-dir C:\tmp\apilens-synthetic-jsonl-validation`
  - Result: wrote 20 requests, 1 log, 60 spans, plus manifest

## Notes

- Local pytest was not run because the reused local API virtualenv does not have `pytest` installed. The repo CI installs pytest explicitly before running `pytest tests/`.
- No database writes, HTTP ingest writes, or destructive actions were executed during validation.
