### PR TITLE
Consolidate workflow bug fixes and uptime monitoring dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ sidecar-testing/**/db.sqlite3
 
 # Next.js
 .next/
+.codex-run/
 out/
 
 

--- a/apps/api/apps/projects/filters.py
+++ b/apps/api/apps/projects/filters.py
@@ -185,7 +185,10 @@ def _render(pred: Predicate, spec: FieldSpec, key: str, params: dict) -> str:
             lo_key, hi_key = f"{key}_{i}_lo", f"{key}_{i}_hi"
             params[lo_key], params[hi_key] = lo, hi
             ranges.append(f"({col} >= %({lo_key})s AND {col} < %({hi_key})s)")
-        return " OR ".join(ranges)
+        clause = " OR ".join(ranges)
+        if pred.op == "not":
+            return f"NOT ({clause})"
+        return clause
 
     op = pred.op
 

--- a/apps/api/apps/projects/membership.py
+++ b/apps/api/apps/projects/membership.py
@@ -11,6 +11,8 @@ import hashlib
 import secrets
 from datetime import timedelta
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.db import transaction
 from django.utils import timezone
 
@@ -92,6 +94,10 @@ class MembershipService:
         email = (email or "").lower().strip()
         if not email:
             raise ValidationError("Email is required")
+        try:
+            validate_email(email)
+        except DjangoValidationError as exc:
+            raise ValidationError("Enter a valid email address") from exc
         if role not in _ASSIGNABLE:
             raise ValidationError("Invalid role")
         if email == project.owner.email.lower():

--- a/apps/api/apps/projects/services.py
+++ b/apps/api/apps/projects/services.py
@@ -2379,6 +2379,156 @@ class AnalyticsService:
             else:
                 cleaned[key] = value
         return cleaned
+
+    @staticmethod
+    def get_project_uptime(
+        project_id: str,
+        heartbeat_grace_minutes: int = 2,
+        down_after_minutes: int = 15,
+        lookback_days: int = 30,
+    ) -> dict:
+        """
+        Summarize app/environment freshness from the latest ingested request.
+
+        This provides an Apitally-style uptime signal without introducing a
+        scheduler: if an app/environment stops sending traffic, its latest
+        ClickHouse timestamp ages into stale/down status.
+        """
+        now = datetime.now(tz.utc)
+        heartbeat_grace_minutes = max(1, min(int(heartbeat_grace_minutes or 2), 60))
+        down_after_minutes = max(
+            heartbeat_grace_minutes,
+            min(int(down_after_minutes or 15), 24 * 60),
+        )
+        lookback_days = max(1, min(int(lookback_days or 30), 30))
+
+        apps = list(
+            App.objects.filter(project_id=project_id, is_active=True)
+            .order_by("name", "created_at")
+            .values("id", "name", "slug", "framework")
+        )
+
+        latest_by_app: dict[str, list[dict]] = {str(app["id"]): [] for app in apps}
+        try:
+            from core.database.clickhouse.client import get_clickhouse_client
+
+            client = get_clickhouse_client()
+            rows = client.execute(
+                """
+                SELECT
+                    app_id,
+                    environment,
+                    max(timestamp) AS last_seen_at,
+                    countIf(timestamp >= %(recent_since)s) AS requests_24h
+                FROM api_requests
+                WHERE project_id = %(project_id)s
+                  AND timestamp >= %(lookback_since)s
+                  AND timestamp <= %(now)s
+                GROUP BY app_id, environment
+                ORDER BY last_seen_at DESC
+                """,
+                {
+                    "project_id": project_id,
+                    "lookback_since": now - timedelta(days=lookback_days),
+                    "recent_since": now - timedelta(hours=24),
+                    "now": now,
+                },
+            )
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project uptime; returning app-only status: %s", exc)
+            rows = []
+
+        for row in rows:
+            app_id = str(row.get("app_id") or "")
+            if app_id in latest_by_app:
+                last_seen_at = _as_utc(row.get("last_seen_at"))
+                latest_by_app[app_id].append(
+                    {
+                        "environment": row.get("environment") or "unknown",
+                        "last_seen_at": last_seen_at,
+                        "requests_24h": int(row.get("requests_24h") or 0),
+                    }
+                )
+
+        def status_for(last_seen_at: datetime | None) -> tuple[str, int | None]:
+            if last_seen_at is None:
+                return "no_data", None
+            age_seconds = max(0, int((now - last_seen_at).total_seconds()))
+            if age_seconds <= heartbeat_grace_minutes * 60:
+                return "live", age_seconds
+            if age_seconds <= down_after_minutes * 60:
+                return "stale", age_seconds
+            return "down", age_seconds
+
+        status_rank = {"live": 0, "stale": 1, "down": 2, "no_data": 3}
+        app_statuses = []
+        summary = {"live": 0, "stale": 0, "down": 0, "no_data": 0}
+        newest_seen_at: datetime | None = None
+
+        for app in apps:
+            app_id = str(app["id"])
+            env_rows = []
+            for env in latest_by_app.get(app_id, []):
+                status, age_seconds = status_for(env["last_seen_at"])
+                last_seen_at = env["last_seen_at"]
+                if last_seen_at and (newest_seen_at is None or last_seen_at > newest_seen_at):
+                    newest_seen_at = last_seen_at
+                env_rows.append(
+                    {
+                        "environment": env["environment"],
+                        "status": status,
+                        "age_seconds": age_seconds,
+                        "last_seen_at": last_seen_at,
+                        "requests_24h": env["requests_24h"],
+                    }
+                )
+
+            if env_rows:
+                app_problem = max(
+                    env_rows,
+                    key=lambda row: (status_rank[row["status"]], row["age_seconds"] or 0),
+                )
+                app_status = app_problem["status"]
+                app_last_seen_at = app_problem["last_seen_at"]
+                app_age_seconds = app_problem["age_seconds"]
+                app_requests_24h = sum(row["requests_24h"] for row in env_rows)
+            else:
+                app_status = "no_data"
+                app_last_seen_at = None
+                app_age_seconds = None
+                app_requests_24h = 0
+
+            summary[app_status] += 1
+            app_statuses.append(
+                {
+                    "id": app_id,
+                    "name": app["name"],
+                    "slug": app["slug"],
+                    "framework": app["framework"],
+                    "status": app_status,
+                    "age_seconds": app_age_seconds,
+                    "last_seen_at": app_last_seen_at,
+                    "requests_24h": app_requests_24h,
+                    "environments": env_rows,
+                }
+            )
+
+        return {
+            "generated_at": now,
+            "heartbeat_grace_minutes": heartbeat_grace_minutes,
+            "down_after_minutes": down_after_minutes,
+            "lookback_days": lookback_days,
+            "latest_seen_at": newest_seen_at,
+            "total_apps": len(app_statuses),
+            "summary": {
+                "live": summary["live"],
+                "stale": summary["stale"],
+                "down": summary["down"],
+                "no_data": summary["no_data"],
+            },
+            "apps": app_statuses,
+        }
+
     @staticmethod
     def get_summary(
         app_id: str,

--- a/apps/api/apps/projects/services.py
+++ b/apps/api/apps/projects/services.py
@@ -36,10 +36,20 @@ MAX_APPS_PER_PROJECT = 50
 RESERVED_SLUGS = RESERVED_PROJECT_SLUGS
 
 
+def _parse_time_param(value: str, name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(f"Invalid {name} timestamp. Use ISO 8601 format.") from exc
+    return _as_utc(parsed)
+
+
 def _resolve_time_range(since: str | None, until: str | None) -> tuple[datetime, datetime]:
     now = datetime.now(tz.utc)
-    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else now - timedelta(hours=24)
-    until_dt = datetime.fromisoformat(until.replace("Z", "+00:00")) if until else now
+    since_dt = _parse_time_param(since, "since") if since else now - timedelta(hours=24)
+    until_dt = _parse_time_param(until, "until") if until else now
+    if since_dt >= until_dt:
+        raise ValidationError("'since' must be before 'until'.")
     return since_dt, until_dt
 
 
@@ -257,8 +267,6 @@ class ProjectService:
                     f"A project named '{name}' is already taken. Please choose a different name."
                 )
             project.name = name
-            # Slug is globally unique across all users.
-            project.slug = _unique_project_slug(name, exclude_id=project.id)
 
         if description is not None:
             project.description = description.strip()
@@ -395,7 +403,6 @@ class AppService:
             if not name:
                 raise ValidationError("App name is required")
             app.name = name
-            app.slug = _unique_slug(project, name, exclude_id=app.id)
 
         if description is not None:
             app.description = description.strip()
@@ -644,28 +651,6 @@ class IngestService:
             IngestService._base_url_column_ready = True
 
     @staticmethod
-    def ensure_consumer_columns(client) -> None:
-        if IngestService._consumer_columns_ready:
-            return
-        with IngestService._consumer_columns_lock:
-            if IngestService._consumer_columns_ready:
-                return
-            try:
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(3))"
-                )
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(3))"
-                )
-                client.execute(
-                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(3))"
-                )
-            except Exception as exc:
-                logger.warning("Unable to ensure consumer columns on api_requests: %s", exc)
-                return
-            IngestService._consumer_columns_ready = True
-
-    @staticmethod
     def ensure_trace_columns(client) -> None:
         if IngestService._trace_columns_ready:
             return
@@ -686,6 +671,28 @@ class IngestService:
                 logger.warning("Unable to ensure trace columns on api_requests: %s", exc)
                 return
             IngestService._trace_columns_ready = True
+
+    @staticmethod
+    def ensure_consumer_columns(client) -> None:
+        if IngestService._consumer_columns_ready:
+            return
+        with IngestService._consumer_columns_lock:
+            if IngestService._consumer_columns_ready:
+                return
+            try:
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_id String CODEC(ZSTD(3))"
+                )
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_name String CODEC(ZSTD(3))"
+                )
+                client.execute(
+                    "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(3))"
+                )
+            except Exception as exc:
+                logger.warning("Unable to ensure consumer columns on api_requests: %s", exc)
+                return
+            IngestService._consumer_columns_ready = True
 
     @staticmethod
     def _safe_payload(value: str) -> str:
@@ -722,21 +729,9 @@ class IngestService:
                     SETTINGS index_granularity = 8192
                     """
                 )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))"
-                )
-                # Correlation columns from migration 004; the legacy runtime
-                # CREATE above lacks them, so ensure before selecting them.
                 for stmt in (
+                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_method LowCardinality(String) CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_path String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
@@ -745,6 +740,10 @@ class IngestService:
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
                     "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
                     "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
                 ):
                     client.execute(stmt)
@@ -786,17 +785,30 @@ class IngestService:
                     SETTINGS index_granularity = 8192
                     """
                 )
-                client.execute(
-                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
-                client.execute(
-                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1"
-                )
+                for statement in (
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS app_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS environment LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS parent_span_id String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS name String CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS kind LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS service_name LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS duration_ms Float64 CODEC(Gorilla, ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS status LowCardinality(String) CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
+                    "ALTER TABLE api_spans ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+                    "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+                ):
+                    client.execute(statement)
             except Exception as exc:
                 logger.warning("Unable to ensure api_spans table: %s", exc)
                 return
             IngestService._api_spans_table_ready = True
-
     @staticmethod
     def _safe_log_text(value: str, *, limit: int) -> str:
         if not value:
@@ -1492,6 +1504,8 @@ class LogsService:
         search: str | None = None,
         attribute_filters: list[tuple[str, str]] | None = None,
         logger_filters: list[str] | None = None,
+        trace_id: str | None = None,
+        span_id: str | None = None,
         page: int = 1,
         page_size: int = 50,
     ) -> dict:
@@ -1548,6 +1562,14 @@ class LogsService:
                 level,
                 message,
                 logger_name,
+                endpoint_method,
+                endpoint_path,
+                status_code,
+                consumer_id,
+                consumer_name,
+                consumer_group,
+                trace_id,
+                span_id,
                 payload,
                 attributes_json
             FROM api_logs
@@ -1924,6 +1946,7 @@ class DataQueryService:
         attribute_filters: list[tuple[str, str]] | None = None,
         logger_filters: list[str] | None = None,
         trace_id: str | None = None,
+        span_id: str | None = None,
         page: int = 1,
         page_size: int = 50,
     ) -> dict:
