### PR TITLE
fix: SDK version drift + unreachable stub returning None

### DIFF
--- a/apps/api/apps/projects/services.py
+++ b/apps/api/apps/projects/services.py
@@ -1264,10 +1264,11 @@ class ConsumerStatsService:
         until: str | None = None,
         limit: int = 100,
     ) -> list[dict]:
-        from core.database.clickhouse.client import get_clickhouse_client
-
-        if not consumer or not consumer.strip():
-            return []
+        # Not implemented yet — only reachable via the unmounted apps router
+        # (routers/apps/router.py), so this is a safe no-op rather than a
+        # crash: honors the declared list[dict] return type instead of
+        # falling through to an implicit None.
+        return []
 
     @staticmethod
     def get_consumer_activity(

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -13,7 +13,7 @@ import type {
   Logger,
 } from "./types.js";
 
-const SDK_VERSION = "0.1.0";
+export const SDK_VERSION = "0.1.1";
 
 type RequiredConfig = {
   apiKey: string;

--- a/packages/sdk-typescript/tests/client.test.ts
+++ b/packages/sdk-typescript/tests/client.test.ts
@@ -1,6 +1,14 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ApiLensClient } from "../src/client.js";
+
+const packageJson = JSON.parse(
+  readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "../package.json"), "utf-8"),
+) as { version: string };
 
 afterEach(async () => {
   await ApiLensClient.shutdown();
@@ -132,6 +140,27 @@ describe("ApiLensClient", () => {
     client.capture({ method: "GET", path: "/x", status_code: 200, response_time_ms: 1 });
     await client.flushAll();
     expect(urls[0]).toBe("http://localhost:8000/ingest/requests");
+  });
+
+  it("sends a User-Agent header matching the released package.json version", async () => {
+    const headers: Array<Record<string, string> | undefined> = [];
+    const client = new ApiLensClient({
+      apiKey: "test",
+      projectSlug: "test",
+      appId: "test",
+      enabled: true,
+      batchSize: 10,
+      fetchImpl: async (_url, options) => {
+        headers.push(options?.headers as Record<string, string> | undefined);
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    client.stop();
+    client.capture({ method: "GET", path: "/x", status_code: 200, response_time_ms: 1 });
+    await client.flushAll();
+
+    expect(headers[0]?.["User-Agent"]).toBe(`apilens-js-sdk/${packageJson.version}`);
   });
 
   it("uses absolute ingestPath as-is", async () => {


### PR DESCRIPTION
## Summary
Two small, unrelated bug fixes found while auditing the repo, bundled into one hygiene PR since neither is large enough to warrant its own:

1. **`packages/sdk-typescript`** — `SDK_VERSION` was hardcoded to `"0.1.0"` in `src/client.ts` and never bumped alongside `package.json` releases (now `0.1.1`), so the `User-Agent` header every SDK sends to the ingest server has been permanently one version behind. Bumped the constant and added a regression test (`tests/client.test.ts`) that asserts the actual sent `User-Agent` header matches `package.json`'s version — so a future release that forgets this fails CI instead of silently drifting again.
2. **`apps/api`** — `ConsumerStatsService.get_consumer_request_stats` had a dead-end code path: for any non-empty `consumer` argument it fell off the end of the function with no `return`, implicitly returning `None` against its declared `-> list[dict]` signature. It's only reachable via `routers/apps/router.py`, which isn't mounted anywhere in the live API, so there's no real caller and no existing spec to reconstruct a correct query from — made it a safe no-op (`return []`) that honors its own type contract, rather than inventing new ClickHouse query logic for code nothing can currently call.

## Validation
| Check | Result |
|---|---|
| `python -m py_compile apps/projects/services.py` | Pass |
| `pnpm exec vitest run` (sdk-typescript) | 9/9 passed, including the new User-Agent regression test |
| `pnpm exec tsc --noEmit` (sdk-typescript) | Pass |
| `pnpm exec tsup` build (both ESM + CJS) | Pass, no warnings |

## Risk
Very low — one is a version-string correction plus a test, the other narrows a `None` return to `[]` for code with zero live callers.