### PR TITLE
fix(ci): repoint API CI and dependabot at apps/api and apps/web

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # Backend Python dependencies (uv/pip)
   - package-ecosystem: "pip"
-    directory: "/backend"
+    directory: "/apps/api"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -26,7 +26,7 @@ updates:
 
   # Frontend npm dependencies
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directory: "/apps/web"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,16 +1,16 @@
-name: Backend CI
+name: API CI
 
 on:
   push:
     branches: [main, develop]
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
+      - 'apps/api/**'
+      - '.github/workflows/api-ci.yml'
   pull_request:
     branches: [main, develop]
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
+      - 'apps/api/**'
+      - '.github/workflows/api-ci.yml'
 
 jobs:
   lint:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: backend
+        working-directory: apps/api
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('backend/pyproject.toml') }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('apps/api/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-uv-
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: backend
+        working-directory: apps/api
 
     steps:
       - name: Checkout code
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('backend/pyproject.toml') }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('apps/api/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-uv-
 
@@ -89,10 +89,10 @@ jobs:
         run: |
           set +e
           pytest tests/ \
-            --cov=api \
             --cov=apps \
             --cov=core \
             --cov=config \
+            --cov=routers \
             --cov-report=xml \
             --cov-report=term \
             --cov-report=html
@@ -112,8 +112,8 @@ jobs:
         with:
           name: coverage-reports
           path: |
-            backend/coverage.xml
-            backend/htmlcov/
+            apps/api/coverage.xml
+            apps/api/htmlcov/
 
       - name: Check coverage threshold
         run: |


### PR DESCRIPTION
## Summary
- `API CI` (previously named `Backend CI`) and `dependabot.yml` still targeted the pre-restructure `backend/`/`frontend/` directories, so the workflow's path filters never matched real changes under `apps/api/**` — CI showed no checks at all on PRs touching the backend (e.g. #142, #143, #147).
- Repointed `working-directory`, path filters, the self-referencing workflow-file path, the `uv` cache key, coverage `--cov` flags/artifact paths, and both dependabot `directory` entries at the current `apps/api` / `apps/web` layout.
- `frontend-ci.yml` was already correctly scoped to `apps/web/**` and needed no changes.

## Why
Reviewers currently can't see any CI signal on backend PRs because the workflow silently never triggers — this just repoints stale paths, no behavior/test-coverage changes.

## Test plan
- [x] Confirmed no other `backend/`/`frontend/` path references remain in `api-ci.yml` or `dependabot.yml`
- [ ] Confirm the `API CI` workflow now runs and reports checks on this PR