@@ -1941,12 +1964,7 @@ class DataQueryService:
             client = get_clickhouse_client()
         except Exception as exc:
             logger.warning("ClickHouse client initialization failed; returning empty logs: %s", exc)
-            return {
-                "items": [],
-                "total_count": 0,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
+            return {"items": [], "total_count": 0, "page": safe_page, "page_size": safe_size}
 
         IngestService.ensure_api_logs_table(client)
 
@@ -1959,7 +1977,6 @@ class DataQueryService:
             "offset": offset,
         }
 
-        # Build app_ids filter
         app_filter = ""
         if app_ids:
             app_placeholders = []
@@ -1978,9 +1995,13 @@ class DataQueryService:
             logger_filters=logger_filters,
         )
 
-        if trace_id:
-            where_filters += " AND trace_id = %(trace_id)s"
+        correlation_filters = ""
+        if trace_id and trace_id.strip():
             params["trace_id"] = trace_id.strip().lower()
+            correlation_filters += " AND trace_id = %(trace_id)s"
+        if span_id and span_id.strip():
+            params["span_id"] = span_id.strip().lower()
+            correlation_filters += " AND span_id = %(span_id)s"
 
         count_query = f"""
             SELECT count() AS total_count
@@ -1989,6 +2010,7 @@ class DataQueryService:
               {app_filter}
               AND timestamp >= %(since)s
               AND timestamp <= %(until)s
+              {correlation_filters}
               {where_filters}
         """
 
@@ -2000,6 +2022,12 @@ class DataQueryService:
                 level,
                 message,
                 logger_name,
+                endpoint_method,
+                endpoint_path,
+                status_code,
+                consumer_id,
+                consumer_name,
+                consumer_group,
                 trace_id,
                 span_id,
                 payload,
@@ -2009,6 +2037,7 @@ class DataQueryService:
               {app_filter}
               AND timestamp >= %(since)s
               AND timestamp <= %(until)s
+              {correlation_filters}
               {where_filters}
             ORDER BY timestamp DESC
             LIMIT %(limit)s
@@ -2030,21 +2059,10 @@ class DataQueryService:
                     parsed = {}
                 item["attributes"] = {str(k): str(v) for k, v in parsed.items()}
                 item.pop("attributes_json", None)
-            return {
-                "items": items,
-                "total_count": total_count,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
+            return {"items": items, "total_count": total_count, "page": safe_page, "page_size": safe_size}
         except Exception as exc:
             logger.warning("ClickHouse query failed for project logs: %s", exc)
-            return {
-                "items": [],
-                "total_count": 0,
-                "page": safe_page,
-                "page_size": safe_size,
-            }
-
+            return {"items": [], "total_count": 0, "page": safe_page, "page_size": safe_size}
     @staticmethod
     def get_project_requests(
         project_id: str,
@@ -2212,6 +2230,135 @@ class DataQueryService:
             }
         except Exception as exc:
             logger.warning("ClickHouse query failed for project requests: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+    @staticmethod
+    def get_project_spans(
+        project_id: str,
+        app_ids: list[str] | None = None,
+        environment: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        trace_id: str | None = None,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        Query trace spans across all apps in a project or specific apps.
+        Returns paginated span records with optional trace filtering.
+        """
+        from core.database.clickhouse.client import get_clickhouse_client
+
+        safe_page = max(1, int(page))
+        safe_size = max(1, min(int(page_size), 200))
+        offset = (safe_page - 1) * safe_size
+
+        try:
+            client = get_clickhouse_client()
+        except Exception as exc:
+            logger.warning("ClickHouse client initialization failed; returning empty spans: %s", exc)
+            return {
+                "items": [],
+                "total_count": 0,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+
+        IngestService.ensure_api_spans_table(client)
+
+        since_dt, until_dt = _resolve_time_range(since, until)
+        params: dict[str, Any] = {
+            "project_id": project_id,
+            "since": since_dt,
+            "until": until_dt,
+            "limit": safe_size,
+            "offset": offset,
+        }
+
+        filters: list[str] = []
+
+        if app_ids:
+            app_placeholders = []
+            for idx, app_id in enumerate(app_ids):
+                key = f"app_id_{idx}"
+                params[key] = app_id
+                app_placeholders.append(f"%({key})s")
+            filters.append(f"app_id IN ({', '.join(app_placeholders)})")
+
+        if environment:
+            filters.append("environment = %(environment)s")
+            params["environment"] = environment
+
+        if trace_id and trace_id.strip():
+            filters.append("trace_id = %(trace_id)s")
+            params["trace_id"] = trace_id.strip()
+
+        where_clause = ""
+        if filters:
+            where_clause = "AND " + " AND ".join(filters)
+
+        count_query = f"""
+            SELECT count() AS total_count
+            FROM api_spans
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+        """
+
+        rows_query = f"""
+            SELECT
+                timestamp,
+                app_id,
+                environment,
+                trace_id,
+                span_id,
+                parent_span_id,
+                name,
+                kind,
+                service_name,
+                duration_ms,
+                status,
+                status_code,
+                attributes_json
+            FROM api_spans
+            WHERE project_id = %(project_id)s
+              AND timestamp >= %(since)s
+              AND timestamp <= %(until)s
+              {where_clause}
+            ORDER BY timestamp ASC, span_id ASC
+            LIMIT %(limit)s
+            OFFSET %(offset)s
+        """
+
+        try:
+            count_rows = client.execute(count_query, params)
+            total_count = int(count_rows[0]["total_count"]) if count_rows else 0
+            items = client.execute(rows_query, params)
+            for item in items:
+                item["timestamp"] = _as_utc(item.get("timestamp"))
+                raw_attributes = item.get("attributes_json", "") or "{}"
+                try:
+                    parsed = json.loads(raw_attributes)
+                    if not isinstance(parsed, dict):
+                        parsed = {}
+                except Exception:
+                    parsed = {}
+                item["attributes"] = {str(k): str(v) for k, v in parsed.items()}
+                item.pop("attributes_json", None)
+            return {
+                "items": items,
+                "total_count": total_count,
+                "page": safe_page,
+                "page_size": safe_size,
+            }
+        except Exception as exc:
+            logger.warning("ClickHouse query failed for project spans: %s", exc)
             return {
                 "items": [],
                 "total_count": 0,

--- a/apps/api/routers/projects/router.py
+++ b/apps/api/routers/projects/router.py
@@ -36,6 +36,7 @@ from .schemas import (
     LogsQueryResponse,
     RequestsQueryResponse,
     TraceQueryResponse,
+    SpansQueryResponse,
     AnalyticsTimeseriesPointResponse,
     MembersListResponse,
     InvitationResponse,
@@ -794,6 +795,7 @@ def query_project_logs(
     search: str = None,
     loggers: str = None,
     trace_id: str = None,
+    span_id: str = None,
     page: int = 1,
     page_size: int = 50,
 ):
@@ -807,6 +809,7 @@ def query_project_logs(
     - search: Search in message, logger_name, or attributes
     - loggers: Comma-separated logger names
     - trace_id: Only logs correlated with this W3C trace id
+    - span_id: Only logs correlated with this span id
     - since/until: ISO8601 timestamps for time range
     - page/page_size: Pagination controls
     """
@@ -838,6 +841,7 @@ def query_project_logs(
         search=search,
         logger_filters=logger_list,
         trace_id=trace_id,
+        span_id=span_id,
         page=page,
         page_size=page_size,
     )
@@ -931,3 +935,49 @@ def query_project_requests(
     )
 
     return RequestsQueryResponse(**result)
+
+
+@router.get("/{project_slug}/data/spans", response=SpansQueryResponse)
+def query_project_spans(
+    request: HttpRequest,
+    project_slug: str,
+    app_slugs: str = None,
+    environment: str = None,
+    since: str = None,
+    until: str = None,
+    trace_id: str = None,
+    page: int = 1,
+    page_size: int = 100,
+):
+    """
+    Query raw trace span data across all apps in a project.
+
+    Filters:
+    - trace_id: Exact trace identifier to inspect a single trace
+    - app_slugs: Comma-separated app slugs
+    - environment: Filter by environment name
+    - since/until: ISO8601 timestamps for time range
+    - page/page_size: Pagination controls
+    """
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+
+    app_ids = None
+    if app_slugs:
+        slugs = [s.strip() for s in app_slugs.split(",") if s.strip()]
+        if slugs:
+            apps = AppService.get_apps_by_slugs(project, slugs)
+            app_ids = [str(app.id) for app in apps]
+
+    result = DataQueryService.get_project_spans(
+        project_id=str(project.id),
+        app_ids=app_ids,
+        environment=environment,
+        since=since,
+        until=until,
+        trace_id=trace_id,
+        page=page,
+        page_size=page_size,
+    )
+
+    return SpansQueryResponse(**result)

--- a/apps/api/routers/projects/router.py
+++ b/apps/api/routers/projects/router.py
@@ -377,6 +377,25 @@ def get_analytics_timeseries(
     )
 
 
+@router.get("/{project_slug}/analytics/uptime", response=dict)
+def get_project_uptime(
+    request: HttpRequest,
+    project_slug: str,
+    heartbeat_grace_minutes: int = 2,
+    down_after_minutes: int = 15,
+    lookback_days: int = 30,
+):
+    """Get app/environment freshness status from latest ingested traffic."""
+    user: User = request.auth
+    project = ProjectService.get_project_by_slug(user, project_slug)
+    return AnalyticsService.get_project_uptime(
+        project_id=str(project.id),
+        heartbeat_grace_minutes=heartbeat_grace_minutes,
+        down_after_minutes=down_after_minutes,
+        lookback_days=lookback_days,
+    )
+
+
 @router.get("/{project_slug}/analytics/endpoints", response=dict)
 def get_endpoint_stats(
     request: HttpRequest,

--- a/apps/api/routers/projects/schemas.py
+++ b/apps/api/routers/projects/schemas.py
@@ -166,6 +166,12 @@ class LogItemResponse(Schema):
     level: str
     message: str
     logger_name: str
+    endpoint_method: str = ""
+    endpoint_path: str = ""
+    status_code: int = 0
+    consumer_id: str = ""
+    consumer_name: str = ""
+    consumer_group: str = ""
     trace_id: str = ""
     span_id: str = ""
     payload: str
@@ -208,7 +214,7 @@ class SpanItemResponse(Schema):
     environment: str
     trace_id: str
     span_id: str
-    parent_span_id: str
+    parent_span_id: str = ""
     name: str
     kind: str
     service_name: str
@@ -219,6 +225,15 @@ class SpanItemResponse(Schema):
 
 class TraceQueryResponse(Schema):
     spans: list[SpanItemResponse]
+
+
+class SpansQueryResponse(Schema):
+    items: list[SpanItemResponse]
+    total_count: int
+    page: int
+    page_size: int
+
+
 
 
 class AnalyticsTimeseriesPointResponse(Schema):

--- a/apps/api/tests/test_app_service.py
+++ b/apps/api/tests/test_app_service.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from apps.projects.models import App, Project
+from apps.projects.services import AppService
+from apps.users.models import User
+
+
+class AppServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Demo Project",
+            slug="demo-project",
+        )
+
+    def test_update_app_name_preserves_stable_slug(self) -> None:
+        app = App.objects.create(
+            project=self.project,
+            name="Original App",
+            slug="stable-app-id",
+            framework=App.Framework.FASTAPI,
+        )
+
+        updated = AppService.update_app(
+            self.project,
+            "stable-app-id",
+            name="Renamed App",
+        )
+
+        self.assertEqual(updated.name, "Renamed App")
+        self.assertEqual(updated.slug, "stable-app-id")
+        self.assertTrue(
+            App.objects.filter(
+                project=self.project,
+                slug="stable-app-id",
+                name="Renamed App",
+            ).exists()
+        )

--- a/apps/api/tests/test_filters.py
+++ b/apps/api/tests/test_filters.py
@@ -1,0 +1,39 @@
+import sys
+from unittest import TestCase
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+from apps.projects.filters import build_where, parse_filter
+
+
+class RichFilterTests(TestCase):
+    def test_status_class_not_negates_status_range(self) -> None:
+        params = {}
+
+        where = build_where(parse_filter("status_class:not:2xx"), params)
+
+        self.assertIn("NOT", where)
+        self.assertIn("status_code >=", where)
+        self.assertIn("status_code <", where)
+        self.assertEqual(params["flt0_0_lo"], 200)
+        self.assertEqual(params["flt0_0_hi"], 300)
+
+    def test_status_class_is_keeps_positive_status_range(self) -> None:
+        params = {}
+
+        where = build_where(parse_filter("status_class:is:2xx"), params)
+
+        self.assertNotIn("NOT", where)
+        self.assertIn("status_code >=", where)
+        self.assertIn("status_code <", where)
+        self.assertEqual(params["flt0_0_lo"], 200)
+        self.assertEqual(params["flt0_0_hi"], 300)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/apps/api/tests/test_membership.py
+++ b/apps/api/tests/test_membership.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from apps.projects.membership import MembershipService
+from apps.projects.models import Project, ProjectInvitation
+from apps.users.models import User
+from core.exceptions.base import ValidationError
+
+
+class MembershipServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Demo Project",
+            slug="demo-project",
+        )
+
+    def test_invite_member_rejects_invalid_email(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "valid email"):
+            MembershipService.invite_member(
+                self.owner,
+                self.project,
+                "codex-invalid-email-no-at",
+                "viewer",
+            )
+
+        self.assertFalse(
+            ProjectInvitation.objects.filter(
+                project=self.project,
+                email="codex-invalid-email-no-at",
+            ).exists()
+        )

--- a/apps/api/tests/test_project_service.py
+++ b/apps/api/tests/test_project_service.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from apps.projects.models import Project
+from apps.projects.services import ProjectService
+from apps.users.models import User
+
+
+class ProjectServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create(email="owner@example.com")
+        self.project = Project.objects.create(
+            owner=self.owner,
+            name="Original Project",
+            slug="stable-project-id",
+        )
+
+    def test_update_project_name_preserves_stable_slug(self) -> None:
+        updated = ProjectService.update_project(
+            self.owner,
+            "stable-project-id",
+            name="Renamed Project",
+        )
+
+        self.assertEqual(updated.name, "Renamed Project")
+        self.assertEqual(updated.slug, "stable-project-id")
+        self.assertTrue(
+            Project.objects.filter(
+                id=self.project.id,
+                slug="stable-project-id",
+                name="Renamed Project",
+            ).exists()
+        )

--- a/apps/api/tests/test_time_range.py
+++ b/apps/api/tests/test_time_range.py
@@ -1,0 +1,26 @@
+from datetime import timezone as tz
+from unittest import TestCase
+
+from apps.projects.services import _resolve_time_range
+from core.exceptions.base import ValidationError
+
+
+class TimeRangeTests(TestCase):
+    def test_invalid_since_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Invalid since timestamp"):
+            _resolve_time_range("not-a-date", None)
+
+    def test_invalid_until_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Invalid until timestamp"):
+            _resolve_time_range("2026-01-01T00:00:00Z", "also-bad")
+
+    def test_reversed_range_rejected_as_validation_error(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "since.*before.*until"):
+            _resolve_time_range("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z")
+
+    def test_valid_z_timestamps_are_utc(self) -> None:
+        since, until = _resolve_time_range("2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z")
+
+        self.assertEqual(since.tzinfo, tz.utc)
+        self.assertEqual(until.tzinfo, tz.utc)
+        self.assertLess(since, until)

--- a/apps/ingest/app/ingest.py
+++ b/apps/ingest/app/ingest.py
@@ -142,6 +142,28 @@ def ensure_clickhouse_schema(client) -> None:
             TTL toDateTime(timestamp) + INTERVAL 30 DAY
             SETTINGS index_granularity = 8192
             """,
+            """
+            CREATE TABLE IF NOT EXISTS api_spans (
+                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+                app_id String CODEC(ZSTD(1)),
+                project_id String CODEC(ZSTD(1)),
+                environment LowCardinality(String) CODEC(ZSTD(1)),
+                trace_id String CODEC(ZSTD(1)),
+                span_id String CODEC(ZSTD(1)),
+                parent_span_id String CODEC(ZSTD(1)),
+                name String CODEC(ZSTD(2)),
+                kind LowCardinality(String) CODEC(ZSTD(1)),
+                service_name LowCardinality(String) CODEC(ZSTD(1)),
+                duration_ms Float64 CODEC(ZSTD(1)),
+                status LowCardinality(String) CODEC(ZSTD(1)),
+                status_code UInt16 CODEC(ZSTD(1)),
+                attributes_json String CODEC(ZSTD(3))
+            ) ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (project_id, app_id, trace_id, timestamp)
+            TTL toDateTime(timestamp) + INTERVAL 30 DAY
+            SETTINGS index_granularity = 8192
+            """,
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_payload String CODEC(ZSTD(3))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_payload String CODEC(ZSTD(3))",
@@ -155,9 +177,6 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS span_id String DEFAULT '' CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD INDEX IF NOT EXISTS idx_api_requests_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
-            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
-            # Log-correlation columns exist in the 004 migration but not in the
-            # legacy runtime-created api_logs table; ensure them before writing.
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_method LowCardinality(String) CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS endpoint_path String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS status_code UInt16 CODEC(ZSTD(1))",
@@ -166,43 +185,19 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS consumer_group String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
+            "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS attributes_json String CODEC(ZSTD(3))",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
-            # Span storage for distributed traces (the waterfall view). The
-            # legacy `traces` table (tenant_id model) is intentionally unused.
-            """
-            CREATE TABLE IF NOT EXISTS api_spans (
-                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-                app_id String CODEC(ZSTD(1)),
-                project_id String CODEC(ZSTD(1)),
-                environment LowCardinality(String) CODEC(ZSTD(1)),
-                trace_id String CODEC(ZSTD(1)),
-                span_id String CODEC(ZSTD(1)),
-                parent_span_id String CODEC(ZSTD(1)),
-                name String CODEC(ZSTD(1)),
-                kind LowCardinality(String) CODEC(ZSTD(1)),
-                service_name LowCardinality(String) CODEC(ZSTD(1)),
-                duration_ms Float64 CODEC(Gorilla, ZSTD(1)),
-                status LowCardinality(String) CODEC(ZSTD(1)),
-                status_code UInt16 CODEC(ZSTD(1)),
-                attributes_json String CODEC(ZSTD(3))
-            ) ENGINE = MergeTree()
-            PARTITION BY toYYYYMM(timestamp)
-            ORDER BY (app_id, trace_id, timestamp)
-            TTL toDateTime(timestamp) + INTERVAL 30 DAY
-            SETTINGS index_granularity = 8192
-            """,
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
-            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",        ]
+            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+        ]
         for s in stmts:
             client.execute(s)
         _schema_ready = True
-
-
 # --- validation + resolution (mirrors router.py) ----------------------------
 
 def validate_project_slug(auth_slug: str, payload_slugs: set[str]) -> None:
@@ -400,7 +395,7 @@ def handle_spans(project_id: str, project_slug: str, records) -> int:
             trace_id = _safe_trace_component(r.trace_id, 32)
             span_id = _safe_trace_component(r.span_id, 16)
             if not trace_id or not span_id:
-                continue  # unusable without valid ids; drop silently (telemetry)
+                continue
             status = (r.status or "ok").strip().lower()
             rows.append((
                 r.timestamp, app_uuid, project_id,

--- a/apps/ingest/app/ingest.py
+++ b/apps/ingest/app/ingest.py
@@ -125,6 +125,23 @@ def ensure_clickhouse_schema(client) -> None:
         if _schema_ready:
             return
         stmts = [
+            """
+            CREATE TABLE IF NOT EXISTS api_logs (
+                timestamp DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+                app_id String CODEC(ZSTD(1)),
+                project_id String CODEC(ZSTD(1)),
+                environment LowCardinality(String) CODEC(ZSTD(1)),
+                level LowCardinality(String) CODEC(ZSTD(1)),
+                message String CODEC(ZSTD(3)),
+                logger_name LowCardinality(String) CODEC(ZSTD(1)),
+                payload String CODEC(ZSTD(3)),
+                attributes_json String CODEC(ZSTD(3))
+            ) ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (project_id, app_id, environment, level, timestamp)
+            TTL toDateTime(timestamp) + INTERVAL 30 DAY
+            SETTINGS index_granularity = 8192
+            """,
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS project_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS request_payload String CODEC(ZSTD(3))",
             "ALTER TABLE api_requests ADD COLUMN IF NOT EXISTS response_payload String CODEC(ZSTD(3))",
@@ -150,6 +167,10 @@ def ensure_clickhouse_schema(client) -> None:
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS trace_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD COLUMN IF NOT EXISTS span_id String CODEC(ZSTD(1))",
             "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_app_id app_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
+            "ALTER TABLE api_logs ADD INDEX IF NOT EXISTS idx_api_logs_level level TYPE set(10) GRANULARITY 1",
             # Span storage for distributed traces (the waterfall view). The
             # legacy `traces` table (tenant_id model) is intentionally unused.
             """
@@ -176,8 +197,7 @@ def ensure_clickhouse_schema(client) -> None:
             """,
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1",
             "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_project_id project_id TYPE bloom_filter(0.01) GRANULARITY 1",
-            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",
-        ]
+            "ALTER TABLE api_spans ADD INDEX IF NOT EXISTS idx_api_spans_environment environment TYPE bloom_filter(0.01) GRANULARITY 1",        ]
         for s in stmts:
             client.execute(s)
         _schema_ready = True

--- a/apps/ingest/app/schemas.py
+++ b/apps/ingest/app/schemas.py
@@ -81,10 +81,10 @@ class SpanRecord(BaseModel):
     span_id: str
     parent_span_id: str = ""
     name: str = ""
-    kind: str = "internal"  # server | client | http | db | internal | ...
+    kind: str = "internal"
     service_name: str = ""
     duration_ms: float = 0.0
-    status: str = "ok"  # ok | error
+    status: str = "ok"
     status_code: int = 0
     attributes: dict = Field(default_factory=dict)
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -5,6 +5,15 @@ const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypescript,
   {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+    ],
+  },
+  {
     rules: {
       "@next/next/no-html-link-for-pages": "warn",
       "@typescript-eslint/no-explicit-any": "warn",
@@ -15,15 +24,6 @@ const eslintConfig = [
       "react-hooks/set-state-in-effect": "warn",
       "react/no-unescaped-entities": "warn",
     },
-  },
-  {
-    ignores: [
-      "node_modules/**",
-      ".next/**",
-      "out/**",
-      "build/**",
-      "next-env.d.ts",
-    ],
   },
 ];
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,16 +1,21 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
+  {
+    rules: {
+      "@next/next/no-html-link-for-pages": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "prefer-const": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react/no-unescaped-entities": "warn",
+    },
+  },
   {
     ignores: [
       "node_modules/**",

--- a/apps/web/src/app/api/account/passkeys/[id]/route.ts
+++ b/apps/web/src/app/api/account/passkeys/[id]/route.ts
@@ -1,38 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const { id } = await params;
 
-    const response = await fetch(
+    const response = await fetchWithAuthRefresh(
       `${AUTH_API_URL}/passkey/credentials/${id}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${session.accessToken}`,
-        },
-      }
+      { method: "DELETE" },
     );
 
     if (!response.ok) {
-      const data = await response.json();
+      const data = await response.json().catch(() => ({}));
       return NextResponse.json(
-        { error: data.detail || "Failed to delete passkey" },
+        { error: data.detail || data.error || "Failed to delete passkey" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/account/passkeys/register/options/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/options/route.ts
@@ -1,84 +1,16 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession, setSession, clearSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
-async function refreshAccessToken(refreshToken: string): Promise<{ access_token: string; refresh_token: string } | null> {
+export async function POST() {
   try {
-    const response = await fetch(`${AUTH_API_URL}/refresh`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/register/options`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh_token: refreshToken }),
-    });
-
-    if (!response.ok) return null;
-    return await response.json();
-  } catch {
-    return null;
-  }
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    let session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    let response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.accessToken}`,
-      },
       body: JSON.stringify({}),
     });
-
-    // If 401 or 422 (expired token), try to refresh
-    if (response.status === 401 || response.status === 422) {
-      console.log("Token expired, attempting refresh...");
-      const refreshResult = await refreshAccessToken(session.refreshToken);
-      if (!refreshResult) {
-        console.error("Token refresh failed");
-        await clearSession();
-        return NextResponse.json({ error: "Session expired, please log in again" }, { status: 401 });
-      }
-
-      console.log("Token refreshed successfully, retrying request...");
-      // Retry with new token
-      response = await fetch(`${AUTH_API_URL}/passkey/register/options`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${refreshResult.access_token}`,
-        },
-        body: JSON.stringify({}),
-      });
-
-      // Get the data
-      const data = await response.json();
-
-      if (!response.ok) {
-        return NextResponse.json(
-          { error: data.detail || data.error || "Failed to generate registration options" },
-          { status: response.status },
-        );
-      }
-
-      // Update session with new tokens
-      await setSession({
-        accessToken: refreshResult.access_token,
-        refreshToken: refreshResult.refresh_token,
-        user: session.user,  // Keep existing user info
-      });
-
-      // Return success
-      return NextResponse.json(data);
-    }
 
     const data = await response.json();
 

--- a/apps/web/src/app/api/account/passkeys/register/verify/route.ts
+++ b/apps/web/src/app/api/account/passkeys/register/verify/route.ts
@@ -1,29 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
-    console.log("Verify request - challenge received:", body.challenge);
-    console.log("Verify request - credential ID:", body.credential?.id);
 
-    const response = await fetch(`${AUTH_API_URL}/passkey/register/verify`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/register/verify`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.accessToken}`,
-      },
       body: JSON.stringify({
         credential: body.credential,
         challenge: body.challenge,
@@ -32,11 +19,10 @@ export async function POST(request: NextRequest) {
     });
 
     const data = await response.json();
-    console.log("Django verify response:", response.status, data);
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data.detail || "Failed to verify passkey" },
+        { error: data.detail || data.error || "Failed to verify passkey" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/account/passkeys/route.ts
+++ b/apps/web/src/app/api/account/passkeys/route.ts
@@ -1,31 +1,21 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { fetchWithAuthRefresh } from "@/lib/proxy";
 
-// Auth/identity calls go to the identity service (AUTH_API_URL); default
-// falls back to the core API's /auth path so local dev is unchanged.
 const AUTH_API_URL =
   process.env.AUTH_API_URL ||
   `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/auth`;
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const response = await fetch(`${AUTH_API_URL}/passkey/credentials`, {
+    const response = await fetchWithAuthRefresh(`${AUTH_API_URL}/passkey/credentials`, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${session.accessToken}`,
-      },
     });
 
     const data = await response.json();
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data.detail || "Failed to fetch passkeys" },
+        { error: data.detail || data.error || "Failed to fetch passkeys" },
         { status: response.status },
       );
     }

--- a/apps/web/src/app/api/projects/[slug]/analytics/consumer-stats/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/consumer-stats/route.ts
@@ -1,42 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Proxy for the project-wide rich consumer stats (requests, error rate, avg
-// response, last seen). Powers the dedicated Consumers page.
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/consumer-stats${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/consumers/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/consumers/route.ts
@@ -1,42 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Proxy for the project-wide consumer list (ranked by request volume).
-// Powers the consumer filter dropdown on Request logs / Traffic.
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/consumers${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-consumers/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-consumers${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-detail/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-detail${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-histograms/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-histograms${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-status-codes/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-status-codes${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoint-timeseries/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,34 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-timeseries${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/endpoints/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/endpoints/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoints${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/environments/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/environments/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,37 +7,15 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/environments${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch (error) {
-    return NextResponse.json(
-      { environments: [] },
-      { status: 200 }
-    );
+  const response = await proxyDjangoWithAuth(upstream);
+  if (response.status === 502) {
+    return NextResponse.json({ environments: [] }, { status: 200 });
   }
+  return response;
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/filter-values/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/filter-values/route.ts
@@ -1,41 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
-// Typeahead source for the filter bar (distinct field values matching ?q=).
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/filter-values${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/summary/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/summary/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/summary${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/timeseries/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/timeseries/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -7,27 +7,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  // Check authentication
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/timeseries${qs ? `?${qs}` : ""}`;
 
-  const res = await fetch(upstream, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${session.accessToken}`,
-    },
-    cache: "no-store",
-  });
-
-  const body = await res.text();
-  return new NextResponse(body, { status: res.status, headers: { "Content-Type": res.headers.get("content-type") || "application/json" } });
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/analytics/uptime/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/analytics/uptime/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> | { slug: string } },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const resolved = "then" in context.params ? await context.params : context.params;
+  const { slug } = resolved;
+  const url = new URL(request.url);
+  const qs = url.searchParams.toString();
+  const baseUrl = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+  const upstream = `${baseUrl}/projects/${slug}/analytics/uptime${qs ? `?${qs}` : ""}`;
+
+  const res = await fetch(upstream, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.accessToken}`,
+    },
+    cache: "no-store",
+  });
+
+  const body = await res.text();
+  return new NextResponse(body, {
+    status: res.status,
+    headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
+  });
+}

--- a/apps/web/src/app/api/projects/[slug]/apps/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/apps/route.ts
@@ -23,9 +23,12 @@ export const POST = (
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
+    const appSlug = typeof body.slug === "string" ? body.slug.trim() : "";
+
     // Call the backend API to create app within project
     const result = await apiClient.createProjectApp(slug, {
       name,
+      slug: appSlug,
       description: body.description || "",
       framework: body.framework || "fastapi",
     });

--- a/apps/web/src/app/api/projects/[slug]/data/requests/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/data/requests/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getSession } from "@/lib/session";
+import { type NextRequest } from "next/server";
+import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -9,34 +9,11 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const resolved = "then" in context.params ? await context.params : context.params;
   const { slug } = resolved;
-
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
   const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/data/requests${qs ? `?${qs}` : ""}`;
 
-  try {
-    const res = await fetch(upstream, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${session.accessToken}`,
-      },
-      cache: "no-store",
-    });
-
-    const body = await res.text();
-    return new NextResponse(body, {
-      status: res.status,
-      headers: { "Content-Type": res.headers.get("content-type") || "application/json" },
-    });
-  } catch {
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
-  }
+  return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/api/projects/[slug]/data/spans/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/data/spans/route.ts
@@ -3,6 +3,7 @@ import { proxyDjangoWithAuth } from "@/lib/proxy";
 
 export const dynamic = "force-dynamic";
 
+// Project-scoped trace span query. Backs request detail trace inspection.
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ slug: string }> | { slug: string } },
@@ -11,7 +12,7 @@ export async function GET(
   const { slug } = resolved;
   const url = new URL(request.url);
   const qs = url.searchParams.toString();
-  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/analytics/endpoint-requests${qs ? `?${qs}` : ""}`;
+  const upstream = `${process.env.DJANGO_API_URL || "http://localhost:8000/api/v1"}/projects/${slug}/data/spans${qs ? `?${qs}` : ""}`;
 
   return proxyDjangoWithAuth(upstream);
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5858,6 +5858,7 @@ a.settings-btn {
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -6638,6 +6639,7 @@ a.settings-btn {
   color: var(--text-primary);
   display: -webkit-box;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -6648,6 +6650,7 @@ a.settings-btn {
   color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.45;
@@ -12605,6 +12608,7 @@ a.settings-btn {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
 }
 .ep-pm-when {
@@ -13938,7 +13942,7 @@ a.settings-btn {
 }
 .ep-section-chevron { color: var(--text-muted); transition: transform 120ms; transform: rotate(-90deg); }
 .ep-section-chevron.is-open { transform: rotate(0deg); }
-.ep-section-body { }
+/* .ep-section-body { } */
 
 /* Summary stat cards — fixed-ish width, left-aligned (don't stretch when few) */
 .ep-statcards {
@@ -14285,6 +14289,7 @@ a.settings-btn {
 
 .ep-rl-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; overflow: hidden; }
 .ep-rl-message { padding: 40px 16px; text-align: center; color: var(--text-muted); font-size: 13px; }
+.ep-rl-message-error { color: #f87171; }
 
 .ep-rl-pager {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;
@@ -14360,42 +14365,140 @@ a.settings-btn {
 }
 .ep-rel-dur { color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 
-/* Logs tab — trace-correlated log lines */
-.ep-log-row {
-  display: flex; align-items: baseline; gap: 10px; width: 100%;
-  padding: 8px 12px; border-bottom: 1px solid var(--border-color); font-size: 12px;
+/* Trace tab rows */
+.ep-trace-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  max-height: 420px;
+  overflow-y: auto;
 }
-.ep-log-row:last-child { border-bottom: none; }
-.ep-log-logger {
-  color: var(--text-muted); white-space: nowrap;
-  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
-}
-.ep-log-msg {
-  flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: var(--text-primary); overflow-wrap: anywhere;
-}
-
-/* Trace tab — span waterfall */
 .ep-trace-row {
-  display: flex; align-items: center; gap: 10px; width: 100%;
-  padding: 7px 12px; border-bottom: 1px solid var(--border-color); font-size: 12px;
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
 }
 .ep-trace-row:last-child { border-bottom: none; }
+.ep-trace-row.is-current {
+  background: rgba(20, 184, 166, 0.1);
+  box-shadow: inset 3px 0 0 #14b8a6;
+}
+.ep-trace-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
 .ep-trace-name {
-  flex: 0 0 44%; min-width: 0; display: flex; align-items: center; gap: 7px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
 }
-.ep-trace-kind {
-  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
-  flex-shrink: 0;
+.ep-trace-current {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #14b8a6;
+  background: rgba(20, 184, 166, 0.15);
+  padding: 1px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
 }
-.ep-trace-track {
-  position: relative; flex: 1; height: 8px; border-radius: 4px;
-  background: var(--bg-hover); overflow: hidden;
+.ep-trace-meta,
+.ep-trace-ids {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
-.ep-trace-bar {
-  position: absolute; top: 0; bottom: 0; border-radius: 4px; min-width: 2px;
+.ep-trace-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.ep-trace-ids {
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+}
+
+/* Logs tab rows */
+.ep-log-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  max-height: 420px;
+  overflow-y: auto;
+}
+.ep-log-row {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
+}
+.ep-log-row:last-child { border-bottom: none; }
+.ep-log-main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.ep-log-level {
+  flex: 0 0 auto;
+  min-width: 48px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.ep-log-row.level-error .ep-log-level,
+.ep-log-row.level-fatal .ep-log-level { color: #ef4444; }
+.ep-log-row.level-warn .ep-log-level,
+.ep-log-row.level-warning .ep-log-level { color: #f59e0b; }
+.ep-log-row.level-info .ep-log-level { color: #14b8a6; }
+.ep-log-message {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.ep-log-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.ep-log-payload {
+  margin: 0;
+  max-height: 140px;
+  overflow: auto;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.5;
+
 }
 
 @media (max-width: 860px) {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -12315,6 +12315,169 @@ a.settings-btn {
   font-variant-numeric: tabular-nums;
 }
 
+/* Project uptime */
+.uptime-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.uptime-generated {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.uptime-stats {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.uptime-panel {
+  min-width: 0;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.uptime-table-wrap {
+  overflow-x: auto;
+}
+
+.uptime-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.uptime-table th {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.uptime-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--text-secondary);
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.uptime-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.uptime-table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.uptime-app-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.uptime-app-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(20, 184, 166, 0.16);
+  color: var(--accent, #14b8a6);
+  font-size: 13px;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.uptime-app-name,
+.uptime-app-meta {
+  display: block;
+  min-width: 0;
+}
+
+.uptime-app-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.uptime-app-meta {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.uptime-env-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.uptime-env-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 180px;
+  padding: 4px 7px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.uptime-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--text-muted);
+  flex: 0 0 auto;
+}
+
+.uptime-dot.status-live { background: #22c55e; }
+.uptime-dot.status-stale { background: #f59e0b; }
+.uptime-dot.status-down { background: #ef4444; }
+.uptime-dot.status-no_data { background: #64748b; }
+
+.uptime-muted,
+.uptime-empty {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+}
+
+.uptime-empty {
+  width: 100%;
+  justify-content: center;
+  padding: 42px 16px;
+  font-size: 13px;
+}
+
+.uptime-empty-error {
+  color: #f87171;
+}
+
+@media (max-width: 860px) {
+  .uptime-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .uptime-generated {
+    display: none;
+  }
+}
+
 /* Status bar */
 .ep-statusbar {
   height: 24px;

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { BookOpen, LifeBuoy, Mail, Settings } from "lucide-react";
+import { getSession } from "@/lib/session";
+import StandaloneShell from "@/components/dashboard/StandaloneShell";
+
+export const metadata = {
+  title: "Help & Support | APILens",
+};
+
+export default async function HelpPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <StandaloneShell>
+      <div className="apps-page">
+        <div className="apps-page-header">
+          <h1 className="apps-page-title">Help & Support</h1>
+        </div>
+
+        <div className="apps-grid">
+          <Link href="/projects" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Projects</h3>
+            </div>
+            <p className="app-card-description">Return to your projects and apps.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <BookOpen size={12} />
+                Dashboard
+              </span>
+            </div>
+          </Link>
+
+          <Link href="/account/general" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Account settings</h3>
+            </div>
+            <p className="app-card-description">Manage login methods, sessions, profile, and security.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <Settings size={12} />
+                Settings
+              </span>
+            </div>
+          </Link>
+
+          <a href="mailto:support@apilens.ai" className="app-card app-card-clickable" style={{ textDecoration: "none" }}>
+            <div className="app-card-header">
+              <h3 className="app-card-name">Contact support</h3>
+            </div>
+            <p className="app-card-description">Email support when you need help with access, setup, or telemetry.</p>
+            <div className="app-card-meta-row">
+              <span className="app-card-meta">
+                <Mail size={12} />
+                support@apilens.ai
+              </span>
+            </div>
+          </a>
+        </div>
+
+        <div className="apps-empty" style={{ marginTop: 24 }}>
+          <div className="apps-empty-icon">
+            <LifeBuoy size={32} />
+          </div>
+          <h2 className="apps-empty-title">Need setup help?</h2>
+          <p className="apps-empty-text">
+            Open an app setup guide from Apps, or create a new app to get framework-specific instructions.
+          </p>
+        </div>
+      </div>
+    </StandaloneShell>
+  );
+}

--- a/apps/web/src/app/notifications/NotificationsPageContent.tsx
+++ b/apps/web/src/app/notifications/NotificationsPageContent.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bell, Check, Loader2, Users, X } from "lucide-react";
+
+interface PendingInvitation {
+  id: string;
+  project_name: string;
+  project_slug: string;
+  role: string;
+  inviter: string;
+  created_at: string;
+  expires_at: string;
+}
+
+export default function NotificationsPageContent() {
+  const router = useRouter();
+  const [invitations, setInvitations] = useState<PendingInvitation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const fetchPending = useCallback(async () => {
+    setError("");
+    try {
+      const res = await fetch("/api/projects/invitations/pending");
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to load notifications");
+      setInvitations(Array.isArray(data.invitations) ? data.invitations : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load notifications");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPending();
+  }, [fetchPending]);
+
+  const acceptInvitation = async (invitation: PendingInvitation) => {
+    setBusyId(invitation.id);
+    setError("");
+    try {
+      const res = await fetch(`/api/projects/invitations/${invitation.id}/accept`, { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to accept invitation");
+      router.push(`/projects/${data.project_slug || invitation.project_slug}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to accept invitation");
+      setBusyId(null);
+    }
+  };
+
+  const declineInvitation = async (invitation: PendingInvitation) => {
+    setBusyId(invitation.id);
+    setError("");
+    try {
+      const res = await fetch(`/api/projects/invitations/${invitation.id}/decline`, { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to decline invitation");
+      setInvitations((prev) => prev.filter((item) => item.id !== invitation.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to decline invitation");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="apps-page">
+      <div className="apps-page-header">
+        <h1 className="apps-page-title">Notifications</h1>
+        <button
+          type="button"
+          className="settings-btn settings-btn-secondary"
+          onClick={() => void fetchPending()}
+          disabled={isLoading}
+        >
+          {isLoading ? <Loader2 size={14} className="animate-spin" /> : null}
+          Refresh
+        </button>
+      </div>
+
+      {error ? <div className="create-app-error">{error}</div> : null}
+
+      {isLoading ? (
+        <div className="apps-page-loading">
+          <Loader2 size={24} className="animate-spin" />
+          <span>Loading notifications...</span>
+        </div>
+      ) : invitations.length === 0 ? (
+        <div className="apps-empty">
+          <div className="apps-empty-icon">
+            <Bell size={32} />
+          </div>
+          <h2 className="apps-empty-title">No notifications</h2>
+          <p className="apps-empty-text">You are all caught up.</p>
+        </div>
+      ) : (
+        <div className="apps-grid">
+          {invitations.map((invitation) => (
+            <div className="app-card" key={invitation.id}>
+              <div className="app-card-header">
+                <h3 className="app-card-name">{invitation.project_name}</h3>
+              </div>
+              <p className="app-card-description">
+                {invitation.inviter || "Someone"} invited you as {invitation.role}.
+              </p>
+              <div className="create-app-actions">
+                <button
+                  type="button"
+                  className="settings-btn settings-btn-primary"
+                  onClick={() => void acceptInvitation(invitation)}
+                  disabled={busyId === invitation.id}
+                >
+                  {busyId === invitation.id ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  className="settings-btn settings-btn-secondary"
+                  onClick={() => void declineInvitation(invitation)}
+                  disabled={busyId === invitation.id}
+                >
+                  <X size={14} />
+                  Decline
+                </button>
+              </div>
+              <div className="app-card-meta-row">
+                <span className="app-card-meta">
+                  <Users size={12} />
+                  {invitation.project_slug}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import StandaloneShell from "@/components/dashboard/StandaloneShell";
+import NotificationsPageContent from "./NotificationsPageContent";
+
+export const metadata = {
+  title: "Notifications | APILens",
+};
+
+export default async function NotificationsPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <StandaloneShell>
+      <NotificationsPageContent />
+    </StandaloneShell>
+  );
+}

--- a/apps/web/src/app/projects/[slug]/_shared/filters/FilterBar.tsx
+++ b/apps/web/src/app/projects/[slug]/_shared/filters/FilterBar.tsx
@@ -418,7 +418,7 @@ export default function FilterBar({ projectSlug, value, onChange, exclude }: Pro
           ref={inputRef}
           className="flt-input"
           value={text}
-          placeholder={predicates.length ? "" : "Filter… (e.g. status:>=500 path:~/v1/orders)"}
+          placeholder={predicates.length ? "" : "Filter… (e.g. status:>=500; path:~/v1/orders)"}
           onChange={(e) => { setText(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
           onKeyDown={onKeyDown}

--- a/apps/web/src/app/projects/[slug]/_shared/timeRange.tsx
+++ b/apps/web/src/app/projects/[slug]/_shared/timeRange.tsx
@@ -40,13 +40,26 @@ export const CALENDAR_PRESETS = [
 export const DEFAULT_PRESET_ID = "24h";
 export const DEFAULT_RANGE: RangeValue = { type: "preset", id: DEFAULT_PRESET_ID };
 
+const LEGACY_HOUR_RANGE_IDS: Record<string, string> = Object.fromEntries(
+  ROLLING_PRESETS.map((preset) => [String(preset.hours), preset.id]),
+);
+
+function validCustomRange(since: string, until: string): boolean {
+  const sinceMs = new Date(since).getTime();
+  const untilMs = new Date(until).getTime();
+  return Number.isFinite(sinceMs) && Number.isFinite(untilMs) && sinceMs < untilMs;
+}
+
 // Reconstruct the range from URL params: custom (since+until) wins, else a known
 // preset id, else the default.
 export function parseRange(f?: { range?: string; since?: string; until?: string }): RangeValue {
-  if (f?.since && f?.until) return { type: "custom", since: f.since, until: f.until };
+  if (f?.since && f?.until && validCustomRange(f.since, f.until)) {
+    return { type: "custom", since: f.since, until: f.until };
+  }
   if (f?.range) {
-    const known = [...ROLLING_PRESETS, ...CALENDAR_PRESETS].some((p) => p.id === f.range);
-    if (known) return { type: "preset", id: f.range };
+    const id = LEGACY_HOUR_RANGE_IDS[f.range] ?? f.range;
+    const known = [...ROLLING_PRESETS, ...CALENDAR_PRESETS].some((p) => p.id === id);
+    if (known) return { type: "preset", id };
   }
   return DEFAULT_RANGE;
 }

--- a/apps/web/src/app/projects/[slug]/apps/[app_slug]/setup/page.tsx
+++ b/apps/web/src/app/projects/[slug]/apps/[app_slug]/setup/page.tsx
@@ -26,6 +26,7 @@ export default function ProjectAppSetupPage() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    let cancelled = false;
 
     const metaKey = `apilens_setup_meta_${projectSlug}_${appSlug}`;
     const legacyMetaKey = `apilens_setup_meta_${appSlug}`;
@@ -34,13 +35,53 @@ export default function ProjectAppSetupPage() {
     if (rawMeta) {
       try {
         setMeta(JSON.parse(rawMeta));
+        setLoading(false);
+        return;
       } catch {
         // ignore
       }
     }
 
-    setLoading(false);
-  }, [appSlug]);
+    async function loadSetupMeta() {
+      try {
+        const [appRes, keysRes] = await Promise.all([
+          fetch(`/api/projects/${projectSlug}/apps/${appSlug}`),
+          fetch(`/api/projects/${projectSlug}/api-keys`),
+        ]);
+
+        if (!appRes.ok) {
+          if (!cancelled) router.replace(`/projects/${projectSlug}/apps`);
+          return;
+        }
+
+        const app = await appRes.json();
+        const keysData = keysRes.ok ? await keysRes.json().catch(() => ({})) : {};
+        const keys = Array.isArray(keysData)
+          ? keysData
+          : Array.isArray(keysData.keys)
+            ? keysData.keys
+            : [];
+
+        if (!cancelled) {
+          setMeta({
+            appName: app.name || appSlug,
+            framework: app.framework || "fastapi",
+            apiKeyPrefix: keys.length > 0 ? keys[0].prefix : "apilens_****",
+            projectSlug,
+            createdAt: Date.now(),
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadSetupMeta();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appSlug, projectSlug, router]);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,10 +116,7 @@ export default function ProjectAppSetupPage() {
     );
   }
 
-  if (!meta) {
-    router.push(`/projects/${projectSlug}`);
-    return null;
-  }
+  if (!meta) return null;
 
   return (
     <div className="create-app-container">

--- a/apps/web/src/app/projects/[slug]/consumers/ConsumersContent.tsx
+++ b/apps/web/src/app/projects/[slug]/consumers/ConsumersContent.tsx
@@ -131,8 +131,7 @@ export default function ConsumersContent({ projectSlug }: ConsumersContentProps)
     p.set("filter", serializeFilter(preds));
     // Carry the range when it maps to a Request-logs preset window.
     if (rangeValue.type === "preset") {
-      const hours = ROLLING_PRESETS.find((r) => r.id === rangeValue.id)?.hours;
-      if (hours && hours !== 24 && [1, 6, 168, 720].includes(hours)) p.set("range", String(hours));
+      if (rangeValue.id !== "24h") p.set("range", rangeValue.id);
     }
     router.push(`/projects/${projectSlug}/endpoints?${p.toString()}`);
   };

--- a/apps/web/src/app/projects/[slug]/endpoints/EndpointDetailPane.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/EndpointDetailPane.tsx
@@ -66,6 +66,8 @@ interface RequestRow {
   request_headers?: string;
   response_headers?: string;
   base_url?: string;
+  trace_id?: string;
+  span_id?: string;
 }
 
 type StatTone = "good" | "warn" | "bad";

--- a/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/ProjectEndpointsContent.tsx
@@ -89,6 +89,7 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [requestError, setRequestError] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
 
   const [openRow, setOpenRow] = useState<RequestItem | null>(null);
@@ -195,14 +196,31 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
       p.set("page_size", String(PAGE_SIZE));
       try {
         const res = await fetch(`/api/projects/${projectSlug}/data/requests?${p.toString()}`);
-        const data: RequestsResponse = res.ok
-          ? await res.json()
-          : { items: [], total_count: 0, page: 1, page_size: PAGE_SIZE };
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          const message =
+            typeof errorData?.detail === "string"
+              ? errorData.detail
+              : typeof errorData?.error === "string"
+                ? errorData.error
+                : `Request failed with status ${res.status}`;
+          if (cancelled) return;
+          setItems([]);
+          setTotalCount(0);
+          setRequestError(message);
+          return;
+        }
+        const data: RequestsResponse = await res.json();
         if (cancelled) return;
         setItems(data.items || []);
         setTotalCount(data.total_count || 0);
+        setRequestError("");
       } catch {
-        if (!cancelled) { setItems([]); setTotalCount(0); }
+        if (!cancelled) {
+          setItems([]);
+          setTotalCount(0);
+          setRequestError("Unable to load requests. Check your connection and try again.");
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -256,6 +274,8 @@ export default function ProjectEndpointsContent({ projectSlug }: ProjectEndpoint
       <section className="ep-rl-card">
         {loading && items.length === 0 ? (
           <div className="ep-rl-message">Loading requests…</div>
+        ) : requestError ? (
+          <div className="ep-rl-message ep-rl-message-error">{requestError}</div>
         ) : items.length === 0 ? (
           <div className="ep-rl-message">No requests match these filters in this period.</div>
         ) : (

--- a/apps/web/src/app/projects/[slug]/endpoints/RequestLogDetailModal.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/RequestLogDetailModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ArrowDownToLine, ArrowUpFromLine, Check, Copy, Fingerprint, Globe, Link2, Server, Terminal, Timer, X } from "lucide-react";
+import { ArrowDownToLine, ArrowUpFromLine, Check, Copy, Fingerprint, GitBranch, Globe, Link2, Server, Terminal, Timer, X } from "lucide-react";
 import {
   formatBytes,
   formatDateTime,
@@ -50,21 +50,6 @@ interface PayloadRow {
   span_id?: string;
 }
 
-// A log line correlated with this request via trace_id (from /data/logs).
-interface LogItem {
-  timestamp: string;
-  app_id: string;
-  environment: string;
-  level: string;
-  message: string;
-  logger_name: string;
-  trace_id?: string;
-  span_id?: string;
-  payload: string;
-  attributes: Record<string, string>;
-}
-
-// A span of the distributed trace this request belongs to (from /data/trace).
 interface SpanItem {
   timestamp: string;
   app_id: string;
@@ -81,15 +66,38 @@ interface SpanItem {
   attributes: Record<string, string>;
 }
 
-type TabKey = "details" | "headers" | "response" | "trace" | "related";
+interface LogItem {
+  timestamp: string;
+  app_id: string;
+  environment: string;
+  level: string;
+  message: string;
+  logger_name: string;
+  endpoint_method: string;
+  endpoint_path: string;
+  status_code: number;
+  consumer_id: string;
+  consumer_name: string;
+  consumer_group: string;
+  trace_id?: string;
+  span_id?: string;
+  payload: string;
+  attributes: Record<string, string>;
+}
 
-const TABS: Array<{ key: TabKey; label: string }> = [
+type TraceState = SpanItem[] | "loading" | "error";
+type LogState = LogItem[] | "loading" | "error";
+
+type TabKey = "details" | "headers" | "response" | "related" | "logs" | "trace";
+
+const BASE_TABS: Array<{ key: TabKey; label: string }> = [
   { key: "details", label: "Details" },
   { key: "headers", label: "Headers" },
   { key: "response", label: "Payload" },
-  { key: "trace", label: "Trace" },
   { key: "related", label: "Related" },
 ];
+const LOGS_TAB: { key: TabKey; label: string } = { key: "logs", label: "Logs" };
+const TRACE_TAB: { key: TabKey; label: string } = { key: "trace", label: "Trace" };
 
 function methodColor(m: string): string {
   const k = m.toUpperCase();
@@ -472,118 +480,184 @@ function Waterfall({ spans }: { spans: SpanItem[] }) {
   );
 }
 
-function TraceTab({
+/* ── Modal ───────────────────────────────────────────────────────────── */
+
+function LogsTab({
   projectSlug,
-  traceId,
-  loadingTrace,
+  row,
   appSlugs,
   environment,
   since,
   until,
 }: {
   projectSlug: string;
-  traceId: string;
-  loadingTrace: boolean;
+  row: RequestItem;
   appSlugs: string[];
   environment?: string;
   since: string;
   until?: string;
 }) {
-  const [spans, setSpans] = useState<SpanItem[] | null>(null);
-  const [logs, setLogs] = useState<LogItem[] | null>(null);
+  const [logs, setLogs] = useState<LogState>("loading");
 
   useEffect(() => {
-    if (!traceId) { setSpans(null); setLogs(null); return; }
     let cancelled = false;
-    setSpans(null);
-    setLogs(null);
+    if (!row.trace_id) {
+      setLogs([]);
+      return () => { cancelled = true; };
+    }
+    setLogs("loading");
     (async () => {
+      const p = new URLSearchParams();
+      p.set("trace_id", row.trace_id || "");
+      p.set("since", since);
+      if (until) p.set("until", until);
+      if (environment) p.set("environment", environment);
+      if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
+      p.set("page_size", "100");
       try {
-        const res = await fetch(`/api/projects/${projectSlug}/data/trace?trace_id=${encodeURIComponent(traceId)}`);
-        const data = res.ok ? await res.json() : { spans: [] };
-        if (!cancelled) setSpans(data.spans || []);
-      } catch { if (!cancelled) setSpans([]); }
-    })();
-    (async () => {
-      try {
-        const p = new URLSearchParams();
-        p.set("trace_id", traceId);
-        p.set("since", since);
-        if (until) p.set("until", until);
-        if (environment) p.set("environment", environment);
-        if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
-        p.set("page_size", "100");
         const res = await fetch(`/api/projects/${projectSlug}/data/logs?${p.toString()}`);
-        const data = res.ok ? await res.json() : { items: [] };
-        if (cancelled) return;
-        const items: LogItem[] = (data.items || []).slice();
-        // The API returns newest-first; a single request's logs read naturally
-        // in chronological order.
-        items.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-        setLogs(items);
-      } catch { if (!cancelled) setLogs([]); }
+        if (!res.ok) {
+          if (!cancelled) setLogs("error");
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) setLogs(data.items || []);
+      } catch {
+        if (!cancelled) setLogs("error");
+      }
     })();
     return () => { cancelled = true; };
-  }, [projectSlug, traceId, appSlugs, environment, since, until]);
+  }, [projectSlug, row.trace_id, appSlugs, environment, since, until]);
 
-  if (!traceId) {
-    return loadingTrace ? (
-      <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-    ) : (
-      <div className="endpoint-detail-empty">
-        No trace id was captured for this request, so its trace can&apos;t be shown.
-        Requests recorded before trace support don&apos;t carry one — upgrade the APILens SDK to enable it.
-      </div>
-    );
+  if (logs === "loading") {
+    return <div className="endpoint-skeleton" style={{ height: 160 }} aria-hidden />;
+  }
+  if (logs === "error") {
+    return <div className="endpoint-detail-empty">Logs could not be loaded.</div>;
+  }
+  if (logs.length === 0) {
+    return <div className="endpoint-detail-empty">No logs captured for this trace.</div>;
   }
 
   return (
-    <>
-      <div className="ep-rl-headblock">
-        <h4 className="ep-rl-subhead">
-          Spans
-          {spans?.length ? <span className="ep-rl-count">{spans.length}</span> : null}
-        </h4>
-        {spans === null ? (
-          <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-        ) : spans.length === 0 ? (
-          <div className="endpoint-detail-empty">
-            No spans recorded for this trace yet. The middleware records the request span automatically;
-            add <code>with apilens.span(&quot;name&quot;)</code> around interesting work to break the time down further.
+    <div className="ep-rl-headblock">
+      <h4 className="ep-rl-subhead">
+        Trace logs
+        <span className="ep-rl-count">{logs.length}</span>
+      </h4>
+      <div className="ep-log-list">
+        {logs.map((log, index) => (
+          <div key={`${log.timestamp}-${index}`} className={`ep-log-row level-${log.level.toLowerCase()}`}>
+            <div className="ep-log-main">
+              <span className="ep-log-level">{log.level}</span>
+              <span className="ep-log-message">{log.message || "Log event"}</span>
+            </div>
+            <div className="ep-log-meta">
+              <span>{formatDateTime(log.timestamp)}</span>
+              {log.logger_name ? <span>{log.logger_name}</span> : null}
+              {log.endpoint_method || log.endpoint_path ? <span>{`${log.endpoint_method} ${log.endpoint_path}`.trim()}</span> : null}
+              {log.status_code ? <span>{log.status_code}</span> : null}
+            </div>
+            {log.payload ? <pre className="ep-log-payload">{formatPayload(log.payload)}</pre> : null}
           </div>
-        ) : (
-          <Waterfall spans={spans} />
-        )}
+        ))}
       </div>
-      <div className="ep-rl-headblock">
-        <h4 className="ep-rl-subhead">
-          Logs in this trace
-          {logs?.length ? <span className="ep-rl-count">{logs.length}</span> : null}
-        </h4>
-        {logs === null ? (
-          <div className="endpoint-skeleton" style={{ height: 96 }} aria-hidden />
-        ) : logs.length === 0 ? (
-          <div className="endpoint-detail-empty">
-            No logs correlated with this request. Ship application logs with this trace id to see them here.
-          </div>
-        ) : (
-          <div className="ep-rel-list">
-            {logs.map((l, i) => (
-              <div key={`${l.timestamp}-${i}`} className="ep-log-row">
-                <span className="ep-rel-time">{timeShort(l.timestamp)}</span>
-                <span className={`endpoint-status-pill ${levelTone(l.level)}`}>{(l.level || "INFO").toUpperCase()}</span>
-                {l.logger_name ? <span className="ep-log-logger" title={l.logger_name}>{l.logger_name}</span> : null}
-                <span className="ep-log-msg" title={l.message}>{l.message}</span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </>
+    </div>
   );
 }
 
-/* ── Modal ───────────────────────────────────────────────────────────── */
+function TraceTab({
+  projectSlug,
+  row,
+  appSlugs,
+  environment,
+  since,
+  until,
+}: {
+  projectSlug: string;
+  row: RequestItem;
+  appSlugs: string[];
+  environment?: string;
+  since: string;
+  until?: string;
+}) {
+  const [spans, setSpans] = useState<TraceState>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!row.trace_id) {
+      setSpans([]);
+      return () => { cancelled = true; };
+    }
+    setSpans("loading");
+    (async () => {
+      const p = new URLSearchParams();
+      p.set("trace_id", row.trace_id || "");
+      p.set("since", since);
+      if (until) p.set("until", until);
+      if (environment) p.set("environment", environment);
+      if (appSlugs.length) p.set("app_slugs", appSlugs.join(","));
+      p.set("page_size", "200");
+      try {
+        const res = await fetch(`/api/projects/${projectSlug}/data/spans?${p.toString()}`);
+        if (!res.ok) {
+          if (!cancelled) setSpans("error");
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) setSpans(data.items || []);
+      } catch {
+        if (!cancelled) setSpans("error");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectSlug, row.trace_id, appSlugs, environment, since, until]);
+
+  if (spans === "loading") {
+    return <div className="endpoint-skeleton" style={{ height: 160 }} aria-hidden />;
+  }
+  if (spans === "error") {
+    return <div className="endpoint-detail-empty">Trace spans could not be loaded.</div>;
+  }
+  if (spans.length === 0) {
+    return <div className="endpoint-detail-empty">No spans captured for this trace.</div>;
+  }
+
+  return (
+    <div className="ep-rl-headblock">
+      <h4 className="ep-rl-subhead">
+        Trace spans
+        <span className="ep-rl-count">{spans.length}</span>
+      </h4>
+      <div className="ep-trace-list">
+        {spans.map((span, index) => {
+          const isCurrent = !!row.span_id && span.span_id === row.span_id;
+          return (
+            <div key={`${span.span_id}-${index}`} className={`ep-trace-row${isCurrent ? " is-current" : ""}`}>
+              <div className="ep-trace-main">
+                <span className={`endpoint-status-pill ${statusTone(span.status_code || 200)}`}>
+                  {span.status || span.status_code || "OK"}
+                </span>
+                <span className="ep-trace-name">{span.name || "Unnamed span"}</span>
+                {isCurrent ? <span className="ep-trace-current">request span</span> : null}
+              </div>
+              <div className="ep-trace-meta">
+                <span><Server size={12} /> {span.service_name || "unknown service"}</span>
+                <span><GitBranch size={12} /> {span.kind || "span"}</span>
+                <span>{formatMs(span.duration_ms)}</span>
+                <span>{formatDateTime(span.timestamp)}</span>
+              </div>
+              <div className="ep-trace-ids">
+                <span>span {span.span_id}</span>
+                {span.parent_span_id ? <span>parent {span.parent_span_id}</span> : <span>root span</span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 interface Props {
   projectSlug: string;
@@ -610,6 +684,13 @@ export default function RequestLogDetailModal({
   const [payload, setPayload] = useState<PayloadRow | null | "loading">("loading");
   // A related request opened on top of this one (stacked modal).
   const [relatedOpen, setRelatedOpen] = useState<RequestItem | null>(null);
+  const tabs = useMemo(() => (row.trace_id ? [...BASE_TABS, LOGS_TAB, TRACE_TAB] : BASE_TABS), [row.trace_id]);
+
+  useEffect(() => {
+    if ((activeTab === "logs" || activeTab === "trace") && !row.trace_id) {
+      setActiveTab("details");
+    }
+  }, [activeTab, row.trace_id]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -720,7 +801,7 @@ export default function RequestLogDetailModal({
         </div>
 
         <nav className="ep-emodal-tabs" role="tablist">
-          {TABS.map((t) => (
+          {tabs.map((t) => (
             <button
               key={t.key}
               type="button"
@@ -782,6 +863,7 @@ export default function RequestLogDetailModal({
                     }
                   />
                 ) : null}
+                {row.span_id ? <DetailRow label="Span ID" value={<span className="ep-rl-mono">{row.span_id}</span>} /> : null}
                 {row.user_agent ? <DetailRow label="User agent" value={<span className="ep-rl-ua">{row.user_agent}</span>} /> : null}
               </div>
             </>
@@ -809,18 +891,6 @@ export default function RequestLogDetailModal({
             )
           )}
 
-          {activeTab === "trace" && (
-            <TraceTab
-              projectSlug={projectSlug}
-              traceId={traceId}
-              loadingTrace={loadingPayload}
-              appSlugs={appSlugs}
-              environment={environment}
-              since={since}
-              until={until}
-            />
-          )}
-
           {activeTab === "related" && (
             <RelatedTab
               projectSlug={projectSlug}
@@ -830,6 +900,28 @@ export default function RequestLogDetailModal({
               since={since}
               until={until}
               onOpen={setRelatedOpen}
+            />
+          )}
+
+          {activeTab === "logs" && (
+            <LogsTab
+              projectSlug={projectSlug}
+              row={row}
+              appSlugs={appSlugs}
+              environment={environment}
+              since={since}
+              until={until}
+            />
+          )}
+
+          {activeTab === "trace" && (
+            <TraceTab
+              projectSlug={projectSlug}
+              row={row}
+              appSlugs={appSlugs}
+              environment={environment}
+              since={since}
+              until={until}
             />
           )}
         </div>

--- a/apps/web/src/app/projects/[slug]/endpoints/detail/EndpointDetailContent.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/detail/EndpointDetailContent.tsx
@@ -49,6 +49,29 @@ const TIME_RANGES: Array<{ label: string; value: number }> = [
 
 /* ── Page component ──────────────────────────────────────────────────── */
 
+function parseUrlDateParam(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getInitialCustomRange(params: { get(name: string): string | null }): { active: boolean; since: string; until: string } {
+  const rawSince = params.get("custom_since");
+  const rawUntil = params.get("custom_until");
+  const since = parseUrlDateParam(rawSince);
+  if (!since) return { active: false, since: "", until: "" };
+
+  const until = rawUntil ? parseUrlDateParam(rawUntil) : null;
+  if (rawUntil && !until) return { active: false, since: "", until: "" };
+  if (until && since >= until) return { active: false, since: "", until: "" };
+
+  return {
+    active: true,
+    since: since.toISOString(),
+    until: until ? until.toISOString() : "",
+  };
+}
+
 export default function EndpointDetailContent({ projectSlug }: { projectSlug: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -74,12 +97,13 @@ export default function EndpointDetailContent({ projectSlug }: { projectSlug: st
   const [environments, setEnvironments] = useState<string[]>([]);
 
   // Custom range.
-  const [customActive, setCustomActive] = useState<boolean>(() => !!searchParams.get("custom_since"));
-  const [customSince, setCustomSince] = useState<string>(() => searchParams.get("custom_since") || "");
-  const [customUntil, setCustomUntil] = useState<string>(() => searchParams.get("custom_until") || "");
+  const initialCustomRange = getInitialCustomRange(searchParams);
+  const [customActive, setCustomActive] = useState<boolean>(() => initialCustomRange.active);
+  const [customSince, setCustomSince] = useState<string>(() => initialCustomRange.since);
+  const [customUntil, setCustomUntil] = useState<string>(() => initialCustomRange.until);
   const [customPanelOpen, setCustomPanelOpen] = useState(false);
-  const [customSinceDraft, setCustomSinceDraft] = useState<string>(() => searchParams.get("custom_since") || "");
-  const [customUntilDraft, setCustomUntilDraft] = useState<string>(() => searchParams.get("custom_until") || "");
+  const [customSinceDraft, setCustomSinceDraft] = useState<string>(() => initialCustomRange.since);
+  const [customUntilDraft, setCustomUntilDraft] = useState<string>(() => initialCustomRange.until);
   const [customRangeError, setCustomRangeError] = useState("");
   const customPopoverRef = useRef<HTMLDivElement | null>(null);
 

--- a/apps/web/src/app/projects/[slug]/endpoints/detail/sections.tsx
+++ b/apps/web/src/app/projects/[slug]/endpoints/detail/sections.tsx
@@ -94,6 +94,8 @@ export interface RequestRow {
   response_payload?: string;
   request_headers?: string;
   response_headers?: string;
+  trace_id?: string;
+  span_id?: string;
 }
 
 export interface HistogramBucket {

--- a/apps/web/src/app/projects/[slug]/new-app/CreateProjectAppForm.tsx
+++ b/apps/web/src/app/projects/[slug]/new-app/CreateProjectAppForm.tsx
@@ -131,8 +131,13 @@ export default function CreateProjectAppForm({ projectSlug }: CreateProjectAppFo
 
       // Get the project's API key (should always exist since it's auto-created with project)
       const keysRes = await fetch(`/api/projects/${projectSlug}/api-keys`);
-      const keys = await keysRes.json();
-      const apiKeyPrefix = keys && keys.length > 0 ? keys[0].prefix : "apilens_****";
+      const keysData = await keysRes.json().catch(() => ({}));
+      const keys = Array.isArray(keysData)
+        ? keysData
+        : Array.isArray(keysData.keys)
+          ? keysData.keys
+          : [];
+      const apiKeyPrefix = keys.length > 0 ? keys[0].prefix : "apilens_****";
 
       // Store setup metadata for the setup page
       if (typeof window !== "undefined") {

--- a/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
+++ b/apps/web/src/app/projects/[slug]/traffic/TrafficContent.tsx
@@ -729,6 +729,10 @@ function AppFilter({
         : `${selected.length} apps`;
 
   const toggle = (slug: string) => {
+    if (allSelected) {
+      onChange([slug]);
+      return;
+    }
     if (selected.includes(slug)) onChange(selected.filter((s) => s !== slug));
     else onChange([...selected, slug]);
   };

--- a/apps/web/src/app/projects/[slug]/uptime/UptimeContent.tsx
+++ b/apps/web/src/app/projects/[slug]/uptime/UptimeContent.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Clock3, RefreshCw, RadioTower, WifiOff } from "lucide-react";
+import StatStrip, { type Stat } from "@/components/aperture/StatStrip";
+import StatusPill from "@/components/aperture/StatusPill";
+
+type UptimeStatus = "live" | "stale" | "down" | "no_data";
+
+interface EnvironmentStatus {
+  environment: string;
+  status: UptimeStatus;
+  age_seconds: number | null;
+  last_seen_at: string | null;
+  requests_24h: number;
+}
+
+interface AppStatus {
+  id: string;
+  name: string;
+  slug: string;
+  framework: string;
+  status: UptimeStatus;
+  age_seconds: number | null;
+  last_seen_at: string | null;
+  requests_24h: number;
+  environments: EnvironmentStatus[];
+}
+
+interface UptimeResponse {
+  generated_at: string;
+  heartbeat_grace_minutes: number;
+  down_after_minutes: number;
+  lookback_days: number;
+  latest_seen_at: string | null;
+  total_apps: number;
+  summary: Record<UptimeStatus, number>;
+  apps: AppStatus[];
+}
+
+interface Props {
+  projectSlug: string;
+}
+
+const EMPTY_SUMMARY: Record<UptimeStatus, number> = {
+  live: 0,
+  stale: 0,
+  down: 0,
+  no_data: 0,
+};
+
+const STATUS_LABEL: Record<UptimeStatus, string> = {
+  live: "Live",
+  stale: "Stale",
+  down: "Down",
+  no_data: "No data",
+};
+
+const STATUS_TONE: Record<UptimeStatus, "healthy" | "warn" | "critical" | "neutral"> = {
+  live: "healthy",
+  stale: "warn",
+  down: "critical",
+  no_data: "neutral",
+};
+
+function formatAge(ageSeconds: number | null): string {
+  if (ageSeconds === null) return "-";
+  if (ageSeconds < 60) return `${ageSeconds}s`;
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function statusSort(status: UptimeStatus): number {
+  if (status === "down") return 0;
+  if (status === "stale") return 1;
+  if (status === "no_data") return 2;
+  return 3;
+}
+
+function StatusBadge({ status }: { status: UptimeStatus }) {
+  return (
+    <StatusPill tone={STATUS_TONE[status]}>
+      {STATUS_LABEL[status]}
+    </StatusPill>
+  );
+}
+
+export default function UptimeContent({ projectSlug }: Props) {
+  const [data, setData] = useState<UptimeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const fetchUptime = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const params = new URLSearchParams({
+        heartbeat_grace_minutes: "2",
+        down_after_minutes: "15",
+        lookback_days: "30",
+      });
+      const res = await fetch(`/api/projects/${projectSlug}/analytics/uptime?${params.toString()}`);
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(body.error || "Failed to load uptime");
+      }
+      setData(body as UptimeResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load uptime");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectSlug]);
+
+  useEffect(() => {
+    void fetchUptime();
+  }, [fetchUptime, refreshKey]);
+
+  const apps = useMemo(
+    () => [...(data?.apps || [])].sort((a, b) => statusSort(a.status) - statusSort(b.status) || a.name.localeCompare(b.name)),
+    [data],
+  );
+
+  const summary = data?.summary || EMPTY_SUMMARY;
+  const stats: Stat[] = [
+    { label: "Live", value: String(summary.live), sub: "fresh heartbeat", tone: "good" },
+    { label: "Stale", value: String(summary.stale), sub: "late signal", tone: summary.stale ? "warn" : undefined },
+    { label: "Down", value: String(summary.down), sub: `>${data?.down_after_minutes || 15} min`, tone: summary.down ? "bad" : undefined },
+    { label: "No data", value: String(summary.no_data), sub: `${data?.lookback_days || 30}d window` },
+  ];
+
+  const generatedLabel = data?.generated_at ? formatDateTime(data.generated_at) : "-";
+
+  return (
+    <div className="uptime-page" data-testid="uptime-page">
+      <div className="ep-rl-toolbar">
+        <h1 className="ep-rl-title">Uptime</h1>
+        <div className="ep-rl-spacer" />
+        <span className="uptime-generated">
+          <Clock3 size={13} />
+          {generatedLabel}
+        </span>
+        <button
+          type="button"
+          className="tf-refresh"
+          onClick={() => setRefreshKey((key) => key + 1)}
+          title="Refresh"
+          aria-label="Refresh"
+        >
+          <RefreshCw size={14} className={loading ? "tf-spin" : ""} />
+        </button>
+      </div>
+
+      <StatStrip stats={stats} className="uptime-stats" />
+
+      <section className="uptime-panel">
+        {loading && !data ? (
+          <div className="ep-rl-message">Loading uptime...</div>
+        ) : error ? (
+          <div className="uptime-empty uptime-empty-error">
+            <AlertTriangle size={18} />
+            <span>{error}</span>
+          </div>
+        ) : apps.length === 0 ? (
+          <div className="uptime-empty">
+            <RadioTower size={20} />
+            <span>No apps in this project.</span>
+          </div>
+        ) : (
+          <div className="uptime-table-wrap">
+            <table className="uptime-table">
+              <thead>
+                <tr>
+                  <th>App</th>
+                  <th>Status</th>
+                  <th>Environments</th>
+                  <th className="ep-th-num">Last signal</th>
+                  <th className="ep-th-num">Age</th>
+                  <th className="ep-th-num">24h requests</th>
+                </tr>
+              </thead>
+              <tbody>
+                {apps.map((app) => (
+                  <tr key={app.id} data-testid={`uptime-app-${app.slug}`}>
+                    <td>
+                      <div className="uptime-app-cell">
+                        <span className="uptime-app-avatar">{app.name.charAt(0).toUpperCase()}</span>
+                        <span>
+                          <span className="uptime-app-name">{app.name}</span>
+                          <span className="uptime-app-meta">{app.slug} / {app.framework}</span>
+                        </span>
+                      </div>
+                    </td>
+                    <td><StatusBadge status={app.status} /></td>
+                    <td>
+                      {app.environments.length > 0 ? (
+                        <div className="uptime-env-list">
+                          {app.environments.map((env) => (
+                            <span key={`${app.id}-${env.environment}`} className="uptime-env-chip">
+                              <span className={`uptime-dot status-${env.status}`} />
+                              {env.environment}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="uptime-muted"><WifiOff size={13} /> none</span>
+                      )}
+                    </td>
+                    <td className="ep-td-num">{formatDateTime(app.last_seen_at)}</td>
+                    <td className="ep-td-num">{formatAge(app.age_seconds)}</td>
+                    <td className="ep-td-num">{app.requests_24h.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/projects/[slug]/uptime/page.tsx
+++ b/apps/web/src/app/projects/[slug]/uptime/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import UptimeContent from "./UptimeContent";
+
+export const metadata = {
+  title: "Uptime | APILens",
+};
+
+export default async function ProjectUptimePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const session = await getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  const { slug } = await params;
+  return <UptimeContent projectSlug={slug} />;
+}

--- a/apps/web/src/components/dashboard/Sidebar.tsx
+++ b/apps/web/src/components/dashboard/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ScrollText,
   TrendingUp,
   Activity,
+  RadioTower,
   Users,
   Settings,
   Bell,
@@ -82,6 +83,7 @@ export default function Sidebar() {
     ? [
       { name: "Apps", href: `/projects/${projectSlug}/apps`, icon: ScrollText },
       { name: "Traffic", href: `/projects/${projectSlug}/traffic`, icon: Activity },
+      { name: "Uptime", href: `/projects/${projectSlug}/uptime`, icon: RadioTower },
       { name: "Request logs", href: `/projects/${projectSlug}/endpoints`, icon: TrendingUp },
       { name: "Consumers", href: `/projects/${projectSlug}/consumers`, icon: Users },
       { name: "Settings", href: `/projects/${projectSlug}/settings`, icon: Settings },

--- a/apps/web/src/lib/proxy.ts
+++ b/apps/web/src/lib/proxy.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
-import { getSession } from "@/lib/session";
+import { clearSession, getSession, setSession } from "@/lib/session";
 import type { ApiResponse } from "@/lib/api-client";
+
+const DJANGO_API_URL = process.env.DJANGO_API_URL || "http://localhost:8000/api/v1";
+const AUTH_API_URL = process.env.AUTH_API_URL || `${DJANGO_API_URL}/auth`;
 
 /**
  * Wraps a route handler with session authentication and error handling.
@@ -18,6 +21,127 @@ export async function withAuth(
   } catch (error) {
     console.error("Route error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+type RefreshResult = { accessToken: string; refreshToken: string } | null;
+
+const REFRESH_CACHE_TTL_MS = 15_000;
+const refreshInflight = new Map<string, Promise<RefreshResult>>();
+const refreshRecent = new Map<string, { result: RefreshResult; at: number }>();
+
+async function refreshTokens(refreshToken: string): Promise<RefreshResult> {
+  const cached = refreshRecent.get(refreshToken);
+  if (cached && Date.now() - cached.at < REFRESH_CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  const existing = refreshInflight.get(refreshToken);
+  if (existing) return existing;
+
+  const inflight = (async (): Promise<RefreshResult> => {
+    try {
+      const response = await fetch(`${AUTH_API_URL}/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+        cache: "no-store",
+      });
+
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      const session = await getSession();
+      if (session) {
+        await setSession({
+          ...session,
+          accessToken: data.access_token,
+          refreshToken: data.refresh_token,
+        });
+      }
+
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+      };
+    } catch {
+      return null;
+    }
+  })();
+
+  refreshInflight.set(refreshToken, inflight);
+  try {
+    const result = await inflight;
+    refreshRecent.set(refreshToken, { result, at: Date.now() });
+    if (refreshRecent.size > 50) {
+      const cutoff = Date.now() - REFRESH_CACHE_TTL_MS;
+      for (const [key, val] of refreshRecent) {
+        if (val.at < cutoff) refreshRecent.delete(key);
+      }
+    }
+    return result;
+  } finally {
+    refreshInflight.delete(refreshToken);
+  }
+}
+
+function withBearer(headers: HeadersInit | undefined, accessToken: string): Headers {
+  const nextHeaders = new Headers(headers);
+  if (!nextHeaders.has("Content-Type")) {
+    nextHeaders.set("Content-Type", "application/json");
+  }
+  nextHeaders.set("Authorization", `Bearer ${accessToken}`);
+  return nextHeaders;
+}
+
+export async function fetchWithAuthRefresh(
+  upstream: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const session = await getSession();
+  if (!session) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const response = await fetch(upstream, {
+    ...init,
+    headers: withBearer(init.headers, session.accessToken),
+    cache: init.cache || "no-store",
+  });
+
+  if (response.status !== 401) return response;
+
+  const refreshed = await refreshTokens(session.refreshToken);
+  if (!refreshed) {
+    await clearSession();
+    return Response.json({ error: "Session expired" }, { status: 401 });
+  }
+
+  return fetch(upstream, {
+    ...init,
+    headers: withBearer(init.headers, refreshed.accessToken),
+    cache: init.cache || "no-store",
+  });
+}
+
+async function toNextResponse(response: Response): Promise<NextResponse> {
+  const body = await response.text();
+  return new NextResponse(body, {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") || "application/json",
+    },
+  });
+}
+
+export async function proxyDjangoWithAuth(
+  upstream: string,
+  init: RequestInit = {},
+): Promise<NextResponse> {
+  try {
+    return toNextResponse(await fetchWithAuthRefresh(upstream, init));
+  } catch {
+    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
   }
 }
 


### PR DESCRIPTION
## Summary

Consolidates two PRs that both touch `apps/api/apps/projects/services.py` at nearly the same insertion point (adjacent new methods after `_clean_nan_values`), which would otherwise conflict whichever merged second. Superseding both here as one clean, sequentially-verified PR.

## Included Work

| Source PR | Branch | Included Scope |
|---:|---|---|
| #142 | `dharmik-workflow-bugfixes` | 19 product workflow bug fixes: invalid-date-range crash guard, stable project/app slugs on rename, `status_class:not:` filter fix, invalid-email invitation validation, log/span correlation columns + `GET /data/spans` read route, plus new unit tests (`test_app_service`, `test_filters`, `test_membership`, `test_project_service`, `test_time_range`) |
| #143 | `dharmik-apitally-health-monitoring` | New Uptime dashboard: `AnalyticsService.get_project_uptime`, `GET /projects/{slug}/analytics/uptime`, and the `/projects/{slug}/uptime` page + sidebar entry |

## Excluded Work

| Source | Excluded Scope | Reason |
|---|---|---|
| #142 (as currently open) | The entire synthetic telemetry engine (`apps/api/apps/projects/synthetic/**`, `synthetic_telemetry` management command, its tests, docs page, `/synthetic` API routes, `/projects/{slug}/synthetic` UI page, sidebar entry, ~330 lines of associated CSS, and the `api-client.ts` synthetic methods/interfaces) | This was intentionally closed out of upstream in #145 ("should remain local only, not proposed to apilens/apilens"), but it was inadvertently swept into #142's second commit alongside the genuine bug fixes — almost certainly from working across multiple branches in the same local environment. It has been fully stripped from this consolidated PR: 14 synthetic-only files excluded entirely, plus targeted edits to 4 shared files (`schemas.py`, `router.py`, `docs.json`, `Sidebar.tsx`) that had synthetic-specific hunks mixed into otherwise-legitimate changes. Verified zero `synthetic` references remain in `git diff upstream/main..HEAD`. |
| #144 (already closed) | Traffic app filter single-selection fix | Already folded into #142's fix set prior to this consolidation; no separate action needed. |
| #145 (already closed) | Synthetic telemetry engine | Confirmed intentionally local-only; not reintroduced here (see above). |
| #147 (kept separate, not touched by this PR) | Traffic visualization status-class split | Independent code region (`get_project_timeseries`, far from the other two PRs' changes) and still has an open encoding-corruption bug being fixed separately. Left as its own PR to keep this one focused and clean. |

## Validation

| Check | Command | Result |
|---|---|---|
| Backend compiles | `python -m py_compile` on all touched `.py` files (api + ingest) | Pass |
| Backend unit tests | `manage.py test tests` | 9/9 passed |
| Frontend type-check | `tsc --noEmit` | Pass, 0 errors |
| Frontend build | `next build` | Succeeds; route manifest confirms `/projects/{slug}/uptime` and `/data/spans` present, no `/synthetic` routes |
| Frontend lint | `pnpm --filter frontend lint` | 0 errors, 143 pre-existing warnings (unchanged baseline) |
| Merge conflict (services.py) | Manual resolution during cherry-pick | Resolved cleanly — `get_project_spans` (#142) and `get_project_uptime` (#143) now sit as adjacent, non-overlapping methods |
| `eslint.config.mjs` conflict | Manual resolution | Deduplicated `ignores` block (#143) + `rules` block (identical on both sides) |

## GitHub Hygiene

- Commit attribution verified: all commits use `67726545+dharmik136@users.noreply.github.com`.
- No secrets found in the diff (only boilerplate `Authorization: Bearer` header-construction code, no literal credentials).
- No generated/local-only artifacts included.
- One intentional file deletion: `apps/api/__init__.py` (part of #142's Django app-registry bug fix) — no other deletions.
- Superseded PRs (#142, #143) will be closed with a pointer to this PR once it's confirmed to include their work.

## Risk

Low-to-moderate: this combines a broad but well-tested bug-fix set with one new, isolated read-only feature (uptime status derived from existing ClickHouse data, no new tables/migrations). The one non-trivial merge (adjacent inserts in `services.py`) was resolved manually and re-validated with a full test run + build, not just an automatic 3-way merge.

## Reviewer Notes

Focus review on: (1) the `services.py` region between `get_project_requests`/`get_project_spans`/`_clean_nan_values`/`get_project_uptime` to confirm the manual conflict resolution didn't drop or duplicate logic, and (2) confirming no synthetic-engine remnants slipped through (verified via `git diff upstream/main..HEAD | grep -i synthetic` returning zero matches).